### PR TITLE
Feature: Per-metric telemetry with timing and error tracking

### DIFF
--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 from fivenines_agent.cli import VERSION
 from fivenines_agent.collectors import collect_metrics
-from fivenines_agent.debug import log
+from fivenines_agent.debug import log, start_log_capture, stop_log_capture
 from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context
 from fivenines_agent.files import file_handles_limit, file_handles_used
 from fivenines_agent.ip import get_ip
@@ -105,10 +105,12 @@ class Agent:
                 data = static_data.copy()
                 data["ts"] = time.time()
                 start = time.monotonic()
+                self._telemetry = {}
 
                 self._collect_metrics(data)
 
-                packages_sync(self.config, self.synchronizer.send_packages)
+                self._packages_sync_with_telemetry()
+                data["_telemetry"] = self._telemetry
 
                 # Running time and enqueue
                 running_time = time.monotonic() - start
@@ -130,21 +132,60 @@ class Agent:
 
     def _collect_metrics(self, data):
         # Core metrics (always enabled)
-        data["load_average"] = load_average()
-        data["file_handles_used"] = file_handles_used()
-        data["file_handles_limit"] = file_handles_limit()
+        data["load_average"] = self._collect("load_average", load_average)
+        data["file_handles_used"] = self._collect("file_handles_used", file_handles_used)
+        data["file_handles_limit"] = self._collect("file_handles_limit", file_handles_limit)
 
         # Conditional metrics via registry
-        collect_metrics(self.config, data)
+        collect_metrics(self.config, data, self._telemetry)
 
         # Special-case collectors (unique dispatch patterns)
         if self.config.get("ping"):
             for region, host in self.config["ping"].items():
-                data[f"ping_{region}"] = tcp_ping(host)
+                data[f"ping_{region}"] = self._collect(f"ping_{region}", tcp_ping, host)
         if self.config.get("ipv4"):
-            data["ipv4"] = get_ip(ipv6=False)
+            data["ipv4"] = self._collect("ipv4", get_ip, ipv6=False)
         if self.config.get("ipv6"):
