### PR TITLE
Feature: Add pacman package manager support

### DIFF
--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -320,7 +320,7 @@ class PermissionProbe:
 
     def _can_list_packages(self):
         """Check if a supported package manager is available."""
-        for cmd in ("dpkg-query", "rpm", "apk"):
+        for cmd in ("dpkg-query", "rpm", "apk", "pacman"):
             if shutil.which(cmd):
                 log(f"_can_list_packages: found '{cmd}'", "debug")
                 return True
@@ -407,7 +407,7 @@ def print_capabilities_banner():
                 elif cap == "fail2ban":
                     hint = " (requires: sudo fail2ban-client)"
                 elif cap == "packages":
-                    hint = " (requires: dpkg-query, rpm, or apk)"
+                    hint = " (requires: dpkg-query, rpm, apk, or pacman)"
                 elif cap == "zfs":
                     hint = " (requires: zfs permissions)"
                 elif cap in ["temperatures", "fans"]:

--- a/tests/test_permissions_packages.py
+++ b/tests/test_permissions_packages.py
@@ -38,6 +38,18 @@ def test_can_list_packages_apk(mock_probe):
 
 
 @patch.object(PermissionProbe, "_probe_all")
+def test_can_list_packages_pacman(mock_probe):
+    """pacman available should return True."""
+    probe = PermissionProbe.__new__(PermissionProbe)
+    probe.capabilities = {}
+    with patch("fivenines_agent.permissions.shutil.which") as mock_which:
+        mock_which.side_effect = lambda cmd: (
+            "/usr/bin/pacman" if cmd == "pacman" else None
+        )
+        assert probe._can_list_packages() is True
+
+
+@patch.object(PermissionProbe, "_probe_all")
 def test_can_list_packages_none(mock_probe):
     """No package manager should return False."""
     probe = PermissionProbe.__new__(PermissionProbe)


### PR DESCRIPTION
## Summary
- Add `pacman` (Arch Linux, Manjaro, EndeavourOS) to the package scanner alongside dpkg, rpm, and apk
- Uses `pacman -Q` which outputs `name version` per line - simple, no parsing ambiguity
- Updated `packages_available()`, `get_installed_packages()`, `_can_list_packages()`, and capability hint string

## Test plan
- [x] 107 tests pass (6 new)
- [x] `_get_packages_pacman`: success, failure, empty output
- [x] `packages_available` with pacman
- [x] `get_installed_packages` with pacman
- [x] `_can_list_packages` permission probe with pacman
- [x] flake8 clean on changed files