### PR TITLE
Refactor: Improve agent modularity and fix correctness bugs

### DIFF
--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -1,12 +1,9 @@
 #!/usr/bin/python
 
-import grp
 import json
 import os
 import platform
-import pwd
 import signal
-import socket
 import sys
 import time
 from threading import Event
@@ -15,96 +12,22 @@ import psutil
 import systemd_watchdog
 from dotenv import load_dotenv
 
-from fivenines_agent.caddy import caddy_metrics
 from fivenines_agent.cli import VERSION
-from fivenines_agent.cpu import cpu_count, cpu_data, cpu_model, cpu_usage
-from fivenines_agent.debug import debug, log
-from fivenines_agent.docker import docker_metrics
-from fivenines_agent.env import config_dir, dry_run, env_file
-from fivenines_agent.fail2ban import fail2ban_metrics
-from fivenines_agent.fans import fans
+from fivenines_agent.collectors import collect_metrics
+from fivenines_agent.debug import log
+from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context
 from fivenines_agent.files import file_handles_limit, file_handles_used
-from fivenines_agent.io import io
 from fivenines_agent.ip import get_ip
 from fivenines_agent.load_average import load_average
-from fivenines_agent.memory import memory, swap
-from fivenines_agent.network import network
-from fivenines_agent.nginx import nginx_metrics
-from fivenines_agent.packages import (
-    get_distro,
-    get_installed_packages,
-    get_packages_hash,
-)
-from fivenines_agent.partitions import partitions_metadata, partitions_usage
+from fivenines_agent.packages import packages_sync
 from fivenines_agent.permissions import get_permissions, print_capabilities_banner
-from fivenines_agent.ports import listening_ports
-from fivenines_agent.postgresql import postgresql_metrics
-from fivenines_agent.processes import processes
-from fivenines_agent.proxmox import proxmox_metrics
-from fivenines_agent.qemu import qemu_metrics
-from fivenines_agent.raid_storage import raid_storage_health
-from fivenines_agent.redis import redis_metrics
-from fivenines_agent.smart_storage import (
-    smart_storage_health,
-    smart_storage_identification,
-)
+from fivenines_agent.ping import tcp_ping
 from fivenines_agent.synchronization_queue import SynchronizationQueue
 from fivenines_agent.synchronizer import Synchronizer
-from fivenines_agent.temperatures import temperatures
 
 
 CONFIG_DIR = config_dir()
 load_dotenv(dotenv_path=env_file())
-
-
-def get_user_context():
-    """Get information about the user running the agent."""
-    try:
-        uid = os.getuid()
-        euid = os.geteuid()
-        gid = os.getgid()
-
-        # Get username
-        try:
-            username = pwd.getpwuid(uid).pw_name
-        except KeyError:
-            username = str(uid)
-
-        # Get primary group name
-        try:
-            groupname = grp.getgrgid(gid).gr_name
-        except KeyError:
-            groupname = str(gid)
-
-        # Get all groups the user belongs to
-        try:
-            groups = [grp.getgrgid(g).gr_name for g in os.getgroups()]
-        except Exception:
-            groups = [str(g) for g in os.getgroups()]
-
-        # Determine installation type based on config directory
-        is_user_install = CONFIG_DIR.startswith(os.path.expanduser("~"))
-
-        return {
-            "username": username,
-            "uid": uid,
-            "euid": euid,
-            "gid": gid,
-            "groupname": groupname,
-            "groups": groups,
-            "is_root": uid == 0,
-            "is_user_install": is_user_install,
-            "config_dir": CONFIG_DIR,
-            "home_dir": os.path.expanduser("~"),
-        }
-    except Exception as e:
-        log(f"Error getting user context: {e}", "error")
-        return {
-            "username": "unknown",
-            "is_root": False,
-            "is_user_install": False,
-        }
-
 
 # Exit event for safe shutdown
 exit_event = Event()
@@ -112,11 +35,24 @@ exit_event = Event()
 refresh_permissions_event = Event()
 
 
