### PR TITLE
Add Alpine Linux support (musl libc + OpenRC)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -179,9 +179,143 @@ jobs:
           path: dist/fivenines-agent-linux-arm64.tar.gz
           retention-days: 7
 
+  build-alpine-amd64:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        id: image
+        run: |
+          IMAGE_NAME=$(echo "${{ github.repository }}-builder-alpine-amd64" | tr '[:upper:]' '[:lower:]')
+          echo "name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push Docker image (alpine-amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.alpine
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:buildcache,mode=max
+          load: true
+
+      - name: Build agent binary (alpine-amd64)
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -e TARGET_ARCH=amd64 \
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest \
+            sh /workspace/py2exe_alpine.sh
+
+      - name: Fix permissions and create tarball (alpine-amd64)
+        run: |
+          sudo chown -R $(id -u):$(id -g) dist/
+          cd dist/linux
+          tar -czvf fivenines-agent-alpine-amd64.tar.gz fivenines-agent-alpine-amd64/
+          mv fivenines-agent-alpine-amd64.tar.gz ../
+
+      - name: Upload artifact (alpine-amd64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: fivenines-agent-alpine-amd64
+          path: dist/fivenines-agent-alpine-amd64.tar.gz
+          retention-days: 7
+
+  build-alpine-arm64:
+    needs: [lint]
+    runs-on: ubuntu-24.04-arm  # Native ARM64 runner
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set image name (lowercase)
+        id: image
+        run: |
+          IMAGE_NAME=$(echo "${{ github.repository }}-builder-alpine-arm64" | tr '[:upper:]' '[:lower:]')
+          echo "name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push Docker image (alpine-arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.alpine-arm
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:buildcache,mode=max
+          load: true
+
+      - name: Build agent binary (alpine-arm64)
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -e TARGET_ARCH=arm64 \
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest \
+            sh /workspace/py2exe_alpine.sh
+
+      - name: Fix permissions and create tarball (alpine-arm64)
+        run: |
+          sudo chown -R $(id -u):$(id -g) dist/
+          cd dist/linux
+          tar -czvf fivenines-agent-alpine-arm64.tar.gz fivenines-agent-alpine-arm64/
+          mv fivenines-agent-alpine-arm64.tar.gz ../
+
+      - name: Upload artifact (alpine-arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: fivenines-agent-alpine-arm64
+          path: dist/fivenines-agent-alpine-arm64.tar.gz
+          retention-days: 7
+
   # Pre-release for feature and release branches
   pre-release:
-    needs: [build-amd64, build-arm64]
+    needs: [build-amd64, build-arm64, build-alpine-amd64, build-alpine-arm64]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' &&
@@ -222,6 +356,8 @@ jobs:
           mkdir -p release
           mv artifacts/fivenines-agent-linux-amd64/fivenines-agent-linux-amd64.tar.gz release/
           mv artifacts/fivenines-agent-linux-arm64/fivenines-agent-linux-arm64.tar.gz release/
+          mv artifacts/fivenines-agent-alpine-amd64/fivenines-agent-alpine-amd64.tar.gz release/
+          mv artifacts/fivenines-agent-alpine-arm64/fivenines-agent-alpine-arm64.tar.gz release/
           ls -la release/
 
       - name: Delete existing pre-release with same tag (if exists)
@@ -248,8 +384,11 @@ jobs:
 
             ### Quick Install (replace existing agent)
             ```bash
-            # System install (root)
+            # System install (root) - glibc
             FIVENINES_AGENT_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-linux-amd64.tar.gz" bash fivenines_update.sh
+
+            # System install (root) - Alpine/musl
+            FIVENINES_AGENT_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-alpine-amd64.tar.gz" bash fivenines_update.sh
 
             # User install
             FIVENINES_AGENT_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-linux-amd64.tar.gz" bash fivenines_update_user.sh
@@ -257,21 +396,29 @@ jobs:
 
             ### Download URLs
             ```
-            # AMD64
+            # AMD64 (glibc)
             https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-linux-amd64.tar.gz
 
-            # ARM64
+            # ARM64 (glibc)
             https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-linux-arm64.tar.gz
+
+            # AMD64 (Alpine/musl)
+            https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-alpine-amd64.tar.gz
+
+            # ARM64 (Alpine/musl)
+            https://github.com/${{ github.repository }}/releases/download/${{ steps.release_info.outputs.TAG_NAME }}/fivenines-agent-alpine-arm64.tar.gz
             ```
           files: |
             release/fivenines-agent-linux-amd64.tar.gz
             release/fivenines-agent-linux-arm64.tar.gz
+            release/fivenines-agent-alpine-amd64.tar.gz
+            release/fivenines-agent-alpine-arm64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Production release for version tags
   release:
-    needs: [build-amd64, build-arm64]
+    needs: [build-amd64, build-arm64, build-alpine-amd64, build-alpine-arm64]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -290,6 +437,8 @@ jobs:
           mkdir -p release
           mv artifacts/fivenines-agent-linux-amd64/fivenines-agent-linux-amd64.tar.gz release/
           mv artifacts/fivenines-agent-linux-arm64/fivenines-agent-linux-arm64.tar.gz release/
+          mv artifacts/fivenines-agent-alpine-amd64/fivenines-agent-alpine-amd64.tar.gz release/
+          mv artifacts/fivenines-agent-alpine-arm64/fivenines-agent-alpine-arm64.tar.gz release/
           ls -la release/
 
       - name: Extract version from tag
@@ -306,6 +455,8 @@ jobs:
           files: |
             release/fivenines-agent-linux-amd64.tar.gz
             release/fivenines-agent-linux-arm64.tar.gz
+            release/fivenines-agent-alpine-amd64.tar.gz
+            release/fivenines-agent-alpine-arm64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -327,12 +478,17 @@ jobs:
         run: |
           mkdir -p r2-upload/latest
 
-          # Copy release binaries
+          # Copy release binaries (glibc)
           cp artifacts/fivenines-agent-linux-amd64/fivenines-agent-linux-amd64.tar.gz r2-upload/latest/
           cp artifacts/fivenines-agent-linux-arm64/fivenines-agent-linux-arm64.tar.gz r2-upload/latest/
 
-          # Copy static files (service and boot script)
+          # Copy release binaries (Alpine/musl)
+          cp artifacts/fivenines-agent-alpine-amd64/fivenines-agent-alpine-amd64.tar.gz r2-upload/latest/
+          cp artifacts/fivenines-agent-alpine-arm64/fivenines-agent-alpine-arm64.tar.gz r2-upload/latest/
+
+          # Copy static files (service, OpenRC, and boot script)
           cp fivenines-agent.service r2-upload/latest/
+          cp fivenines-agent.openrc r2-upload/latest/
           cp fivenines_script.sh r2-upload/latest/
 
           # Copy install/update/uninstall scripts
@@ -374,5 +530,8 @@ jobs:
           echo "Files synced to R2:"
           echo "  - https://releases.fivenines.io/latest/fivenines-agent-linux-amd64.tar.gz"
           echo "  - https://releases.fivenines.io/latest/fivenines-agent-linux-arm64.tar.gz"
+          echo "  - https://releases.fivenines.io/latest/fivenines-agent-alpine-amd64.tar.gz"
+          echo "  - https://releases.fivenines.io/latest/fivenines-agent-alpine-arm64.tar.gz"
           echo "  - https://releases.fivenines.io/latest/fivenines-agent.service"
+          echo "  - https://releases.fivenines.io/latest/fivenines-agent.openrc"
           echo "  - https://releases.fivenines.io/latest/fivenines_script.sh"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,44 @@
+FROM python:3.11-alpine3.21
+
+# Alpine uses musl libc - no glibc compatibility issues
+# No need to build libtirpc/libcrypt from source (musl provides these)
+
+# Install system packages for building libvirt-python and PyInstaller
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    make \
+    pkgconfig \
+    wget \
+    musl-dev \
+    linux-headers \
+    libxml2-dev \
+    gnutls-dev \
+    libvirt-dev \
+    libffi-dev \
+    openssl-dev \
+    zlib-dev \
+    binutils \
+    patchelf
+
+# Determine libvirt version and install matching libvirt-python
+RUN LIBVIRT_VERSION=$(pkg-config --modversion libvirt) && \
+    echo "System libvirt version: $LIBVIRT_VERSION" && \
+    pip install --no-cache-dir libvirt-python==$LIBVIRT_VERSION
+
+# Verify libvirt-python
+RUN python -c "import libvirt; print('libvirt-python version:', libvirt.getVersion())"
+
+# Comprehensive verification
+RUN echo "=== Alpine Build Environment Verification ===" && \
+    echo "Base: Alpine 3.21 (musl libc)" && \
+    echo "libc: $(ldd --version 2>&1 | head -n1 || echo musl)" && \
+    echo "Python version: $(python --version)" && \
+    echo "Python path: $(which python)" && \
+    echo "libvirt version: $(pkg-config --modversion libvirt)" && \
+    echo "libvirt libs: $(pkg-config --libs libvirt)" && \
+    python -c "import sysconfig; print('Python include path:', sysconfig.get_path('include'))"
+
+ENV TARGET_ARCH="amd64"
+WORKDIR /workspace
+CMD ["sh"]

--- a/Dockerfile.alpine-arm
+++ b/Dockerfile.alpine-arm
@@ -1,0 +1,44 @@
+FROM python:3.11-alpine3.21
+
+# Alpine uses musl libc - no glibc compatibility issues
+# No need to build libtirpc/libcrypt from source (musl provides these)
+
+# Install system packages for building libvirt-python and PyInstaller
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    make \
+    pkgconfig \
+    wget \
+    musl-dev \
+    linux-headers \
+    libxml2-dev \
+    gnutls-dev \
+    libvirt-dev \
+    libffi-dev \
+    openssl-dev \
+    zlib-dev \
+    binutils \
+    patchelf
+
+# Determine libvirt version and install matching libvirt-python
+RUN LIBVIRT_VERSION=$(pkg-config --modversion libvirt) && \
+    echo "System libvirt version: $LIBVIRT_VERSION" && \
+    pip install --no-cache-dir libvirt-python==$LIBVIRT_VERSION
+
+# Verify libvirt-python
+RUN python -c "import libvirt; print('libvirt-python version:', libvirt.getVersion())"
+
+# Comprehensive verification
+RUN echo "=== Alpine Build Environment Verification ===" && \
+    echo "Base: Alpine 3.21 (musl libc)" && \
+    echo "libc: $(ldd --version 2>&1 | head -n1 || echo musl)" && \
+    echo "Python version: $(python --version)" && \
+    echo "Python path: $(which python)" && \
+    echo "libvirt version: $(pkg-config --modversion libvirt)" && \
+    echo "libvirt libs: $(pkg-config --libs libvirt)" && \
+    python -c "import sysconfig; print('Python include path:', sysconfig.get_path('include'))"
+
+ENV TARGET_ARCH="arm64"
+WORKDIR /workspace
+CMD ["sh"]

--- a/fivenines-agent.openrc
+++ b/fivenines-agent.openrc
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+
+name="fivenines-agent"
+description="Five Nines monitoring agent"
+supervisor="supervise-daemon"
+
+command="/opt/fivenines/fivenines_agent"
+command_user="fivenines:fivenines"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+supervise_daemon_args="--env PYTHONUNBUFFERED=1 --respawn-delay 5 --respawn-max 0"
+
+output_log="/var/log/fivenines-agent.log"
+error_log="/var/log/fivenines-agent.log"
+
+depend() {
+    need net
+    after firewall
+}

--- a/fivenines-agent.openrc
+++ b/fivenines-agent.openrc
@@ -17,3 +17,9 @@ depend() {
     need net
     after firewall
 }
+
+start_pre() {
+    # Ensure log file exists and is writable by the service user
+    touch "$output_log"
+    chown fivenines:fivenines "$output_log"
+}

--- a/fivenines_setup.sh
+++ b/fivenines_setup.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # Fivenines Agent Setup Script
-# Works on both standard Linux systems (systemd) and UNRAID
+# Works on standard Linux systems (systemd), OpenRC (Alpine), and UNRAID
+#
+# Environment variables:
+#   FIVENINES_AGENT_URL - Custom download URL for the agent tarball (e.g., pre-release builds)
+#
+# Example with custom build:
+#   FIVENINES_AGENT_URL="https://github.com/Five-Nines-io/fivenines_agent/releases/download/feature-branch-abc1234/fivenines-agent-linux-amd64.tar.gz" bash fivenines_setup.sh YOUR_TOKEN
 
 # Mirror URLs (R2 is IPv6-compatible, GitHub is fallback)
 R2_BASE_URL="https://releases.fivenines.io/latest"
@@ -283,7 +289,13 @@ TARBALL_PATH="/tmp/${TARBALL_NAME}"
 AGENT_DIR="${INSTALL_DIR}/${BINARY_NAME}"
 AGENT_EXECUTABLE="${AGENT_DIR}/${BINARY_NAME}"
 
-download_with_fallback "$TARBALL_NAME" "$TARBALL_PATH" "${GITHUB_RELEASES_URL}/${TARBALL_NAME}" || exit_with_contact "Failed to download agent"
+if [ -n "${FIVENINES_AGENT_URL:-}" ]; then
+  print_warning "Using custom agent URL: $FIVENINES_AGENT_URL"
+  wget --connect-timeout=10 -q "$FIVENINES_AGENT_URL" -O "$TARBALL_PATH" || exit_with_contact "Failed to download from custom URL"
+  print_success "Downloaded from custom URL"
+else
+  download_with_fallback "$TARBALL_NAME" "$TARBALL_PATH" "${GITHUB_RELEASES_URL}/${TARBALL_NAME}" || exit_with_contact "Failed to download agent"
+fi
 
 # Remove old installation if it exists
 if [ -d "$AGENT_DIR" ]; then

--- a/fivenines_setup.sh
+++ b/fivenines_setup.sh
@@ -50,14 +50,15 @@ function download_with_fallback() {
   print_warning "Downloading ${filename}..."
 
   # Try R2 first (IPv6 compatible)
-  if wget --connect-timeout=5 -q "$r2_url" -O "$output" 2>/dev/null; then
+  # Use -T (BusyBox-compatible) instead of --connect-timeout (GNU wget only)
+  if wget -T 5 -q "$r2_url" -O "$output" 2>/dev/null; then
     print_success "Downloaded from releases.fivenines.io"
     return 0
   fi
 
   # Fallback to GitHub
   print_warning "R2 mirror unavailable, trying GitHub..."
-  if wget --connect-timeout=5 -q "$github_url" -O "$output" 2>/dev/null; then
+  if wget -T 5 -q "$github_url" -O "$output" 2>/dev/null; then
     print_success "Downloaded from GitHub"
     return 0
   fi
@@ -198,8 +199,8 @@ if [ $# -eq 0 ] ; then
   exit 1
 fi
 
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then
+# Check if running as root (use `id -u` for BusyBox/ash compatibility)
+if [ "$(id -u)" -ne 0 ]; then
   exit_with_contact "This script must be run as root"
 fi
 
@@ -291,7 +292,7 @@ AGENT_EXECUTABLE="${AGENT_DIR}/${BINARY_NAME}"
 
 if [ -n "${FIVENINES_AGENT_URL:-}" ]; then
   print_warning "Using custom agent URL: $FIVENINES_AGENT_URL"
-  wget --connect-timeout=10 -q "$FIVENINES_AGENT_URL" -O "$TARBALL_PATH" || exit_with_contact "Failed to download from custom URL"
+  wget -T 10 -q "$FIVENINES_AGENT_URL" -O "$TARBALL_PATH" || exit_with_contact "Failed to download from custom URL"
   print_success "Downloaded from custom URL"
 else
   download_with_fallback "$TARBALL_NAME" "$TARBALL_PATH" "${GITHUB_RELEASES_URL}/${TARBALL_NAME}" || exit_with_contact "Failed to download agent"

--- a/fivenines_setup.sh
+++ b/fivenines_setup.sh
@@ -91,13 +91,13 @@ function detect_system() {
   fi
 
   # Check if OpenRC is available (Alpine Linux)
-  if command -v rc-service &> /dev/null && [ -d "/etc/init.d" ]; then
+  if command -v rc-service >/dev/null 2>&1 && [ -d "/etc/init.d" ]; then
     echo "openrc"
     return
   fi
 
   # Check if systemd is available
-  if command -v systemctl &> /dev/null && [ -d "/etc/systemd/system" ]; then
+  if command -v systemctl >/dev/null 2>&1 && [ -d "/etc/systemd/system" ]; then
     echo "systemd"
     return
   fi
@@ -209,7 +209,7 @@ SYSTEM_TYPE=$(detect_system)
 print_success "Detected system type: $SYSTEM_TYPE"
 
 # Check if SELinux is installed
-if command -v getenforce &> /dev/null; then
+if command -v getenforce >/dev/null 2>&1; then
   selinux_status=$(getenforce 2>/dev/null || echo "Disabled")
   print_success "SELinux status: $selinux_status"
   if [ "$selinux_status" == "Enforcing" ]; then
@@ -334,11 +334,8 @@ print_success "Agent installed successfully at $AGENT_DIR"
 
 # Test connectivity
 echo "Testing connectivity..."
-hosts=("asia.fivenines.io" "eu.fivenines.io" "us.fivenines.io" "api.fivenines.io")
-
-# Loop through each host and ping once
-for host in "${hosts[@]}"; do
-  if ping -c 1 -W 5 "$host" &> /dev/null; then
+for host in asia.fivenines.io eu.fivenines.io us.fivenines.io api.fivenines.io; do
+  if ping -c 1 -W 5 "$host" >/dev/null 2>&1; then
     print_success "Connected to $host"
   else
     exit_with_contact "Ping to $host failed or timed out. Check your network connection."

--- a/fivenines_setup_user.sh
+++ b/fivenines_setup_user.sh
@@ -96,7 +96,7 @@ function download_file() {
     local output="$2"
 
     if [ "$DOWNLOADER" = "wget" ]; then
-        wget -q --connect-timeout=10 "$url" -O "$output"
+        wget -q -T 10 "$url" -O "$output"
     else
         curl -sL --connect-timeout 10 "$url" -o "$output"
     fi

--- a/fivenines_uninstall.sh
+++ b/fivenines_uninstall.sh
@@ -2,9 +2,9 @@
 # This script is used to uninstall the fivenines agent
 
 function detect_system() {
-  if command -v rc-service &> /dev/null && [ -d "/etc/init.d" ]; then
+  if command -v rc-service >/dev/null 2>&1 && [ -d "/etc/init.d" ]; then
     echo "openrc"
-  elif command -v systemctl &> /dev/null && [ -d "/etc/systemd/system" ]; then
+  elif command -v systemctl >/dev/null 2>&1 && [ -d "/etc/systemd/system" ]; then
     echo "systemd"
   else
     echo "unknown"
@@ -15,7 +15,7 @@ SYSTEM_TYPE=$(detect_system)
 
 if [ "$SYSTEM_TYPE" == "openrc" ]; then
   # OpenRC: Stop the service
-  if rc-service fivenines-agent status &>/dev/null; then
+  if rc-service fivenines-agent status >/dev/null 2>&1; then
     echo "Stopping fivenines-agent service..."
     sudo rc-service fivenines-agent stop
   else

--- a/fivenines_uninstall.sh
+++ b/fivenines_uninstall.sh
@@ -1,34 +1,68 @@
 #!/bin/bash
 # This script is used to uninstall the fivenines agent
 
-# Stop the fivenines-agent service
-if systemctl is-active --quiet fivenines-agent.service; then
-  echo "Stopping fivenines-agent service..."
-  sudo systemctl stop fivenines-agent.service
+function detect_system() {
+  if command -v rc-service &> /dev/null && [ -d "/etc/init.d" ]; then
+    echo "openrc"
+  elif command -v systemctl &> /dev/null && [ -d "/etc/systemd/system" ]; then
+    echo "systemd"
+  else
+    echo "unknown"
+  fi
+}
+
+SYSTEM_TYPE=$(detect_system)
+
+if [ "$SYSTEM_TYPE" == "openrc" ]; then
+  # OpenRC: Stop the service
+  if rc-service fivenines-agent status &>/dev/null; then
+    echo "Stopping fivenines-agent service..."
+    sudo rc-service fivenines-agent stop
+  else
+    echo "fivenines-agent service is not running."
+  fi
+
+  # OpenRC: Remove from default runlevel
+  if rc-update show default | grep -q fivenines-agent; then
+    echo "Removing fivenines-agent from default runlevel..."
+    sudo rc-update del fivenines-agent default
+  fi
+
+  # OpenRC: Remove the init script
+  if [ -f /etc/init.d/fivenines-agent ]; then
+    echo "Removing fivenines-agent init script..."
+    sudo rm /etc/init.d/fivenines-agent
+  fi
 else
-  echo "fivenines-agent service is not running."
+  # systemd: Stop the service
+  if systemctl is-active --quiet fivenines-agent.service; then
+    echo "Stopping fivenines-agent service..."
+    sudo systemctl stop fivenines-agent.service
+  else
+    echo "fivenines-agent service is not running."
+  fi
+
+  # systemd: Disable the service
+  if systemctl is-enabled --quiet fivenines-agent.service; then
+    echo "Disabling fivenines-agent service..."
+    sudo systemctl disable fivenines-agent.service
+  else
+    echo "fivenines-agent service is not enabled."
+  fi
+
+  # systemd: Remove the service file
+  if [ -f /etc/systemd/system/fivenines-agent.service ]; then
+    echo "Removing fivenines-agent.service file..."
+    sudo rm /etc/systemd/system/fivenines-agent.service
+  fi
+
+  # systemd: Reload daemon
+  echo "Reloading systemd daemon..."
+  sudo systemctl daemon-reload
 fi
 
-# Disable the fivenines-agent service
-if systemctl is-enabled --quiet fivenines-agent.service; then
-  echo "Disabling fivenines-agent service..."
-  sudo systemctl disable fivenines-agent.service
-else
-  echo "fivenines-agent service is not enabled."
-fi
-
-# Remove the fivenines-agent service file
-if [ -f /etc/systemd/system/fivenines-agent.service ]; then
-  echo "Removing fivenines-agent.service file..."
-  sudo rm /etc/systemd/system/fivenines-agent.service
-fi
-
-# Reload systemd daemon
-echo "Reloading systemd daemon..."
-sudo systemctl daemon-reload
-
-# Uninstall fivenines_agent
-if su - fivenines -s /bin/bash -c 'pipx list | grep -q fivenines_agent'; then
+# Uninstall fivenines_agent (legacy pipx)
+if su - fivenines -s /bin/bash -c 'pipx list | grep -q fivenines_agent' 2>/dev/null; then
   echo "Uninstalling fivenines_agent..."
   sudo su - fivenines -s /bin/bash -c 'pipx uninstall fivenines_agent'
 else
@@ -46,7 +80,12 @@ fi
 # Remove the system user for the agent
 if id -u fivenines >/dev/null 2>&1; then
   echo "Removing system user fivenines..."
-  sudo userdel -r fivenines
+  if [ "$SYSTEM_TYPE" == "openrc" ]; then
+    sudo deluser --remove-home fivenines 2>/dev/null || sudo userdel -r fivenines 2>/dev/null || true
+    sudo delgroup fivenines 2>/dev/null || true
+  else
+    sudo userdel -r fivenines
+  fi
 else
   echo "System user fivenines does not exist."
 fi

--- a/fivenines_uninstall_user.sh
+++ b/fivenines_uninstall_user.sh
@@ -45,6 +45,7 @@ if [ -f "$INSTALL_DIR/stop.sh" ]; then
     "$INSTALL_DIR/stop.sh" 2>/dev/null || true
 fi
 pkill -f "fivenines-agent-linux" 2>/dev/null || true
+pkill -f "fivenines-agent-alpine" 2>/dev/null || true
 sleep 1
 print_success "Agent stopped"
 

--- a/fivenines_update.sh
+++ b/fivenines_update.sh
@@ -45,14 +45,14 @@ function download_with_fallback() {
   print_warning "Downloading ${filename}..."
 
   # Try R2 first (IPv6 compatible)
-  if wget --connect-timeout=5 -q "$r2_url" -O "$output" 2>/dev/null; then
+  if wget -T 5 -q "$r2_url" -O "$output" 2>/dev/null; then
     print_success "Downloaded from releases.fivenines.io"
     return 0
   fi
 
   # Fallback to GitHub
   print_warning "R2 mirror unavailable, trying GitHub..."
-  if wget --connect-timeout=5 -q "$github_url" -O "$output" 2>/dev/null; then
+  if wget -T 5 -q "$github_url" -O "$output" 2>/dev/null; then
     print_success "Downloaded from GitHub"
     return 0
   fi
@@ -149,7 +149,7 @@ AGENT_EXECUTABLE="${AGENT_DIR}/${BINARY_NAME}"
 
 if [ -n "${FIVENINES_AGENT_URL:-}" ]; then
     print_warning "Using custom agent URL: $FIVENINES_AGENT_URL"
-    wget --connect-timeout=10 -q "$FIVENINES_AGENT_URL" -O "$TARBALL_PATH" || exit_with_error "Failed to download from custom URL"
+    wget -T 10 -q "$FIVENINES_AGENT_URL" -O "$TARBALL_PATH" || exit_with_error "Failed to download from custom URL"
     print_success "Downloaded from custom URL"
 else
     download_with_fallback "$TARBALL_NAME" "$TARBALL_PATH" "${GITHUB_RELEASES_URL}/${TARBALL_NAME}" || exit_with_error "Failed to download agent"

--- a/fivenines_update.sh
+++ b/fivenines_update.sh
@@ -71,9 +71,9 @@ function detect_libc() {
 }
 
 function detect_system() {
-  if command -v rc-service &> /dev/null && [ -d "/etc/init.d" ]; then
+  if command -v rc-service >/dev/null 2>&1 && [ -d "/etc/init.d" ]; then
     echo "openrc"
-  elif command -v systemctl &> /dev/null && [ -d "/etc/systemd/system" ]; then
+  elif command -v systemctl >/dev/null 2>&1 && [ -d "/etc/systemd/system" ]; then
     echo "systemd"
   else
     echo "unknown"

--- a/fivenines_update.sh
+++ b/fivenines_update.sh
@@ -60,6 +60,26 @@ function download_with_fallback() {
   return 1
 }
 
+function detect_libc() {
+  if ldd --version 2>&1 | grep -qi musl; then
+    echo "musl"
+  elif [ -f "/lib/ld-musl-x86_64.so.1" ] || [ -f "/lib/ld-musl-aarch64.so.1" ]; then
+    echo "musl"
+  else
+    echo "glibc"
+  fi
+}
+
+function detect_system() {
+  if command -v rc-service &> /dev/null && [ -d "/etc/init.d" ]; then
+    echo "openrc"
+  elif command -v systemctl &> /dev/null && [ -d "/etc/systemd/system" ]; then
+    echo "systemd"
+  else
+    echo "unknown"
+  fi
+}
+
 # Print banner
 echo ""
 echo -e "${BLUE}===============================================================${NC}"
@@ -67,9 +87,16 @@ echo -e "${BLUE}  Fivenines Agent - System Update${NC}"
 echo -e "${BLUE}===============================================================${NC}"
 echo ""
 
+# Detect system type
+SYSTEM_TYPE=$(detect_system)
+
 # stop the agent
 print_warning "Stopping fivenines-agent service..."
-systemctl stop fivenines-agent.service
+if [ "$SYSTEM_TYPE" == "openrc" ]; then
+  rc-service fivenines-agent stop 2>/dev/null || true
+else
+  systemctl stop fivenines-agent.service
+fi
 print_success "Agent stopped"
 
 # if the home directory of user "fivenines" is /home/fivenines (which is the old location), migrate user's home directory to /opt/fivenines
@@ -97,12 +124,22 @@ fi
 CURRENT_ARCH=$(uname -m)
 INSTALL_DIR="/opt/fivenines"
 
-# Update the agent based on the architecture
+# Update the agent based on the architecture and libc
+LIBC_TYPE=$(detect_libc)
 print_success "Detected architecture: $CURRENT_ARCH"
-if [ "$CURRENT_ARCH" == "aarch64" ]; then
-        BINARY_NAME="fivenines-agent-linux-arm64"
+print_success "Detected libc: $LIBC_TYPE"
+if [ "$LIBC_TYPE" == "musl" ]; then
+        if [ "$CURRENT_ARCH" == "aarch64" ]; then
+                BINARY_NAME="fivenines-agent-alpine-arm64"
+        else
+                BINARY_NAME="fivenines-agent-alpine-amd64"
+        fi
 else
-        BINARY_NAME="fivenines-agent-linux-amd64"
+        if [ "$CURRENT_ARCH" == "aarch64" ]; then
+                BINARY_NAME="fivenines-agent-linux-arm64"
+        else
+                BINARY_NAME="fivenines-agent-linux-amd64"
+        fi
 fi
 
 TARBALL_NAME="${BINARY_NAME}.tar.gz"
@@ -166,13 +203,22 @@ fi
 print_success "Agent updated successfully at $AGENT_DIR"
 
 print_warning "Updating the service file..."
-download_with_fallback "fivenines-agent.service" "/etc/systemd/system/fivenines-agent.service" "${GITHUB_RAW_URL}/fivenines-agent.service"
-print_warning "Reloading the systemd daemon..."
-systemctl daemon-reload
+if [ "$SYSTEM_TYPE" == "openrc" ]; then
+  download_with_fallback "fivenines-agent.openrc" "/etc/init.d/fivenines-agent" "${GITHUB_RAW_URL}/fivenines-agent.openrc"
+  chmod 755 /etc/init.d/fivenines-agent
+else
+  download_with_fallback "fivenines-agent.service" "/etc/systemd/system/fivenines-agent.service" "${GITHUB_RAW_URL}/fivenines-agent.service"
+  print_warning "Reloading the systemd daemon..."
+  systemctl daemon-reload
+fi
 
 # Restart the agent
 print_warning "Restarting fivenines-agent service..."
-systemctl restart fivenines-agent.service
+if [ "$SYSTEM_TYPE" == "openrc" ]; then
+  rc-service fivenines-agent restart
+else
+  systemctl restart fivenines-agent.service
+fi
 print_success "Agent restarted"
 
 echo ""

--- a/fivenines_update_user.sh
+++ b/fivenines_update_user.sh
@@ -51,7 +51,7 @@ function download_file() {
     local output="$2"
 
     if command -v wget &> /dev/null; then
-        wget -q --connect-timeout=10 "$url" -O "$output"
+        wget -q -T 10 "$url" -O "$output"
     elif command -v curl &> /dev/null; then
         curl -sL --connect-timeout 10 "$url" -o "$output"
     else

--- a/fivenines_update_user.sh
+++ b/fivenines_update_user.sh
@@ -81,6 +81,16 @@ function download_with_fallback() {
     return 1
 }
 
+function detect_libc() {
+    if ldd --version 2>&1 | grep -qi musl; then
+        echo "musl"
+    elif [ -f "/lib/ld-musl-x86_64.so.1" ] || [ -f "/lib/ld-musl-aarch64.so.1" ]; then
+        echo "musl"
+    else
+        echo "glibc"
+    fi
+}
+
 echo ""
 echo -e "${BLUE}===============================================================${NC}"
 echo -e "${BLUE}  Fivenines Agent - User-Level Update${NC}"
@@ -104,21 +114,36 @@ fi
 
 print_success "Found existing installation"
 
-# Detect architecture
+# Detect architecture and libc
 ARCH=$(uname -m)
-case "$ARCH" in
-    x86_64|amd64)
-        BINARY_NAME="fivenines-agent-linux-amd64"
-        ;;
-    aarch64|arm64)
-        BINARY_NAME="fivenines-agent-linux-arm64"
-        ;;
-    *)
-        exit_with_error "Unsupported architecture: $ARCH"
-        ;;
-esac
+LIBC_TYPE=$(detect_libc)
+if [ "$LIBC_TYPE" = "musl" ]; then
+    case "$ARCH" in
+        x86_64|amd64)
+            BINARY_NAME="fivenines-agent-alpine-amd64"
+            ;;
+        aarch64|arm64)
+            BINARY_NAME="fivenines-agent-alpine-arm64"
+            ;;
+        *)
+            exit_with_error "Unsupported architecture: $ARCH"
+            ;;
+    esac
+else
+    case "$ARCH" in
+        x86_64|amd64)
+            BINARY_NAME="fivenines-agent-linux-amd64"
+            ;;
+        aarch64|arm64)
+            BINARY_NAME="fivenines-agent-linux-arm64"
+            ;;
+        *)
+            exit_with_error "Unsupported architecture: $ARCH"
+            ;;
+    esac
+fi
 
-print_success "Architecture: $ARCH"
+print_success "Architecture: $ARCH, libc: $LIBC_TYPE"
 
 # Stop the agent if running
 echo "Stopping agent..."

--- a/py2exe_alpine.sh
+++ b/py2exe_alpine.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env sh
+
+set -e  # Exit immediately on error
+
+echo "Detected architecture: $TARGET_ARCH"
+
+if [ "$TARGET_ARCH" = "arm64" ]; then
+    BINARY_NAME="fivenines-agent-alpine-arm64"
+else
+    BINARY_NAME="fivenines-agent-alpine-amd64"
+fi
+
+# Verify Python environment
+echo "=== Python Environment Check ==="
+echo "Python executable path: $(which python)"
+echo "Python version: $(python --version)"
+echo "Pip version: $(python -m pip --version)"
+
+# Verify libvirt
+echo "=== Libvirt Environment Check ==="
+echo "libvirt version: $(pkg-config --modversion libvirt 2>/dev/null || echo 'not found')"
+
+#
+# Create virtual environment and install dependencies
+#
+echo "=== Setting up virtual environment ==="
+python -m venv /workspace/venv --clear
+. /workspace/venv/bin/activate
+
+# Install build dependencies
+python -m pip install --upgrade pip setuptools wheel
+
+# Install libvirt-python matching system version
+echo "=== Installing libvirt-python ==="
+LIBVIRT_VERSION=$(pkg-config --modversion libvirt)
+python -m pip install libvirt-python==$LIBVIRT_VERSION
+
+# Test libvirt-python
+python -c "import libvirt; print('libvirt-python imported successfully, version:', libvirt.getVersion())"
+
+#
+# Install Poetry and project dependencies
+#
+echo "=== Installing Poetry and Dependencies ==="
+python -m pip install poetry==2.2.1
+
+# Configure Poetry for current venv
+poetry config virtualenvs.create false
+poetry cache clear --all . || true
+poetry config installer.max-workers 1
+
+poetry install --no-interaction
+
+# Remove systemd-watchdog (not needed on Alpine, may fail to import)
+pip uninstall -y systemd-watchdog 2>/dev/null || true
+
+# Final verification
+echo "=== Final Verification ==="
+python -c "import libvirt; print('libvirt version:', libvirt.getVersion())"
+
+# Export dependencies
+echo "Exporting dependencies to requirements.txt"
+poetry export --without-hashes -o requirements.txt
+
+#
+# Find Python shared library for PyInstaller
+#
+echo "=== Locating Python shared library ==="
+PYTHON_LIB=$(find /usr/local/lib -name "libpython3*.so*" -type f 2>/dev/null | head -1)
+if [ -z "$PYTHON_LIB" ]; then
+    # Alpine Python may have it elsewhere
+    PYTHON_LIB=$(python -c "import sysconfig; import os; lib_dir = sysconfig.get_config_var('LIBDIR'); name = sysconfig.get_config_var('LDLIBRARY'); print(os.path.join(lib_dir, name))" 2>/dev/null)
+fi
+
+echo "Python shared library: $PYTHON_LIB"
+
+#
+# Build the executable
+#
+echo "=== Building Executable ==="
+echo "Building the executable for $TARGET_ARCH (Alpine/musl)"
+mkdir -p build dist/linux
+
+# Verify libvirt module
+python -c "import libvirt; print('libvirt module path:', libvirt.__file__); print('libvirt version:', libvirt.getVersion())"
+
+# Build with PyInstaller - no need for libcrypt/libtirpc on musl
+PYINSTALLER_ARGS="--strip \
+    --optimize=2 \
+    --exclude-module tkinter \
+    --exclude-module unittest \
+    --exclude-module pdb \
+    --exclude-module doctest \
+    --exclude-module test \
+    --exclude-module distutils \
+    --exclude-module systemd_watchdog \
+    --noconfirm \
+    --onedir \
+    --name $BINARY_NAME \
+    --workpath ./build/tmp \
+    --distpath ./build \
+    --clean \
+    --hidden-import=libvirt \
+    --hidden-import=libvirtmod \
+    --hidden-import=proxmoxer.backends \
+    --hidden-import=proxmoxer.backends.https"
+
+if [ -n "$PYTHON_LIB" ] && [ -f "$PYTHON_LIB" ]; then
+    echo "Adding Python shared library: $PYTHON_LIB"
+    pyinstaller $PYINSTALLER_ARGS \
+        --add-binary "$PYTHON_LIB:." \
+        ./py2exe_entrypoint.py
+else
+    echo "No Python shared library found, building without it"
+    pyinstaller $PYINSTALLER_ARGS \
+        ./py2exe_entrypoint.py
+fi
+
+# Verify built binary
+echo "=== Binary Verification ==="
+echo "Directory contents:"
+ls -lh ./build/$BINARY_NAME/
+echo "Executable size: $(ls -lh ./build/$BINARY_NAME/$BINARY_NAME | awk '{print $5}')"
+echo "Total directory size: $(du -sh ./build/$BINARY_NAME | awk '{print $1}')"
+echo "Binary dependencies:"
+ldd ./build/$BINARY_NAME/$BINARY_NAME | head -10 || echo "ldd check failed"
+
+# Quick test
+echo "=== Testing Built Binary ==="
+./build/$BINARY_NAME/$BINARY_NAME --version || echo "Version check failed, but binary was built"
+
+# Move to final location
+mv ./build/$BINARY_NAME ./dist/linux/
+
+#
+# Clean up
+#
+echo "=== Cleanup ==="
+rm -rf ./build/tmp ./build/*.spec
+
+# Reset Poetry
+echo "Resetting environment"
+poetry config virtualenvs.create true
+deactivate
+
+echo "[OK] Alpine build completed successfully!"
+echo "Output directory: ./dist/linux/$BINARY_NAME/"
+echo "Executable: ./dist/linux/$BINARY_NAME/$BINARY_NAME"
+echo ""
+echo "The distribution is built with musl libc for Alpine Linux compatibility."

--- a/tests/test_agent_watchdog.py
+++ b/tests/test_agent_watchdog.py
@@ -1,0 +1,75 @@
+"""Tests for optional systemd-watchdog support in agent.run()."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock libvirt before any fivenines_agent imports that transitively need it
+sys.modules.setdefault("libvirt", MagicMock())
+
+import fivenines_agent.agent as agent_module  # noqa: E402
+from fivenines_agent.agent import Agent  # noqa: E402
+
+
+def make_agent():
+    """Create an Agent-like object without __init__ side effects."""
+    agent = Agent.__new__(Agent)
+    agent.config = {"enabled": True, "interval": 60}
+    agent.synchronizer = MagicMock()
+    agent.permissions = MagicMock()
+    agent.permissions.get_all.return_value = {}
+    agent.permissions.refresh_if_needed.return_value = False
+    agent.queue = MagicMock()
+    agent._telemetry = {}
+    return agent
+
+
+@patch("fivenines_agent.agent.dry_run", return_value=True)
+@patch("fivenines_agent.agent.get_user_context", return_value={})
+@patch("fivenines_agent.agent.collect_metrics")
+@patch("fivenines_agent.agent.packages_sync")
+def test_run_with_watchdog_none(mock_ps, mock_cm, mock_uc, mock_dr):
+    """When systemd_watchdog is None, agent.run() works without calling watchdog."""
+    agent = make_agent()
+    agent.config = {"enabled": True, "interval": 60}
+    agent.synchronizer.get_config.return_value = agent.config
+
+    original = agent_module.systemd_watchdog
+    try:
+        agent_module.systemd_watchdog = None
+        agent_module.exit_event.clear()
+        with pytest.raises(SystemExit) as exc_info:
+            agent.run()
+        assert exc_info.value.code == 0
+    finally:
+        agent_module.systemd_watchdog = original
+
+
+@patch("fivenines_agent.agent.dry_run", return_value=True)
+@patch("fivenines_agent.agent.get_user_context", return_value={})
+@patch("fivenines_agent.agent.collect_metrics")
+@patch("fivenines_agent.agent.packages_sync")
+def test_run_with_watchdog_present(mock_ps, mock_cm, mock_uc, mock_dr):
+    """When systemd_watchdog is available, agent.run() calls wd.ready() and wd.notify()."""
+    agent = make_agent()
+    agent.config = {"enabled": True, "interval": 60}
+    agent.synchronizer.get_config.return_value = agent.config
+
+    mock_wd_module = MagicMock()
+    mock_wd_instance = MagicMock()
+    mock_wd_module.watchdog.return_value = mock_wd_instance
+
+    original = agent_module.systemd_watchdog
+    try:
+        agent_module.systemd_watchdog = mock_wd_module
+        agent_module.exit_event.clear()
+        with pytest.raises(SystemExit) as exc_info:
+            agent.run()
+        assert exc_info.value.code == 0
+
+        mock_wd_module.watchdog.assert_called_once()
+        mock_wd_instance.ready.assert_called_once()
+        mock_wd_instance.notify.assert_called()
+    finally:
+        agent_module.systemd_watchdog = original


### PR DESCRIPTION
## Summary

- Add Alpine Linux support with musl libc detection and OpenRC service management
- Make `systemd-watchdog` optional so the agent runs on non-systemd distros (Alpine uses OpenRC)
- Add Alpine Docker build images and PyInstaller build script (`py2exe_alpine.sh`) for amd64 + arm64
- Update all shell scripts (setup, update, uninstall) with `detect_libc()` to select the correct binary (glibc vs musl) and manage OpenRC services alongside systemd
- Add Alpine build + release jobs to the CI pipeline
- Fix BusyBox compatibility issues (POSIX sh syntax, `wget -T` instead of `--connect-timeout`, `$(id -u)` instead of `$EUID`)
- Allow custom agent tarball URL via `FIVENINES_AGENT_URL` in `fivenines_setup.sh`

## Test plan

- [x] Verify CI builds pass for both Alpine amd64 and arm64
- [x] Install agent on Alpine Linux (musl) and confirm correct binary is downloaded
- [x] Install agent on Debian/Ubuntu (glibc) and confirm no regression
- [x] Verify OpenRC service starts, stops, and restarts correctly on Alpine
- [x] Verify systemd service still works on glibc distros
- [x] Run `make test` and confirm all tests pass (including new watchdog tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)