### PR TITLE
Feature: CentOS/RHEL test matrix expansion (Rocky 8 + Rocky 10)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -435,6 +435,10 @@ jobs:
             binary: linux-amd64
             runner: ubuntu-latest
             skip_ldd: "0"
+          - distro: rockylinux:8
+            binary: linux-amd64
+            runner: ubuntu-latest
+            skip_ldd: "0"
           - distro: ubuntu:20.04
             binary: linux-amd64
             runner: ubuntu-latest
@@ -455,6 +459,12 @@ jobs:
             binary: linux-amd64
             runner: ubuntu-latest
             skip_ldd: "0"
+          # TODO: Remove allow_failure when rockylinux:10 image is GA and tests pass
+          - distro: rockylinux:10
+            binary: linux-amd64
+            runner: ubuntu-latest
+            skip_ldd: "0"
+            allow_failure: "1"
           - distro: fedora:latest
             binary: linux-amd64
             runner: ubuntu-latest
@@ -512,6 +522,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
       - name: Run distro tests
+        id: distro-test
+        continue-on-error: ${{ matrix.allow_failure == '1' }}
         run: |
           mkdir -p ${{ github.workspace }}/test-output
           docker run --rm \
@@ -535,7 +547,7 @@ jobs:
           fi
 
       - name: Upload test logs on failure
-        if: failure()
+        if: steps.distro-test.outcome == 'failure'
         uses: actions/upload-artifact@v5
         with:
           name: test-logs-${{ matrix.binary }}-${{ strategy.job-index }}

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,7 +2,7 @@
 
 ## P3: Docker image caching for CI resilience
 
-Mirror the 13 distro base images used in `test-distro-matrix` to ghcr.io or use
+Mirror the 14 distro base images used in `test-distro-matrix` to ghcr.io or use
 a Docker pull-through cache. Currently, all distro tests pull from Docker Hub
 directly. A Docker Hub outage or rate-limit event would block the entire CI
 pipeline.
@@ -21,3 +21,14 @@ flags) before users do.
 - **Effort:** S (human) / S (CC)
 - **Depends on:** #30 (distro regression testing) shipping first
 - **Files:** `.github/workflows/build-release.yml` (add `schedule:` trigger)
+
+## P2: Promote Rocky 10 to blocking
+
+The `rockylinux:10` test matrix entry runs with `allow_failure: "1"` because the
+Docker image does not exist yet. When Rocky Linux 10 GA ships and the Docker image
+is available on Docker Hub, remove `allow_failure` from the matrix entry so that
+RHEL 10 generation regressions block releases.
+
+- **Effort:** S (human) / S (CC)
+- **Depends on:** Rocky Linux 10 GA release
+- **Files:** `.github/workflows/build-release.yml` (remove `allow_failure: "1"` from rockylinux:10 entry)


### PR DESCRIPTION
## Summary
- Add `rockylinux:8` (amd64) to CI distro test matrix, filling the RHEL 8 / glibc 2.28 coverage gap between centos:7 (2.17) and rockylinux:9 (2.34)
- Add `rockylinux:10` (amd64) as a forward-looking gated entry (`continue-on-error`) that auto-activates when the Docker image ships
- Fix test log upload condition to use step outcome (`steps.distro-test.outcome == 'failure'`) instead of job-level `failure()`, so logs are captured even for allowed-failure entries
- Update TODOS.md with Rocky 10 promotion TODO and corrected image count

## RHEL-Family Coverage After This PR

| RHEL Gen | glibc | Image | Arch | Status |
|----------|-------|-------|------|--------|
| 7 | 2.17 | centos:7 | amd64 | Existing |
| 8 | 2.28 | rockylinux:8 | amd64 | **New** |
| 9 | 2.34 | rockylinux:9 | amd64 + arm64 | Existing |
| 10 | 2.39+ | rockylinux:10 | amd64 | **New (gated)** |

## Test plan
- [ ] CI passes with Rocky 8 running all 10 distro tests successfully
- [ ] Rocky 10 entry either passes (if image available) or fails gracefully without blocking CI
- [ ] Existing matrix entries unaffected (no behavioral change from `continue-on-error` addition)
- [ ] Test logs are uploaded on failure for both new and existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)