+def _on_exit_signal(signum, frame):
+    exit_event.set()
+
+
+def _on_sighup(signum, frame):
+    log("Received SIGHUP - will refresh capabilities", "info")
+    refresh_permissions_event.set()
+
+
+def setup_signals():
+    signal.signal(signal.SIGTERM, _on_exit_signal)
+    signal.signal(signal.SIGINT, _on_exit_signal)
+    signal.signal(signal.SIGHUP, _on_sighup)
+
+
 class Agent:
     def __init__(self):
-        signal.signal(signal.SIGTERM, self._on_exit_signal)
-        signal.signal(signal.SIGINT, self._on_exit_signal)
-        signal.signal(signal.SIGHUP, self._on_sighup)
+        setup_signals()
 
         log(f"fivenines agent v{VERSION}", "info")
 
@@ -130,15 +66,6 @@ class Agent:
         self.queue = SynchronizationQueue(maxsize=100)
         self.synchronizer = Synchronizer(self.token, self.queue)
         self.synchronizer.start()
-
-    def _on_exit_signal(self, signum, frame):
-        # Only set the exit flag; defer cleanup to main loop
-        exit_event.set()
-
-    def _on_sighup(self, signum, frame):
-        # SIGHUP triggers permission refresh instead of exit
-        log("Received SIGHUP - will refresh capabilities", "info")
-        refresh_permissions_event.set()
 
     def _load_file(self, filename):
         try:
@@ -160,21 +87,13 @@ class Agent:
             "uname": platform.uname()._asdict(),
             "boot_time": psutil.boot_time(),
             "capabilities": self.permissions.get_all(),
-            "user_context": get_user_context(),
+            "user_context": get_user_context(CONFIG_DIR),
         }
 
         try:
             while not exit_event.is_set():
                 wd.notify()
-
-                # Check for permission refresh (SIGHUP or periodic)
-                if refresh_permissions_event.is_set():
-                    refresh_permissions_event.clear()
-                    self.permissions.force_refresh()
-                    static_data["capabilities"] = self.permissions.get_all()
-                    print_capabilities_banner()
-                elif self.permissions.refresh_if_needed():
-                    static_data["capabilities"] = self.permissions.get_all()
+                self._handle_permission_refresh(static_data)
 
                 # Refresh config if disabled
                 self.config = self.synchronizer.get_config()
@@ -187,72 +106,13 @@ class Agent:
                 data["ts"] = time.time()
                 start = time.monotonic()
 
-                # Core metrics
-                data["load_average"] = load_average()
-                data["file_handles_used"] = file_handles_used()
-                data["file_handles_limit"] = file_handles_limit()
+                self._collect_metrics(data)
 
-                # Conditional metrics
-                if self.config.get("ping"):
-                    for region, host in self.config["ping"].items():
-                        data[f"ping_{region}"] = self.tcp_ping(host)
-                if self.config.get("cpu"):
-                    data["cpu"] = cpu_data()
-                    data["cpu_usage"] = cpu_usage()
-                    data["cpu_model"] = cpu_model()
-                    data["cpu_count"] = cpu_count()
-                if self.config.get("memory"):
-                    data["memory"] = memory()
-                    data["swap"] = swap()
-                if self.config.get("ipv4"):
-                    data["ipv4"] = get_ip(ipv6=False)
-                if self.config.get("ipv6"):
-                    data["ipv6"] = get_ip(ipv6=True)
-                if self.config.get("network"):
-                    data["network"] = network()
-                if self.config.get("partitions"):
-                    data["partitions_metadata"] = partitions_metadata()
-                    data["partitions_usage"] = partitions_usage()
-                if self.config.get("io"):
-                    data["io"] = io()
-                if self.config.get("smart_storage_health"):
-                    data["smart_storage_identification"] = (
-                        smart_storage_identification()
-                    )
-                    data["smart_storage_health"] = smart_storage_health()
-                if self.config.get("raid_storage_health"):
-                    data["raid_storage_health"] = raid_storage_health()
-                if self.config.get("processes"):
-                    data["processes"] = processes()
-                if self.config.get("ports"):
-                    data["ports"] = listening_ports(**self.config["ports"])
-                if self.config.get("temperatures"):
-                    data["temperatures"] = temperatures()
-                if self.config.get("fans"):
-                    data["fans"] = fans()
-                if self.config.get("redis"):
-                    data["redis"] = redis_metrics(**self.config["redis"])
-                if self.config.get("nginx"):
-                    data["nginx"] = nginx_metrics(**self.config["nginx"])
-                if self.config.get("docker"):
-                    data["docker"] = docker_metrics(**self.config["docker"])
-                if self.config.get("qemu"):
-                    data["qemu"] = qemu_metrics(**self.config["qemu"])
-                if self.config.get("fail2ban"):
-                    data["fail2ban"] = fail2ban_metrics()
-                if self.config.get("caddy"):
-                    data["caddy"] = caddy_metrics(**self.config["caddy"])
-                if self.config.get("postgresql"):
-                    data["postgresql"] = postgresql_metrics(**self.config["postgresql"])
-                if self.config.get("proxmox"):
-                    data["proxmox"] = proxmox_metrics(**self.config["proxmox"])
-
-                self.packages_sync()
+                packages_sync(self.config, self.synchronizer.send_packages)
 
                 # Running time and enqueue
                 running_time = time.monotonic() - start
                 data["running_time"] = running_time
