### PR TITLE
Fix: Add 5s timeout to nginx status page request

### DIFF
--- a/fivenines_agent/nginx.py
+++ b/fivenines_agent/nginx.py
@@ -24,7 +24,7 @@ from fivenines_agent.debug import debug, log
 @debug('nginx_metrics')
 def nginx_metrics(status_page_url='http://127.0.0.1:8080/nginx_status'):
     try:
-      response = requests.get(status_page_url)
+      response = requests.get(status_page_url, timeout=5)
       if response.status_code != 200:
         return None
 


### PR DESCRIPTION
## Summary
- Adds a 5-second timeout to the `requests.get()` call in the nginx collector
- Prevents the agent from hanging indefinitely when the nginx status page is unreachable

## Test plan
- [x] Existing collector tests pass