-            data["ipv6"] = get_ip(ipv6=True)
+            data["ipv6"] = self._collect("ipv6", get_ip, ipv6=True)
+
+    def _collect(self, name, fn, *args, **kwargs):
+        start = time.monotonic()
+        start_log_capture()
+        try:
+            result = fn(*args, **kwargs)
+            duration_ms = round((time.monotonic() - start) * 1000, 2)
+            errors = stop_log_capture()
+            entry = {"duration_ms": duration_ms}
+            if errors:
+                entry["errors"] = errors
+            self._telemetry[name] = entry
+            return result
+        except Exception as e:
+            errors = stop_log_capture()
+            errors.append(str(e))
+            duration_ms = round((time.monotonic() - start) * 1000, 2)
+            self._telemetry[name] = {"duration_ms": duration_ms, "errors": errors}
+            log(f"Error collecting {name}: {e}", "error")
+            return None
+
+    def _packages_sync_with_telemetry(self):
+        ps_start = time.monotonic()
+        start_log_capture()
+        try:
+            packages_sync(self.config, self.synchronizer.send_packages)
+        except Exception as e:
+            errors = stop_log_capture()
+            errors.append(str(e))
+            duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
+            self._telemetry["packages_sync"] = {"duration_ms": duration_ms, "errors": errors}
+            log(f"Error in packages_sync: {e}", "error")
+            return
+        errors = stop_log_capture()
+        duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
+        entry = {"duration_ms": duration_ms}
+        if errors:
+            entry["errors"] = errors
+        self._telemetry["packages_sync"] = entry
 
     def _handle_permission_refresh(self, static_data):
         if refresh_permissions_event.is_set():

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -1,0 +1,302 @@
+"""Tests for per-metric telemetry: _collect, log buffering, packages_sync telemetry."""
+
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+# Mock libvirt before any fivenines_agent imports that transitively need it
+sys.modules.setdefault("libvirt", MagicMock())
+
+
+from fivenines_agent.agent import Agent  # noqa: E402
+from fivenines_agent.debug import (  # noqa: E402
+    _thread_local,
+    log,
+    start_log_capture,
+    stop_log_capture,
+)
+
+
+def make_agent():
+    """Create an Agent-like object with _collect attached."""
+    agent = Agent.__new__(Agent)
+    agent.config = {"enabled": True, "interval": 60}
+    agent.synchronizer = MagicMock()
+    agent._telemetry = {}
+    return agent
+
+
+# --- _collect: success ---
+
+
+def test_collect_returns_value():
+    agent = make_agent()
+    result = agent._collect("test_metric", lambda: 42)
+    assert result == 42
+
+
+def test_collect_records_duration():
+    agent = make_agent()
+    agent._collect("test_metric", lambda: "ok")
+    entry = agent._telemetry["test_metric"]
+    assert "duration_ms" in entry
+    assert isinstance(entry["duration_ms"], float)
+    assert entry["duration_ms"] >= 0
+
+
+def test_collect_no_errors_key_on_success():
+    agent = make_agent()
+    agent._collect("test_metric", lambda: "ok")
+    assert "errors" not in agent._telemetry["test_metric"]
+
+
+# --- _collect: with args/kwargs ---
+
+
+def test_collect_passes_args():
+    agent = make_agent()
+
+    def adder(a, b):
+        return a + b
+
+    result = agent._collect("adder", adder, 3, 7)
+    assert result == 10
+
+
+def test_collect_passes_kwargs():
+    agent = make_agent()
+
+    def greeter(greeting="world"):
+        return f"hello {greeting}"
+
+    result = agent._collect("greeter", greeter, greeting="alice")
+    assert result == "hello alice"
+
+
+# --- _collect: exception ---
+
+
+def test_collect_exception_returns_none():
+    agent = make_agent()
+
+    def failing():
+        raise ValueError("boom")
+
+    result = agent._collect("fail_metric", failing)
+    assert result is None
+
+
+def test_collect_exception_records_error():
+    agent = make_agent()
+
+    def failing():
+        raise ValueError("boom")
+
+    agent._collect("fail_metric", failing)
+    entry = agent._telemetry["fail_metric"]
+    assert "duration_ms" in entry
+    assert "errors" in entry
+    assert "boom" in entry["errors"]
+
+
+# --- _collect: collector that logs errors internally ---
+
+
+@patch("fivenines_agent.debug.log_level", return_value="debug")
+def test_collect_captures_logged_errors(mock_ll):
+    agent = make_agent()
+
+    def noisy_collector():
+        log("something went wrong", "error")
+        log("this is info", "info")
+        log("another error", "error")
+        return "partial"
+
+    result = agent._collect("noisy", noisy_collector)
+    assert result == "partial"
+    entry = agent._telemetry["noisy"]
+    assert entry["errors"] == ["something went wrong", "another error"]
+
+
+# --- _collect: multiple metrics ---
+
+
+def test_collect_multiple_metrics():
+    agent = make_agent()
+    agent._collect("m1", lambda: 1)
+    agent._collect("m2", lambda: 2)
+    agent._collect("m3", lambda: 3)
+    assert set(agent._telemetry.keys()) == {"m1", "m2", "m3"}
+    for key in ("m1", "m2", "m3"):
+        assert "duration_ms" in agent._telemetry[key]
+
+
+# --- Log buffering: basic lifecycle ---
+
+
+@patch("fivenines_agent.debug.log_level", return_value="debug")
+def test_log_capture_basic(mock_ll):
+    start_log_capture()
+    log("info msg", "info")
+    log("err msg", "error")
+    errors = stop_log_capture()
+    assert errors == ["err msg"]
+
+
+@patch("fivenines_agent.debug.log_level", return_value="debug")
+def test_log_capture_only_errors(mock_ll):
+    start_log_capture()
+    log("debug msg", "debug")
+    log("info msg", "info")
+    log("warn msg", "warn")
+    errors = stop_log_capture()
+    assert errors == []
+
+
+@patch("fivenines_agent.debug.log_level", return_value="debug")
+def test_log_messages_still_print(mock_ll, capsys):
+    start_log_capture()
+    log("visible error", "error")
+    errors = stop_log_capture()
+    captured = capsys.readouterr()
+    assert "visible error" in captured.out
+    assert errors == ["visible error"]
+
+
+def test_stop_without_start():
+    """stop_log_capture without start returns empty list."""
+    # Ensure no buffer is set
+    _thread_local.log_buffer = None
+    errors = stop_log_capture()
+    assert errors == []
+
+
+# --- Log buffering: errors captured regardless of log level ---
+
+
+@patch("fivenines_agent.debug.log_level", return_value="critical")
+def test_errors_captured_even_when_log_level_high(mock_ll, capsys):
+    """Error messages are buffered even when log level suppresses printing."""
+    start_log_capture()
+    log("suppressed error", "error")
+    errors = stop_log_capture()
+    # Not printed (log level is critical)
+    captured = capsys.readouterr()
+    assert "suppressed error" not in captured.out
+    # But still captured in buffer
+    assert errors == ["suppressed error"]
+
+
+# --- Log buffering: thread isolation ---
+
+
+@patch("fivenines_agent.debug.log_level", return_value="debug")
+def test_log_capture_thread_isolation(mock_ll):
+    """Buffer on one thread does not capture logs from another."""
+    other_thread_errors = []
+
+    def other_thread_work():
+        log("other thread error", "error")
+        # This thread has no buffer, so nothing captured
+        buf = getattr(_thread_local, "log_buffer", None)
+        other_thread_errors.append(buf)
+
+    start_log_capture()
+    t = threading.Thread(target=other_thread_work)
+    t.start()
+    t.join()
+    log("main thread error", "error")
+    errors = stop_log_capture()
+
+    # Main thread only captured its own error
+    assert errors == ["main thread error"]
+    # Other thread had no buffer
+    assert other_thread_errors == [None]
+
+
+# --- packages_sync telemetry ---
+
+
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
+def test_packages_sync_telemetry_early_return(mock_hash, mock_distro, mock_pkgs):
+    """Telemetry recorded even on early return (no packages config)."""
+    agent = make_agent()
+    agent.config = {"enabled": True}
+
+    agent._packages_sync_with_telemetry()
+
+    assert "packages_sync" in agent._telemetry
+    entry = agent._telemetry["packages_sync"]
+    assert "duration_ms" in entry
+    assert "errors" not in entry
+
+
+@patch("fivenines_agent.packages.dry_run", return_value=False)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
+def test_packages_sync_telemetry_success(mock_hash, mock_distro, mock_pkgs, mock_dry):
+    """Telemetry recorded on successful send."""
+    agent = make_agent()
+    agent.config = {
+        "enabled": True,
+        "packages": {"scan": True, "last_package_hash": "old"},
+    }
+    mock_distro.return_value = "debian:12"
+    mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
+    mock_hash.return_value = "new"
+    agent.synchronizer.send_packages.return_value = {"status": "queued"}
+
+    agent._packages_sync_with_telemetry()
+
+    assert "packages_sync" in agent._telemetry
+    entry = agent._telemetry["packages_sync"]
+    assert "duration_ms" in entry
+
+
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
+def test_packages_sync_telemetry_on_exception(mock_hash, mock_distro, mock_pkgs):
+    """Telemetry with errors recorded when exception occurs."""
+    agent = make_agent()
+    agent.config = {
+        "enabled": True,
+        "packages": {"scan": True, "last_package_hash": None},
+    }
+    mock_distro.side_effect = RuntimeError("distro exploded")
+
+    agent._packages_sync_with_telemetry()
+
+    entry = agent._telemetry["packages_sync"]
+    assert "duration_ms" in entry
+    assert "errors" in entry
+    assert "distro exploded" in entry["errors"]
+
+
+@patch("fivenines_agent.packages.dry_run", return_value=False)
+@patch("fivenines_agent.packages.get_installed_packages")
+@patch("fivenines_agent.packages.get_distro")
+@patch("fivenines_agent.packages.get_packages_hash")
+def test_packages_sync_telemetry_captures_logged_error(
+    mock_hash, mock_distro, mock_pkgs, mock_dry
+):
+    """Telemetry captures error logged by packages_sync (send failure)."""
+    agent = make_agent()
+    agent.config = {
+        "enabled": True,
+        "packages": {"scan": True, "last_package_hash": "old"},
+    }
+    mock_distro.return_value = "debian:12"
+    mock_pkgs.return_value = [{"name": "openssl", "version": "3.0"}]
+    mock_hash.return_value = "new"
+    agent.synchronizer.send_packages.return_value = None  # failure
+
+    agent._packages_sync_with_telemetry()
+
+    entry = agent._telemetry["packages_sync"]
+    assert "duration_ms" in entry
+    assert "errors" in entry
+    assert "Packages synchronization failed, will retry" in entry["errors"]


### PR DESCRIPTION
## Summary
- Add per-metric telemetry instrumentation (`duration_ms` + captured `errors`) to every collector, enabling the backend to monitor collector health and diagnose failures
- Extend `collectors.py` dispatch loop with optional `telemetry` parameter and `_collect_with_telemetry()` helper — zero overhead when telemetry is off
- Add `_collect()` and `_packages_sync_with_telemetry()` methods to `Agent` for core/special-case metrics and package sync
- Add thread-local log buffering (`start_log_capture`/`stop_log_capture`) in `debug.py` to capture error messages during collection

## Test plan
- [x] 101 tests pass (`pytest ./tests/ -v`)
- [x] 19 new tests: 9 for `_collect`, 6 for log buffering, 4 for packages_sync telemetry in `test_agent_telemetry.py`
- [x] 4 new tests for collector-level telemetry in `test_collectors.py`
- [x] flake8 clean on all changed files
- [x] bandit shows no new findings