-
 
                 log(json.dumps(data, indent=2), "debug")
                 # Exit immediately in dry-run
@@ -268,56 +128,39 @@ class Agent:
         finally:
             self._cleanup()
 
+    def _collect_metrics(self, data):
+        # Core metrics (always enabled)
+        data["load_average"] = load_average()
+        data["file_handles_used"] = file_handles_used()
+        data["file_handles_limit"] = file_handles_limit()
+
+        # Conditional metrics via registry
+        collect_metrics(self.config, data)
+
+        # Special-case collectors (unique dispatch patterns)
+        if self.config.get("ping"):
+            for region, host in self.config["ping"].items():
+                data[f"ping_{region}"] = tcp_ping(host)
+        if self.config.get("ipv4"):
+            data["ipv4"] = get_ip(ipv6=False)
+        if self.config.get("ipv6"):
+            data["ipv6"] = get_ip(ipv6=True)
+
+    def _handle_permission_refresh(self, static_data):
+        if refresh_permissions_event.is_set():
+            refresh_permissions_event.clear()
+            self.permissions.force_refresh()
+            static_data["capabilities"] = self.permissions.get_all()
+            print_capabilities_banner()
+        elif self.permissions.refresh_if_needed():
+            static_data["capabilities"] = self.permissions.get_all()
+
     def _wait_interval(self, running_time):
         log(f"Running time: {running_time:.3f}s", "debug")
         interval = self.config.get("interval", 60)
         sleep_time = max(interval - running_time, 0.1)
         log(f"Sleeping time: {sleep_time * 1000:.0f} ms", "debug")
         exit_event.wait(sleep_time)
