### PR TITLE
bump minimum python version to 3.6 to solve FTBFS #4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "WTFPL"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 python-dotenv = "^0.20.0"
 psutil = "^5.9.8"
 systemd-watchdog = "^0.9.0"


### PR DESCRIPTION
bump minimum python version to 3.6 to solve FTBFS #4 due to mismatch with dependency (psutil)