-
-    def packages_sync(self):
-        """Sync packages if backend requests it via packages.scan."""
-        packages_config = self.config.get("packages")
-        if not isinstance(packages_config, dict):
-            return
-        if not packages_config.get("scan"):
-            return
-
-        distro = get_distro()
-        packages = get_installed_packages()
-        if not packages:
-            log("Packages synchronization: no packages found", "debug")
-            return
-
-        packages_hash = get_packages_hash(packages)
-        if packages_hash == packages_config.get("last_package_hash"):
-            log("Packages synchronization: packages unchanged, skipping", "debug")
-            return
-
-        packages_data = {
-            "distro": distro,
-            "packages_hash": packages_hash,
-            "packages": packages,
-        }
-
-        if dry_run():
-            log(f"Packages synchronization (dry-run): {json.dumps(packages_data, indent=2)}", "debug")
-            return
-
-        response = self.synchronizer.send_packages(packages_data)
-        if response is not None:
-            log("Packages synchronization sent successfully", "info")
-        else:
-            log("Packages synchronization failed, will retry", "error")
-
-    @debug("tcp_ping")
-    def tcp_ping(self, host, port=80, timeout=5):
-        try:
-            start = time.time()
-            with socket.create_connection((host, port), timeout):
-                return (time.time() - start) * 1000
-        except Exception:
-            return None
 
     def _cleanup(self):
         log("fivenines agent shutting down. Please wait...")

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -1,0 +1,94 @@
+"""Declarative collector registry for metric dispatch."""
+
+from fivenines_agent.caddy import caddy_metrics
+from fivenines_agent.cpu import cpu_count, cpu_data, cpu_model, cpu_usage
+from fivenines_agent.docker import docker_metrics
+from fivenines_agent.fail2ban import fail2ban_metrics
+from fivenines_agent.fans import fans
+from fivenines_agent.io import io
+from fivenines_agent.memory import memory, swap
+from fivenines_agent.network import network
+from fivenines_agent.nginx import nginx_metrics
+from fivenines_agent.partitions import partitions_metadata, partitions_usage
+from fivenines_agent.ports import listening_ports
+from fivenines_agent.postgresql import postgresql_metrics
+from fivenines_agent.processes import processes
+from fivenines_agent.proxmox import proxmox_metrics
+from fivenines_agent.qemu import qemu_metrics
+from fivenines_agent.raid_storage import raid_storage_health
+from fivenines_agent.redis import redis_metrics
+from fivenines_agent.smart_storage import (
+    smart_storage_health,
+    smart_storage_identification,
+)
+from fivenines_agent.temperatures import temperatures
+
+
+# Registry of metric collectors.
+# Each entry: (config_key, [(data_key, callable, pass_kwargs), ...])
+#
+# pass_kwargs=True means the config value (a dict) is unpacked as **kwargs
+# to the callable. pass_kwargs=False means the callable takes no arguments.
+COLLECTORS = [
+    (
+        "cpu",
+        [
+            ("cpu", cpu_data, False),
+            ("cpu_usage", cpu_usage, False),
+            ("cpu_model", cpu_model, False),
+            ("cpu_count", cpu_count, False),
+        ],
+    ),
+    (
+        "memory",
+        [
+            ("memory", memory, False),
+            ("swap", swap, False),
+        ],
+    ),
+    ("network", [("network", network, False)]),
+    (
+        "partitions",
+        [
+            ("partitions_metadata", partitions_metadata, False),
+            ("partitions_usage", partitions_usage, False),
+        ],
+    ),
+    ("io", [("io", io, False)]),
+    (
+        "smart_storage_health",
+        [
+            ("smart_storage_identification", smart_storage_identification, False),
+            ("smart_storage_health", smart_storage_health, False),
+        ],
+    ),
+    ("raid_storage_health", [("raid_storage_health", raid_storage_health, False)]),
+    ("processes", [("processes", processes, False)]),
+    ("ports", [("ports", listening_ports, True)]),
+    ("temperatures", [("temperatures", temperatures, False)]),
+    ("fans", [("fans", fans, False)]),
+    ("redis", [("redis", redis_metrics, True)]),
+    ("nginx", [("nginx", nginx_metrics, True)]),
+    ("docker", [("docker", docker_metrics, True)]),
+    ("qemu", [("qemu", qemu_metrics, True)]),
+    ("fail2ban", [("fail2ban", fail2ban_metrics, False)]),
+    ("caddy", [("caddy", caddy_metrics, True)]),
+    ("postgresql", [("postgresql", postgresql_metrics, True)]),
+    ("proxmox", [("proxmox", proxmox_metrics, True)]),
+]
+
+
+def collect_metrics(config, data):
+    """Run all registered collectors based on config flags.
+
+    Mutates *data* in place, adding one key per collected metric.
+    """
+    for config_key, collectors in COLLECTORS:
+        config_value = config.get(config_key)
+        if not config_value:
+            continue
+        for data_key, fn, pass_kwargs in collectors:
+            if pass_kwargs and isinstance(config_value, dict):
+                data[data_key] = fn(**config_value)
+            else:
+                data[data_key] = fn()

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -48,7 +48,6 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
 
 @debug('get_ip')
 def get_ip(ipv6=False):
-    global _ip_v4_cache, _ip_v6_cache
     now = time.time()
 
     if ipv6:
@@ -70,7 +69,11 @@ def get_ip(ipv6=False):
         log(f"Response body: {body}", 'debug')
 
         if response.status == 200:
-            return body.strip()
+            ip = body.strip()
+            cache = _ip_v6_cache if ipv6 else _ip_v4_cache
+            cache["timestamp"] = now
+            cache["ip"] = ip
+            return ip
 
         return None
     except ConnectionError as e:

--- a/fivenines_agent/ping.py
+++ b/fivenines_agent/ping.py
@@ -1,0 +1,16 @@
+"""TCP ping utility for latency measurement."""
+
+import socket
+import time
+
+from fivenines_agent.debug import debug
+
+
+@debug("tcp_ping")
+def tcp_ping(host, port=80, timeout=5):
+    try:
+        start = time.time()
+        with socket.create_connection((host, port), timeout):
+            return (time.time() - start) * 1000
+    except Exception:
+        return None

--- a/fivenines_agent/synchronizer.py
+++ b/fivenines_agent/synchronizer.py
@@ -152,9 +152,10 @@ class Synchronizer(Thread):
             return conn
 
     def get_config(self):
-        if self.config["enabled"] == None:
+        with self.config_lock:
+            config = self.config
+        if config["enabled"] is None:
             self.send_metrics({"get_config": True})
-            return self.config
-        else:
             with self.config_lock:
                 return self.config
+        return config

--- a/tests/test_agent_security_scan.py
+++ b/tests/test_agent_security_scan.py
@@ -1,119 +1,105 @@
-"""Tests for Agent.packages_sync()."""
+"""Tests for packages_sync() standalone function."""
 
-import sys
 from unittest.mock import MagicMock, patch
 
+from fivenines_agent.packages import packages_sync
 
-# Mock libvirt before any fivenines_agent imports that transitively need it
-sys.modules.setdefault("libvirt", MagicMock())
-
-
-from fivenines_agent.agent import Agent  # noqa: E402
 
 PACKAGES_CONFIG = {"scan": True, "last_scan_at": None, "last_package_hash": None}
-
-
-def make_agent():
-    """Create an Agent-like object with packages_sync attached."""
-    agent = Agent.__new__(Agent)
-    agent.config = {"enabled": True, "interval": 60}
-    agent.synchronizer = MagicMock()
-    return agent
 
 
 # --- packages_sync ---
 
 
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_no_packages_key(mock_hash, mock_distro, mock_pkgs):
-    agent = make_agent()
-    agent.config = {"enabled": True}
+    config = {"enabled": True}
+    send_fn = MagicMock()
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
     mock_distro.assert_not_called()
     mock_pkgs.assert_not_called()
 
 
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_packages_none(mock_hash, mock_distro, mock_pkgs):
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": None}
+    config = {"enabled": True, "packages": None}
+    send_fn = MagicMock()
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
     mock_distro.assert_not_called()
 
 
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_scan_false(mock_hash, mock_distro, mock_pkgs):
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": {"scan": False}}
+    config = {"enabled": True, "packages": {"scan": False}}
+    send_fn = MagicMock()
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
     mock_distro.assert_not_called()
 
 
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_no_packages_found(mock_hash, mock_distro, mock_pkgs):
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    send_fn = MagicMock()
     mock_distro.return_value = "debian:12"
     mock_pkgs.return_value = []
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
     mock_distro.assert_called_once()
     mock_pkgs.assert_called_once()
     mock_hash.assert_not_called()
-    agent.synchronizer.send_packages.assert_not_called()
+    send_fn.assert_not_called()
 
 
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_hash_matches_server(mock_hash, mock_distro, mock_pkgs):
-    agent = make_agent()
-    agent.config = {
+    config = {
         "enabled": True,
         "packages": {"scan": True, "last_package_hash": "abc123"},
     }
+    send_fn = MagicMock()
     mock_distro.return_value = "debian:12"
     mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
     mock_hash.return_value = "abc123"
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
-    agent.synchronizer.send_packages.assert_not_called()
+    send_fn.assert_not_called()
 
 
-@patch("fivenines_agent.agent.dry_run", return_value=False)
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.dry_run", return_value=False)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_sends_on_hash_change(mock_hash, mock_distro, mock_pkgs, mock_dry):
-    agent = make_agent()
-    agent.config = {
+    config = {
         "enabled": True,
         "packages": {"scan": True, "last_package_hash": "old_hash"},
     }
+    send_fn = MagicMock(return_value={"status": "queued"})
     mock_distro.return_value = "debian:12"
     mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
     mock_hash.return_value = "new_hash"
-    agent.synchronizer.send_packages.return_value = {"status": "queued"}
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
-    agent.synchronizer.send_packages.assert_called_once_with(
+    send_fn.assert_called_once_with(
         {
             "distro": "debian:12",
             "packages_hash": "new_hash",
@@ -122,52 +108,50 @@ def test_sends_on_hash_change(mock_hash, mock_distro, mock_pkgs, mock_dry):
     )
 
 
-@patch("fivenines_agent.agent.dry_run", return_value=False)
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.dry_run", return_value=False)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_sends_when_server_hash_is_none(mock_hash, mock_distro, mock_pkgs, mock_dry):
     """First scan ever: server has no hash yet."""
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    send_fn = MagicMock(return_value={"status": "queued"})
     mock_distro.return_value = "ubuntu:22.04"
     mock_pkgs.return_value = [{"name": "bash", "version": "5.0"}]
     mock_hash.return_value = "hash1"
-    agent.synchronizer.send_packages.return_value = {"status": "queued"}
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
-    agent.synchronizer.send_packages.assert_called_once()
+    send_fn.assert_called_once()
 
 
-@patch("fivenines_agent.agent.dry_run", return_value=False)
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.dry_run", return_value=False)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_failure_logs_error(mock_hash, mock_distro, mock_pkgs, mock_dry):
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    send_fn = MagicMock(return_value=None)
     mock_distro.return_value = "debian:12"
     mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
     mock_hash.return_value = "new_hash"
-    agent.synchronizer.send_packages.return_value = None
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
-    agent.synchronizer.send_packages.assert_called_once()
+    send_fn.assert_called_once()
 
 
-@patch("fivenines_agent.agent.dry_run", return_value=True)
-@patch("fivenines_agent.agent.get_installed_packages")
-@patch("fivenines_agent.agent.get_distro")
-@patch("fivenines_agent.agent.get_packages_hash")
+@patch("fivenines_agent.packages.dry_run", return_value=True)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
 def test_dry_run_skips_send(mock_hash, mock_distro, mock_pkgs, mock_dry):
-    agent = make_agent()
-    agent.config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    config = {"enabled": True, "packages": PACKAGES_CONFIG}
+    send_fn = MagicMock()
     mock_distro.return_value = "debian:12"
     mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
     mock_hash.return_value = "new_hash"
 
-    agent.packages_sync()
+    packages_sync(config, send_fn)
 
-    agent.synchronizer.send_packages.assert_not_called()
+    send_fn.assert_not_called()

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,134 @@
+"""Tests for the collector registry and dispatch loop."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+
+# Mock libvirt before any fivenines_agent imports that transitively need it
+sys.modules.setdefault("libvirt", MagicMock())
+
+
+from fivenines_agent.collectors import COLLECTORS, collect_metrics  # noqa: E402
+
+
+def test_registry_has_expected_config_keys():
+    """All known config keys are present in the registry."""
+    config_keys = [entry[0] for entry in COLLECTORS]
+    expected = [
+        "cpu",
+        "memory",
+        "network",
+        "partitions",
+        "io",
+        "smart_storage_health",
+        "raid_storage_health",
+        "processes",
+        "ports",
+        "temperatures",
+        "fans",
+        "redis",
+        "nginx",
+        "docker",
+        "qemu",
+        "fail2ban",
+        "caddy",
+        "postgresql",
+        "proxmox",
+    ]
+    assert config_keys == expected
+
+
+def test_collect_metrics_skips_disabled():
+    """Collectors are skipped when their config key is falsy."""
+    config = {"cpu": False, "memory": None, "network": 0}
+    data = {}
+    collect_metrics(config, data)
+    assert data == {}
+
+
+def test_collect_metrics_calls_simple_collector():
+    """A simple (no-kwargs) collector is called when config key is truthy."""
+    mock_fn = MagicMock(return_value=42)
+    registry = [("metric", [("metric", mock_fn, False)])]
+    config = {"metric": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_fn.assert_called_once_with()
+    assert data == {"metric": 42}
+
+
+def test_collect_metrics_calls_kwargs_collector():
+    """A kwargs collector unpacks the config dict as keyword arguments."""
+    mock_fn = MagicMock(return_value={"ok": True})
+    registry = [("svc", [("svc", mock_fn, True)])]
+    config = {"svc": {"host": "localhost", "port": 8080}}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_fn.assert_called_once_with(host="localhost", port=8080)
+    assert data == {"svc": {"ok": True}}
+
+
+def test_collect_metrics_kwargs_with_non_dict_config():
+    """When pass_kwargs=True but config value is not a dict, call with no args."""
+    mock_fn = MagicMock(return_value="result")
+    registry = [("svc", [("svc", mock_fn, True)])]
+    config = {"svc": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_fn.assert_called_once_with()
+    assert data == {"svc": "result"}
+
+
+def test_collect_metrics_multi_key():
+    """A config key mapping to multiple data keys calls each collector."""
+    mock_a = MagicMock(return_value="a")
+    mock_b = MagicMock(return_value="b")
+    registry = [("multi", [("key_a", mock_a, False), ("key_b", mock_b, False)])]
+    config = {"multi": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_a.assert_called_once_with()
+    mock_b.assert_called_once_with()
+    assert data == {"key_a": "a", "key_b": "b"}
+
+
+def test_collect_metrics_only_enabled():
+    """Only collectors with truthy config are invoked."""
+    mock_on = MagicMock(return_value="on")
+    mock_off = MagicMock(return_value="off")
+    registry = [
+        ("enabled", [("enabled", mock_on, False)]),
+        ("disabled", [("disabled", mock_off, False)]),
+    ]
+    config = {"enabled": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_on.assert_called_once()
+    mock_off.assert_not_called()
+    assert data == {"enabled": "on"}
+
+
+def test_registry_entries_are_tuples():
+    """Each registry entry has the expected structure."""
+    for config_key, collectors in COLLECTORS:
+        assert isinstance(config_key, str)
+        assert isinstance(collectors, list)
+        for data_key, fn, pass_kwargs in collectors:
+            assert isinstance(data_key, str)
+            assert callable(fn)
+            assert isinstance(pass_kwargs, bool)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,66 @@
+"""Tests for env module functions including get_user_context."""
+
+import os
+from unittest.mock import patch
+
+from fivenines_agent.env import get_user_context
+
+
+def test_get_user_context_returns_dict():
+    result = get_user_context("/opt/fivenines")
+    assert isinstance(result, dict)
+    assert "username" in result
+    assert "uid" in result
+    assert "euid" in result
+    assert "gid" in result
+    assert "groupname" in result
+    assert "groups" in result
+    assert "is_root" in result
+    assert "is_user_install" in result
+    assert "config_dir" in result
+    assert "home_dir" in result
+
+
+def test_get_user_context_system_install():
+    result = get_user_context("/opt/fivenines")
+    assert result["config_dir"] == "/opt/fivenines"
+    assert result["is_user_install"] is False
+
+
+def test_get_user_context_user_install():
+    home = os.path.expanduser("~")
+    cfg_dir = os.path.join(home, ".local/fivenines")
+    result = get_user_context(cfg_dir)
+    assert result["is_user_install"] is True
+
+
+def test_get_user_context_current_user():
+    result = get_user_context("/opt/fivenines")
+    assert result["uid"] == os.getuid()
+    assert result["euid"] == os.geteuid()
+    assert result["gid"] == os.getgid()
+    assert result["is_root"] == (os.getuid() == 0)
+
+
+@patch("fivenines_agent.env.os.getuid", side_effect=OSError("mocked"))
+def test_get_user_context_error_fallback(mock_uid):
+    result = get_user_context("/opt/fivenines")
+    assert result == {
+        "username": "unknown",
+        "is_root": False,
+        "is_user_install": False,
+    }
+
+
+@patch("fivenines_agent.env.pwd.getpwuid", side_effect=KeyError("no user"))
+def test_get_user_context_unknown_username(mock_pw):
+    result = get_user_context("/opt/fivenines")
+    assert result["username"] == str(os.getuid())
+
+
+@patch("fivenines_agent.env.grp.getgrgid", side_effect=KeyError("no group"))
+def test_get_user_context_unknown_group(mock_grp):
+    result = get_user_context("/opt/fivenines")
+    assert result["groupname"] == str(os.getgid())
+    # groups list should also fall back to numeric strings
+    assert all(isinstance(g, str) for g in result["groups"])

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -1,0 +1,134 @@
+"""Tests for IP detection and caching."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import fivenines_agent.ip as ip_module
+from fivenines_agent.ip import get_ip
+
+
+def _reset_caches():
+    """Reset module-level caches between tests."""
+    ip_module._ip_v4_cache["timestamp"] = 0
+    ip_module._ip_v4_cache["ip"] = None
+    ip_module._ip_v6_cache["timestamp"] = 0
+    ip_module._ip_v6_cache["ip"] = None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_v4_success(mock_conn_cls):
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    result = get_ip(ipv6=False)
+    assert result == "1.2.3.4"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_v6_success(mock_conn_cls):
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"::1\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    result = get_ip(ipv6=True)
+    assert result == "::1"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_caches_result(mock_conn_cls):
+    """Second call within TTL should return cached value without HTTP request."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    result1 = get_ip(ipv6=False)
+    result2 = get_ip(ipv6=False)
+
+    assert result1 == "1.2.3.4"
+    assert result2 == "1.2.3.4"
+    # Only one HTTP connection should have been made
+    assert mock_conn_cls.call_count == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_v6_caches_result(mock_conn_cls):
+    """IPv6 cache works independently from IPv4."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"::1\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    result1 = get_ip(ipv6=True)
+    result2 = get_ip(ipv6=True)
+
+    assert result1 == "::1"
+    assert result2 == "::1"
+    assert mock_conn_cls.call_count == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_cache_expired(mock_conn_cls):
+    """After TTL expires, a new HTTP request should be made."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    # First call populates the cache
+    get_ip(ipv6=False)
+    # Expire the cache
+    ip_module._ip_v4_cache["timestamp"] = time.time() - 120
+
+    get_ip(ipv6=False)
+    assert mock_conn_cls.call_count == 2
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_http_error(mock_conn_cls):
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 500
+    mock_response.read.return_value = b"error"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    result = get_ip(ipv6=False)
+    assert result is None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_connection_error(mock_conn_cls):
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("refused")
+
+    result = get_ip(ipv6=False)
+    assert result is None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_generic_exception(mock_conn_cls):
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = Exception("something broke")
+
+    result = get_ip(ipv6=False)
+    assert result is None

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,32 @@
+"""Tests for tcp_ping utility."""
+
+from unittest.mock import MagicMock, patch
+
+from fivenines_agent.ping import tcp_ping
+
+
+@patch("fivenines_agent.ping.socket.create_connection")
+def test_tcp_ping_success(mock_conn):
+    mock_conn.return_value.__enter__ = MagicMock()
+    mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+    result = tcp_ping("example.com", port=80, timeout=5)
+    assert result is not None
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+@patch("fivenines_agent.ping.socket.create_connection")
+def test_tcp_ping_failure(mock_conn):
+    mock_conn.side_effect = OSError("Connection refused")
+
+    result = tcp_ping("example.com", port=80, timeout=5)
+    assert result is None
+
+
+@patch("fivenines_agent.ping.socket.create_connection")
+def test_tcp_ping_timeout(mock_conn):
+    mock_conn.side_effect = TimeoutError("timed out")
+
+    result = tcp_ping("example.com", port=80, timeout=1)
+    assert result is None


### PR DESCRIPTION
## Summary

- **Collector registry**: Replace 25 hardcoded if-blocks in `agent.py` with a declarative registry (`collectors.py`) and dispatch loop, reducing `agent.py` from 329 to 172 lines. Adding a new collector now requires zero changes to `agent.py`.
- **Extract standalone functions**: Move `packages_sync()` to `packages.py`, `get_user_context()` to `env.py`, `tcp_ping()` to new `ping.py`, and signal handlers to top-level `setup_signals()`.
- **Fix thread safety**: `Synchronizer.get_config()` now always reads config under the lock and uses `is None` instead of `== None`.
- **Fix IP cache bug**: `get_ip()` now writes to the cache on success (previously returned without caching, making an HTTP request on every call).

## Test plan

- [x] All 78 tests pass (`poetry run pytest ./tests/ -x`)
- [x] New modules (`collectors.py`, `packages.py`, `ping.py`) at 100% coverage
- [x] `flake8` clean on all new/modified files (pre-existing `ip.py`/`env.py` style issues untouched)
- [ ] `poetry run fivenines_agent --dry-run` on a Linux host to verify identical JSON output