### PR TITLE
Feature: systemd unit collector with health and inventory delta-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,10 +98,11 @@ Each metric collector is a separate module that exports functions to collect spe
 
 - **Core metrics** (always enabled): `cpu.py`, `memory.py`, `load_average.py`, `io.py`, `network.py`, `partitions.py`, `files.py`, `ports.py`, `processes.py`, `temperatures.py`, `fans.py`
 - **Storage**: `smart_storage.py` (requires sudo smartctl), `raid_storage.py` (requires sudo mdadm), `zfs.py`
-- **Services**: `docker.py`, `qemu.py`, `proxmox.py`, `caddy.py`, `nginx.py`, `postgresql.py`, `redis.py`
+- **Services**: `docker.py`, `qemu.py`, `proxmox.py`, `caddy.py`, `nginx.py`, `postgresql.py`, `redis.py`, `systemd.py` (per-unit health + inventory delta-sync, requires systemctl/journalctl)
 - **Security**: `fail2ban.py` (requires sudo fail2ban-client)
 - **Network/connectivity**: `ip.py` (public IPv4/IPv6 via ip.fivenines.io with 60s cache), `ping.py` (TCP latency), `snmp.py` (SNMP device polling via net-snmp CLI tools)
 - **Security scanning**: `packages.py` (installed packages via dpkg/rpm/apk/pacman with hash-based delta sync)
+- **Kernel surfaces**: `cgroup.py` (v1/v2 hierarchy detection + safe per-unit metric reads, used by `systemd.py`)
 
 Collectors use the `@debug` decorator from `debug.py` to log execution time and results.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The agent works without sudo, but these features will be unavailable (this is al
 | ZFS pools | ZFS delegation or permissions |
 | NVIDIA GPU metrics | NVIDIA driver + pynvml library |
 | SNMP device polling | `net-snmp` tools (`snmpget`, `snmpbulkwalk`) |
+| systemd unit metrics | `systemd` init system (`systemctl`, `journalctl`) |
+| Per-unit cgroup metrics | cgroup v1 or v2 mounted at `/sys/fs/cgroup` |
 
 ### Capabilities by Permission Level
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -32,3 +32,42 @@ RHEL 10 generation regressions block releases.
 - **Effort:** S (human) / S (CC)
 - **Depends on:** Rocky Linux 10 GA release
 - **Files:** `.github/workflows/build-release.yml` (remove `allow_failure: "1"` from rockylinux:10 entry)
+
+## P3: User-mode systemd units (systemctl --user)
+
+Extend the systemd collector to optionally include user-mode systemd units
+(`systemctl --user list-units`). Deferred from the initial systemd module ship
+because user-mode systemd is rare on monitored fleets (mostly servers, not
+developer desktops). Surface only if a customer asks for per-user service
+visibility.
+
+- **Effort:** M (human) / S (CC)
+- **Depends on:** systemd module shipping first
+- **Files:** `fivenines_agent/systemd.py` (add per-user invocation loop), `fivenines_agent/permissions.py` (probe), tests
+
+## P3: Event-driven D-Bus subscription for systemd state transitions
+
+The 10x version of systemd monitoring: subscribe to `org.freedesktop.systemd1`
+D-Bus signals and push state transitions in real-time, eliminating polling lag
+and dropping inventory cost to zero between changes. Rejected for the initial
+ship because `pystemd` / `dbus-python` add native build deps that conflict with
+the PyInstaller bundling story (CentOS 7+ binary target). Worth revisiting if
+the binary build constraint changes (e.g., dropping CentOS 7 support, or moving
+to a different bundler).
+
+- **Effort:** L (human) / M (CC)
+- **Depends on:** binary build constraints relaxing OR pystemd alternative emerging
+- **Files:** new `fivenines_agent/systemd_events.py`, `pyproject.toml`, `py2exe.sh`
+
+## P3: OOM detection journal-parse fallback for cgroup v1
+
+The systemd module ships OOM kill detection via cgroup v2 `memory.events`.
+On cgroup v1 and hybrid hosts, OOM count is reported as null. If backend
+alerting needs v1 OOM coverage, add a journal-parse fallback that scans
+`journalctl -k` for "Killed process" entries and correlates by PID/unit.
+Avoided in initial ship because journal-parse is fragile and adds ongoing
+subprocess cost; deferred until a concrete backend requirement appears.
+
+- **Effort:** M (human) / S (CC)
+- **Depends on:** backend signal that v1 OOM coverage matters
+- **Files:** `fivenines_agent/systemd.py` (add fallback path), tests, fixtures

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -11,7 +11,6 @@ from threading import Event
 import psutil
 from dotenv import load_dotenv
 
-
 try:
     import systemd_watchdog
 except ImportError:
@@ -30,7 +29,6 @@ from fivenines_agent.ping import tcp_ping
 from fivenines_agent.synchronization_queue import SynchronizationQueue
 from fivenines_agent.synchronizer import Synchronizer
 from fivenines_agent.systemd import force_inventory_resend, systemd_inventory_sync
-
 
 CONFIG_DIR = config_dir()
 load_dotenv(dotenv_path=env_file())
@@ -149,13 +147,15 @@ class Agent:
     def _collect_metrics(self, data):
         # Core metrics (always enabled)
         data["load_average"] = self._collect("load_average", load_average)
-        data["file_handles_used"] = self._collect("file_handles_used", file_handles_used)
-        data["file_handles_limit"] = self._collect("file_handles_limit", file_handles_limit)
+        data["file_handles_used"] = self._collect(
+            "file_handles_used", file_handles_used
+        )
+        data["file_handles_limit"] = self._collect(
+            "file_handles_limit", file_handles_limit
+        )
 
         # Conditional metrics via registry, gated by capability where available
-        collect_metrics(
-            self.config, data, self._telemetry, self.permissions.get_all()
-        )
+        collect_metrics(self.config, data, self._telemetry, self.permissions.get_all())
 
         # Special-case collectors (unique dispatch patterns)
         if self.config.get("ping"):
@@ -182,6 +182,13 @@ class Agent:
         )
 
     def _systemd_inventory_sync_with_telemetry(self):
+        # Skip when the host is not systemd-managed. Mirrors the capability
+        # gate the metrics registry already applies via _is_capability_gated.
+        # Without this, containers where systemctl exists but the host wasn't
+        # booted by systemd would pay subprocess cost on every tick only to
+        # fail at list-units.
+        if not self.permissions.get("systemd"):
+            return
         # Consume the SIGHUP-triggered force flag once per tick. The reset
         # has to happen before _collect() in case sync raises - we still
         # want the next tick to fall back to hash-equality comparison.

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -11,6 +11,7 @@ from threading import Event
 import psutil
 from dotenv import load_dotenv
 
+
 try:
     import systemd_watchdog
 except ImportError:
@@ -28,6 +29,7 @@ from fivenines_agent.permissions import get_permissions, print_capabilities_bann
 from fivenines_agent.ping import tcp_ping
 from fivenines_agent.synchronization_queue import SynchronizationQueue
 from fivenines_agent.synchronizer import Synchronizer
+from fivenines_agent.systemd import force_inventory_resend, systemd_inventory_sync
 
 
 CONFIG_DIR = config_dir()
@@ -80,6 +82,10 @@ class Agent:
         self.synchronizer = Synchronizer(self.token, self.queue, self.static_data)
         self.synchronizer.start()
 
+        # Set to True after SIGHUP so the next systemd_inventory_sync resends
+        # the full snapshot regardless of hash equality.
+        self._systemd_force_resend = False
+
     def _load_file(self, filename):
         try:
             path = os.path.join(CONFIG_DIR, filename)
@@ -118,6 +124,7 @@ class Agent:
                 self._collect_metrics(data)
 
                 self._packages_sync_with_telemetry()
+                self._systemd_inventory_sync_with_telemetry()
                 data["_telemetry"] = self._telemetry
 
                 # Running time and enqueue
@@ -202,12 +209,44 @@ class Agent:
             entry["errors"] = errors
         self._telemetry["packages_sync"] = entry
 
+    def _systemd_inventory_sync_with_telemetry(self):
+        ps_start = time.monotonic()
+        start_log_capture()
+        force = self._systemd_force_resend
+        self._systemd_force_resend = False
+        try:
+            systemd_inventory_sync(
+                self.config,
+                self.synchronizer.send_systemd_inventory,
+                force_resend=force,
+            )
+        except Exception as e:
+            errors = stop_log_capture()
+            errors.append(str(e))
+            duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
+            self._telemetry["systemd_inventory_sync"] = {
+                "duration_ms": duration_ms,
+                "errors": errors,
+            }
+            log(f"Error in systemd_inventory_sync: {e}", "error")
+            return
+        errors = stop_log_capture()
+        duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
+        entry = {"duration_ms": duration_ms}
+        if errors:
+            entry["errors"] = errors
+        self._telemetry["systemd_inventory_sync"] = entry
+
     def _handle_permission_refresh(self):
         if refresh_permissions_event.is_set():
             refresh_permissions_event.clear()
             self.permissions.force_refresh()
             self.static_data["capabilities"] = self.permissions.get_all()
             print_capabilities_banner()
+            # Permission refresh = orient agent. Reset systemd inventory hash so
+            # the next sync resends a fresh snapshot even if nothing changed.
+            force_inventory_resend()
+            self._systemd_force_resend = True
         elif self.permissions.refresh_if_needed():
             self.static_data["capabilities"] = self.permissions.get_all()
 

--- a/fivenines_agent/cgroup.py
+++ b/fivenines_agent/cgroup.py
@@ -1,0 +1,223 @@
+"""
+Cgroup helper for fivenines agent.
+
+Resolves cgroup paths for systemd units across cgroup v1 and v2 hierarchies,
+and provides safe per-unit metric reads. EACCES on cgroup files is treated as
+the expected capability gap (silent None) rather than an error to log.
+
+Path layout:
+  v2 (unified):  /sys/fs/cgroup/system.slice/<unit>/<file>
+  v1 (per-ctrl): /sys/fs/cgroup/<controller>/system.slice/<unit>/<file>
+
+Hybrid systems (v1 + v2 unified at /sys/fs/cgroup/unified) are detected as v1
+because per-unit memory/cpu accounting still lives in the v1 hierarchy.
+"""
+
+import os
+
+from fivenines_agent.debug import log
+
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+# Module-level cache - cleared by reset_cache() in tests
+_cached_hierarchy = None
+_cached_hierarchy_set = False
+
+
+def reset_cache():
+    """Reset the cached hierarchy detection. Used in tests."""
+    global _cached_hierarchy, _cached_hierarchy_set
+    _cached_hierarchy = None
+    _cached_hierarchy_set = False
+
+
+def detect_hierarchy():
+    """Detect cgroup hierarchy.
+
+    Returns:
+        "v2" if cgroup v2 unified hierarchy is mounted at /sys/fs/cgroup
+        "v1" if v1 per-controller hierarchy or hybrid mode
+        None if no cgroup hierarchy found
+    """
+    global _cached_hierarchy, _cached_hierarchy_set
+    if _cached_hierarchy_set:
+        return _cached_hierarchy
+
+    if os.path.exists(os.path.join(CGROUP_ROOT, "cgroup.controllers")):
+        _cached_hierarchy = "v2"
+    elif os.path.isdir(os.path.join(CGROUP_ROOT, "memory")):
+        _cached_hierarchy = "v1"
+    else:
+        _cached_hierarchy = None
+
+    _cached_hierarchy_set = True
+    return _cached_hierarchy
+
+
+def _validate_unit_name(unit_name):
+    """Reject unit names that could escape the cgroup root.
+
+    systemd unit names are kernel-validated, but defense in depth costs nothing.
+    """
+    if "/" in unit_name or "\x00" in unit_name:
+        raise ValueError(f"invalid unit name: {unit_name!r}")
+
+
+def unit_path(unit_name, hierarchy, controller=None):
+    """Build the cgroup directory path for a systemd unit.
+
+    Args:
+        unit_name: full unit name (e.g. "nginx.service")
+        hierarchy: "v1" or "v2"
+        controller: required for v1 (e.g. "memory", "cpuacct")
+
+    Returns:
+        Absolute filesystem path string. The caller checks if the path exists.
+
+    Raises:
+        ValueError: if unit_name contains path-traversal characters.
+    """
+    _validate_unit_name(unit_name)
+
+    if hierarchy == "v2":
+        return os.path.join(CGROUP_ROOT, "system.slice", unit_name)
+    if hierarchy == "v1":
+        if not controller:
+            raise ValueError("controller is required for cgroup v1 path")
+        return os.path.join(CGROUP_ROOT, controller, "system.slice", unit_name)
+    raise ValueError(f"unsupported hierarchy: {hierarchy!r}")
+
+
+def _read_text(path):
+    """Read a small cgroup text file safely.
+
+    Returns the stripped text on success, None on missing file or denied access.
+    Logs unexpected errors at debug level so capability-gap noise stays quiet.
+    """
+    try:
+        with open(path, "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        # EACCES on cgroup files is the expected state when the agent user
+        # lacks the right group memberships. Silent on purpose.
+        return None
+    except OSError as e:
+        log(f"cgroup read error for {path}: {e}", "debug")
+        return None
+
+
+def _parse_int(text):
+    """Parse a single integer from cgroup text. Returns None on failure or 'max'."""
+    if text is None or text == "max":
+        return None
+    try:
+        return int(text)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_kv_field(text, key):
+    """Extract a numeric value from key=value cgroup files (e.g. cpu.stat, memory.events).
+
+    Format example (cpu.stat):
+        usage_usec 12345
+        user_usec 11111
+
+    Returns int value or None if key absent or unparseable.
+    """
+    if text is None:
+        return None
+    for line in text.splitlines():
+        parts = line.strip().split()
+        if len(parts) == 2 and parts[0] == key:
+            try:
+                return int(parts[1])
+            except (ValueError, TypeError):
+                return None
+    return None
+
+
+def read_memory_current(unit_name, hierarchy):
+    """Current memory usage for a unit in bytes. None if unavailable."""
+    if hierarchy == "v2":
+        path = os.path.join(unit_path(unit_name, "v2"), "memory.current")
+        return _parse_int(_read_text(path))
+    if hierarchy == "v1":
+        path = os.path.join(
+            unit_path(unit_name, "v1", controller="memory"),
+            "memory.usage_in_bytes",
+        )
+        return _parse_int(_read_text(path))
+    return None
+
+
+def read_cpu_usec(unit_name, hierarchy):
+    """Cumulative CPU usage for a unit in microseconds. None if unavailable."""
+    if hierarchy == "v2":
+        path = os.path.join(unit_path(unit_name, "v2"), "cpu.stat")
+        return _parse_kv_field(_read_text(path), "usage_usec")
+    if hierarchy == "v1":
+        # cpuacct.usage is in nanoseconds; convert to microseconds
+        path = os.path.join(
+            unit_path(unit_name, "v1", controller="cpuacct"),
+            "cpuacct.usage",
+        )
+        ns = _parse_int(_read_text(path))
+        if ns is None:
+            return None
+        return ns // 1000
+    return None
+
+
+def read_oom_kill_count(unit_name, hierarchy):
+    """Cumulative OOM kill count for a unit (cgroup v2 only).
+
+    cgroup v1 has no equivalent surface; returns None. Hybrid mode is treated
+    as v1.
+    """
+    if hierarchy != "v2":
+        return None
+    path = os.path.join(unit_path(unit_name, "v2"), "memory.events")
+    return _parse_kv_field(_read_text(path), "oom_kill")
+
+
+def read_inception_id(unit_name, hierarchy):
+    """Inode of the unit's cgroup directory.
+
+    Used jointly with NRestarts to detect counter resets when a unit restarts
+    and its cgroup is recreated. Returns None if the directory does not exist.
+    """
+    if hierarchy == "v2":
+        path = unit_path(unit_name, "v2")
+    elif hierarchy == "v1":
+        path = unit_path(unit_name, "v1", controller="memory")
+    else:
+        return None
+    try:
+        return os.stat(path).st_ino
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        return None
+    except OSError as e:
+        log(f"cgroup stat error for {path}: {e}", "debug")
+        return None
+
+
+def read_unit_resources(unit_name, hierarchy):
+    """Read all per-unit cgroup metrics in one call.
+
+    Returns dict with keys: memory_current, cpu_usec, oom_kill_count,
+    inception_id. Each value is None if the underlying surface is unavailable.
+    Returns empty dict if hierarchy is None.
+    """
+    if hierarchy not in ("v1", "v2"):
+        return {}
+    return {
+        "memory_current": read_memory_current(unit_name, hierarchy),
+        "cpu_usec": read_cpu_usec(unit_name, hierarchy),
+        "oom_kill_count": read_oom_kill_count(unit_name, hierarchy),
+        "inception_id": read_inception_id(unit_name, hierarchy),
+    }

--- a/fivenines_agent/cgroup.py
+++ b/fivenines_agent/cgroup.py
@@ -22,13 +22,40 @@ CGROUP_ROOT = "/sys/fs/cgroup"
 # Module-level cache - cleared by reset_cache() in tests
 _cached_hierarchy = None
 _cached_hierarchy_set = False
+_cached_v1_cpu_controller = None
+_cached_v1_cpu_controller_set = False
 
 
 def reset_cache():
     """Reset the cached hierarchy detection. Used in tests."""
     global _cached_hierarchy, _cached_hierarchy_set
+    global _cached_v1_cpu_controller, _cached_v1_cpu_controller_set
     _cached_hierarchy = None
     _cached_hierarchy_set = False
+    _cached_v1_cpu_controller = None
+    _cached_v1_cpu_controller_set = False
+
+
+def _v1_cpu_controller():
+    """Detect the v1 controller mount that exposes cpuacct.usage.
+
+    Older kernels mount cpuacct as its own controller at
+    /sys/fs/cgroup/cpuacct/. CentOS 7 / RHEL 7 (and most modern v1 systems)
+    mount it combined with cpu at /sys/fs/cgroup/cpu,cpuacct/. Detect once
+    at first call and cache the result.
+
+    Returns the controller name to pass to unit_path, or None if neither
+    mount exists.
+    """
+    global _cached_v1_cpu_controller, _cached_v1_cpu_controller_set
+    if _cached_v1_cpu_controller_set:
+        return _cached_v1_cpu_controller
+    for candidate in ("cpuacct", "cpu,cpuacct"):
+        if os.path.isdir(os.path.join(CGROUP_ROOT, candidate)):
+            _cached_v1_cpu_controller = candidate
+            break
+    _cached_v1_cpu_controller_set = True
+    return _cached_v1_cpu_controller
 
 
 def detect_hierarchy():
@@ -159,9 +186,12 @@ def read_cpu_usec(unit_name, hierarchy):
         path = os.path.join(unit_path(unit_name, "v2"), "cpu.stat")
         return _parse_kv_field(_read_text(path), "usage_usec")
     if hierarchy == "v1":
+        controller = _v1_cpu_controller()
+        if controller is None:
+            return None
         # cpuacct.usage is in nanoseconds; convert to microseconds
         path = os.path.join(
-            unit_path(unit_name, "v1", controller="cpuacct"),
+            unit_path(unit_name, "v1", controller=controller),
             "cpuacct.usage",
         )
         ns = _parse_int(_read_text(path))

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -25,6 +25,7 @@ from fivenines_agent.smart_storage import (
     smart_storage_health,
     smart_storage_identification,
 )
+from fivenines_agent.systemd import systemd_metrics
 from fivenines_agent.temperatures import temperatures
 
 
@@ -80,6 +81,7 @@ COLLECTORS = [
     ("caddy", [("caddy", caddy_metrics, True)]),
     ("postgresql", [("postgresql", postgresql_metrics, True)]),
     ("proxmox", [("proxmox", proxmox_metrics, True)]),
+    ("systemd", [("systemd", systemd_metrics, True)]),
 ]
 
 

--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -69,6 +69,10 @@ class PermissionProbe:
             "packages": self._can_list_packages(),
             # SNMP polling - needs net-snmp CLI tools
             "snmp": self._has_snmpget(),
+            # systemd unit collection
+            "systemd": self._can_probe_systemd(),
+            # cgroup hierarchy: "v1", "v2", or None
+            "cgroup": self._detect_cgroup_hierarchy(),
         }
 
         # Log any capability changes (only after first probe)
@@ -369,6 +373,52 @@ class PermissionProbe:
         log("_can_list_packages: no supported package manager found", "debug")
         return False
 
+    def _can_probe_systemd(self):
+        """Check if systemd is the active init system and systemctl is usable.
+
+        Returns True only when:
+          * /run/systemd/system exists (systemd booted this host)
+          * systemctl is in PATH and `systemctl --version` exits cleanly
+        Returns False on Alpine (OpenRC), bare containers without their own
+        systemd, and macOS dev environments.
+        """
+        if not os.path.isdir("/run/systemd/system"):
+            log("_can_probe_systemd: /run/systemd/system not present", "debug")
+            return False
+        if not shutil.which("systemctl"):
+            log("_can_probe_systemd: systemctl not in PATH", "debug")
+            return False
+        try:
+            result = subprocess.run(
+                ["systemctl", "--version"],
+                capture_output=True,
+                timeout=5,
+                env=get_clean_env(),
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            log(f"_can_probe_systemd: systemctl --version failed: {e}", "debug")
+            return False
+        if result.returncode != 0:
+            log("_can_probe_systemd: systemctl --version returned non-zero", "debug")
+            return False
+        log("_can_probe_systemd: -> AVAILABLE", "debug")
+        return True
+
+    def _detect_cgroup_hierarchy(self):
+        """Detect cgroup hierarchy version. Returns 'v1', 'v2', or None.
+
+        Reads /sys/fs/cgroup directly so this works whether or not systemd is
+        installed (some hosts run cgroups without systemd).
+        """
+        if os.path.exists("/sys/fs/cgroup/cgroup.controllers"):
+            log("_detect_cgroup_hierarchy: -> v2", "debug")
+            return "v2"
+        if os.path.isdir("/sys/fs/cgroup/memory"):
+            log("_detect_cgroup_hierarchy: -> v1", "debug")
+            return "v1"
+        log("_detect_cgroup_hierarchy: no cgroup hierarchy found", "debug")
+        return None
+
     def get(self, capability, default=False):
         """Get a specific capability status."""
         return self.capabilities.get(capability, default)
@@ -415,9 +465,9 @@ def print_capabilities_banner():
         "ports",
         "processes",
     ]
-    hardware = ["temperatures", "fans", "nvidia_gpu"]
+    hardware = ["temperatures", "fans", "nvidia_gpu", "cgroup"]
     storage = ["smart_storage", "raid_storage", "zfs"]
-    services = ["docker", "qemu", "proxmox"]
+    services = ["docker", "qemu", "proxmox", "systemd"]
     security = ["fail2ban", "packages"]
     networking = ["snmp"]
 
@@ -433,6 +483,10 @@ def print_capabilities_banner():
             status = caps.get(cap, False)
             icon = "[+]" if status else "[-]"
             name = cap.replace("_", " ").title()
+
+            # cgroup is tri-state: "v1", "v2", or None (not bool)
+            if cap == "cgroup" and status:
+                name = f"Cgroup {status}"
 
             # Add hints for unavailable features
             hint = ""
@@ -459,6 +513,10 @@ def print_capabilities_banner():
                     hint = " (no accessible sensors)"
                 elif cap == "snmp":
                     hint = " (requires: net-snmp)"
+                elif cap == "systemd":
+                    hint = " (requires: systemd init system)"
+                elif cap == "cgroup":
+                    hint = " (no /sys/fs/cgroup hierarchy found)"
 
             print(f"    {icon} {name}{hint}")
         print("")

--- a/fivenines_agent/synchronizer.py
+++ b/fivenines_agent/synchronizer.py
@@ -121,6 +121,10 @@ class Synchronizer(Thread):
         """Send packages data to /packages. Returns response or None."""
         return self._post("/packages", packages_data)
 
+    def send_systemd_inventory(self, inventory_data):
+        """Send systemd inventory snapshot to /systemd_inventory. Returns response or None."""
+        return self._post("/systemd_inventory", inventory_data)
+
     def get_conn(self):
         url = api_url()
         if not url.startswith("localhost"):

--- a/fivenines_agent/systemd.py
+++ b/fivenines_agent/systemd.py
@@ -763,10 +763,22 @@ def systemd_metrics(unit_types=DEFAULT_UNIT_TYPES, **_kwargs):
 
 
 def systemd_inventory_sync(config, send_fn, force_resend=False):
-    """Inventory snapshot push. Called from agent.py per tick (analogous to packages_sync)."""
+    """Inventory snapshot push. Called from agent.py per tick (analogous to packages_sync).
+
+    Reads unit_types from config["systemd"] so the inventory snapshot stays
+    consistent with the per-tick metrics scope and the module-level singleton
+    is not churned every tick when metrics + inventory disagree on which unit
+    types to enumerate.
+    """
     if not shutil.which("systemctl"):
         return
-    _get_collector().inventory_sync(config, send_fn, force_resend=force_resend)
+    systemd_config = config.get("systemd")
+    unit_types = DEFAULT_UNIT_TYPES
+    if isinstance(systemd_config, dict):
+        unit_types = systemd_config.get("unit_types", DEFAULT_UNIT_TYPES)
+    _get_collector(unit_types=unit_types).inventory_sync(
+        config, send_fn, force_resend=force_resend
+    )
 
 
 def force_inventory_resend():

--- a/fivenines_agent/systemd.py
+++ b/fivenines_agent/systemd.py
@@ -1,0 +1,779 @@
+"""
+systemd units collector for fivenines agent.
+
+Two surfaces:
+  * Per-tick health: systemctl list-units + bulk systemctl show, cgroup metrics,
+    failure drilldown (journal tail + reverse deps) for newly-failed units.
+  * Inventory snapshot: full unit properties hashed for delta-sync, sent only
+    when the hash changes. Forced resend by passing force_resend=True from the
+    agent loop on SIGHUP.
+
+Architecture:
+  sync_config["systemd"]
+       |
+       v
+  systemd_metrics()
+       |
+       +---> SystemdCollector.collect()
+                |
+                +---> _list_units (one subprocess)
+                +---> _show_bulk (one subprocess for ALL units)
+                +---> cgroup.read_unit_resources() per unit (no fork)
+                +---> _drilldown_failed_units (ThreadPoolExecutor max 10)
+                |         each thread runs journalctl + list-dependencies
+                +---> aggregate -> {"units": [...], "drilldowns": {...}}
+
+  sync_config["systemd"]["scan"]
+       |
+       v
+  systemd_inventory_sync(config, send_fn)
+       |
+       +---> _build_inventory (one subprocess: systemctl show all units)
+       +---> _canonical_inventory_hash
+       +---> compare to server hash + local hash
+       +---> send_fn(inventory) if changed (or forced)
+
+Subprocess discipline:
+  - All calls go through get_clean_env() per CLAUDE.md.
+  - Per-call timeout 5s, mirrors snmp.py.
+  - PermissionError on cgroup files is silent (capability gap is expected).
+"""
+
+import concurrent.futures
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+
+from fivenines_agent.cgroup import detect_hierarchy, read_unit_resources
+from fivenines_agent.debug import debug, log
+from fivenines_agent.env import dry_run
+from fivenines_agent.subprocess_utils import get_clean_env
+
+# Subprocess timeouts (seconds)
+SYSTEMCTL_TIMEOUT = 5
+JOURNALCTL_TIMEOUT = 5
+LIST_DEPS_TIMEOUT = 5
+
+# Drilldown parallelism cap
+MAX_DRILLDOWN_WORKERS = 10
+
+# Default unit types we collect
+DEFAULT_UNIT_TYPES = "service,timer,socket"
+
+# Number of journal lines to capture per failed unit
+JOURNAL_TAIL_LINES = 5
+
+# Failure signature LRU max size (per-host bound)
+FAILURE_SIG_MAX = 1024
+
+# Properties read for per-tick health
+HEALTH_PROPERTIES = (
+    "Id",
+    "LoadState",
+    "ActiveState",
+    "SubState",
+    "Result",
+    "NRestarts",
+    "ActiveEnterTimestamp",
+    "InactiveEnterTimestamp",
+    "UnitFileState",
+)
+
+# Properties read for inventory snapshot (in addition to HEALTH_PROPERTIES)
+INVENTORY_PROPERTIES = HEALTH_PROPERTIES + (
+    "FragmentPath",
+    "Restart",
+    "ExecStart",
+    "ExecStartPre",
+    "ExecStartPost",
+    "ExecStop",
+    "ExecStopPost",
+    "ExecReload",
+    "ExecCondition",
+    "After",
+    "Before",
+    "Wants",
+    "Requires",
+    "WantedBy",
+    "RequiredBy",
+    "DropInPaths",
+    "OnCalendar",
+)
+
+# Top-level properties stripped from inventory hash because they mutate per
+# restart and would flap the delta-sync.
+RUNTIME_FIELDS_TO_STRIP = frozenset(
+    (
+        "MainPID",
+        "ControlPID",
+        "ExecMainPID",
+        "ExecMainStartTimestamp",
+        "ExecMainStartTimestampMonotonic",
+        "ExecMainExitTimestamp",
+        "ExecMainExitTimestampMonotonic",
+        "ExecMainCode",
+        "ExecMainStatus",
+        "StatusText",
+        "StatusErrno",
+        "InvocationID",
+        "WatchdogTimestamp",
+        "WatchdogTimestampMonotonic",
+        "StateChangeTimestamp",
+        "StateChangeTimestampMonotonic",
+        "ActiveEnterTimestampMonotonic",
+        "InactiveEnterTimestampMonotonic",
+    )
+)
+
+# Properties that hold space-separated lists (sorted for canonical hash)
+LIST_VALUED_PROPERTIES = frozenset(
+    (
+        "After",
+        "Before",
+        "Wants",
+        "Requires",
+        "WantedBy",
+        "RequiredBy",
+        "DropInPaths",
+    )
+)
+
+# Reverse dependencies are gated on systemd >= 230 (CentOS 7 ships 219).
+MIN_SYSTEMD_VERSION_REVERSE_DEPS = 230
+
+# Static fields to keep from Exec*= structured records. Everything else
+# (start_time, pid, status, etc.) is runtime noise that flaps the hash.
+EXEC_PATH_RE = re.compile(r"path=([^\s;]+)")
+EXEC_ARGV_RE = re.compile(r"argv\[\]=(.*?)(?=\s*;\s|\s*\})")
+EXEC_IGNORE_RE = re.compile(r"ignore_errors=([^\s;]+)")
+
+
+def _extract_exec_record(record_str):
+    """Extract static fields (path, argv, ignore_errors) from one Exec= record.
+
+    Returns a dict with only the static keys; runtime fields are dropped.
+    Returns None if no path can be extracted (malformed record).
+    """
+    out = {}
+    m = EXEC_PATH_RE.search(record_str)
+    if not m:
+        return None
+    out["path"] = m.group(1)
+    m = EXEC_ARGV_RE.search(record_str)
+    if m:
+        out["argv"] = m.group(1).strip()
+    m = EXEC_IGNORE_RE.search(record_str)
+    if m:
+        out["ignore_errors"] = m.group(1)
+    return out
+
+
+def _parse_exec_property(value):
+    """Parse a multi-record Exec*= property value into static-field records.
+
+    Each record is wrapped in `{ ... }`; multiple records may appear.
+    Returns a list of dicts.
+    """
+    if not value:
+        return []
+    records = []
+    depth = 0
+    start = None
+    for i, ch in enumerate(value):
+        if ch == "{":
+            if depth == 0:
+                start = i + 1
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                rec = _extract_exec_record(value[start:i])
+                if rec:
+                    records.append(rec)
+                start = None
+    return records
+
+
+def _systemd_version():
+    """Detect systemd version (integer major). Returns None if unavailable."""
+    if not shutil.which("systemctl"):
+        return None
+    try:
+        result = subprocess.run(
+            ["systemctl", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SYSTEMCTL_TIMEOUT,
+            env=get_clean_env(),
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        log(f"systemctl --version failed: {e}", "debug")
+        return None
+    if result.returncode != 0:
+        return None
+    # First line: "systemd 252 (252.4-1ubuntu3.1)" or "systemd 219"
+    first = result.stdout.strip().splitlines()[0] if result.stdout else ""
+    parts = first.split()
+    if len(parts) >= 2 and parts[0] == "systemd":
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+    return None
+
+
+def _run_systemctl(args, timeout=SYSTEMCTL_TIMEOUT):
+    """Run systemctl with clean env. Returns (stdout, error_dict_or_None)."""
+    return _run_subprocess("systemctl", args, timeout)
+
+
+def _run_journalctl(args, timeout=JOURNALCTL_TIMEOUT):
+    """Run journalctl with clean env. Returns (stdout, error_dict_or_None)."""
+    return _run_subprocess("journalctl", args, timeout)
+
+
+def _run_subprocess(cmd, args, timeout):
+    """Generic subprocess wrapper used by both systemctl and journalctl.
+
+    Returns (stdout, error_dict_or_None) where error_dict has "type" and
+    "message" keys for telemetry consumers.
+    """
+    if not shutil.which(cmd):
+        return None, {"type": "missing", "message": f"{cmd} not in PATH"}
+    try:
+        result = subprocess.run(
+            [cmd] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=get_clean_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return None, {
+            "type": "timeout",
+            "message": f"{cmd} timed out after {timeout}s",
+        }
+    except OSError as e:
+        return None, {"type": "unknown", "message": str(e)}
+    if result.returncode != 0:
+        return None, {
+            "type": "cli_error",
+            "message": result.stderr.strip() or f"exit {result.returncode}",
+        }
+    return result.stdout, None
+
+
+def _parse_list_units(stdout):
+    """Parse `systemctl list-units --no-legend --plain` output.
+
+    Format per line: "UNIT LOAD ACTIVE SUB DESCRIPTION" with arbitrary
+    whitespace separators. Returns a list of unit name strings.
+    """
+    units = []
+    if not stdout:
+        return units
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 4)
+        if len(parts) < 4:
+            continue
+        unit = parts[0]
+        # Skip `not-found` placeholder rows where the unit doesn't actually exist
+        if parts[1] == "not-found":
+            continue
+        units.append(unit)
+    return units
+
+
+def _parse_show_bulk(stdout):
+    """Parse `systemctl show <unit1> <unit2> ...` output.
+
+    Format: KEY=VALUE blocks separated by blank lines, one block per unit.
+    Returns dict keyed by unit Id, values are property dicts.
+    """
+    units = {}
+    if not stdout:
+        return units
+    for block in stdout.split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        props = {}
+        for line in block.splitlines():
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            props[key] = value
+        unit_id = props.get("Id")
+        if unit_id:
+            units[unit_id] = props
+    return units
+
+
+def _parse_journalctl_failed(stdout):
+    """Parse journalctl --output=json output. Returns list of message strings."""
+    messages = []
+    if not stdout:
+        return messages
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        msg = entry.get("MESSAGE")
+        if isinstance(msg, list):
+            try:
+                msg = bytes(msg).decode("utf-8", errors="replace")
+            except (TypeError, ValueError):
+                msg = ""
+        if msg:
+            messages.append(msg)
+    return messages
+
+
+def _parse_reverse_deps(stdout):
+    """Parse `systemctl list-dependencies --reverse` indented tree output.
+
+    First line is the unit being queried; subsequent indented lines are the
+    dependents. Returns deduplicated list of dependent unit names.
+    """
+    if not stdout:
+        return []
+    seen = set()
+    deps = []
+    lines = stdout.splitlines()
+    # Skip first line (the unit being queried)
+    for line in lines[1:]:
+        # Strip tree drawing characters and whitespace
+        cleaned = line.lstrip(" ├│─└").strip()
+        if not cleaned:
+            continue
+        # Some entries include an active marker bullet; take first whitespace-token
+        name = cleaned.split()[0]
+        if name and name not in seen:
+            seen.add(name)
+            deps.append(name)
+    return deps
+
+
+def _normalize_property_for_hash(key, value):
+    """Canonicalize a property value for the inventory hash.
+
+    - Exec*= records keep only static sub-fields (path/argv/ignore_errors),
+      sorted by (path, argv).
+    - List-valued properties are space-split and sorted.
+    - Everything else is stripped of trailing whitespace.
+    """
+    if key.startswith("Exec"):
+        records = _parse_exec_property(value)
+        records.sort(key=lambda r: (r.get("path", ""), r.get("argv", "")))
+        return records
+    if key in LIST_VALUED_PROPERTIES:
+        items = [s for s in (value or "").split() if s]
+        items.sort()
+        return items
+    return (value or "").strip()
+
+
+def _canonicalize_unit(props):
+    """Return a hash-stable dict for a single unit.
+
+    Strips runtime fields, normalizes Exec records and list properties.
+    """
+    canon = {}
+    for key, value in props.items():
+        if key in RUNTIME_FIELDS_TO_STRIP:
+            continue
+        canon[key] = _normalize_property_for_hash(key, value)
+    return canon
+
+
+def _canonical_inventory_hash(units_props):
+    """SHA-256 of the canonical inventory.
+
+    units_props: dict keyed by unit name -> property dict.
+    Sorts by name, strips runtime fields, sort_keys=True for stable output.
+    """
+    canonical = {
+        name: _canonicalize_unit(props) for name, props in sorted(units_props.items())
+    }
+    blob = json.dumps(
+        canonical,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+class SystemdCollector:
+    """Collects per-tick systemd unit health and inventory snapshots.
+
+    Class-level state survives instance recreation across ticks (mirrors
+    snmp.py's SNMPCollector pattern).
+    """
+
+    # unit_name -> (NRestarts_str, ActiveEnterTimestamp_str)
+    _last_failure_signatures: dict = {}
+    # Hash of last sent inventory (for force-resend tracking)
+    _last_local_inventory_hash = None
+    # Cached systemd version
+    _version = None
+    # Cached cgroup hierarchy
+    _hierarchy = None
+
+    def __init__(
+        self, unit_types=DEFAULT_UNIT_TYPES, journal_tail_lines=JOURNAL_TAIL_LINES
+    ):
+        self.unit_types = unit_types
+        self.journal_tail_lines = journal_tail_lines
+        if SystemdCollector._version is None:
+            SystemdCollector._version = _systemd_version()
+        if SystemdCollector._hierarchy is None:
+            SystemdCollector._hierarchy = detect_hierarchy()
+
+    # ---- Per-tick health ----
+
+    def collect(self):
+        """Collect per-tick health for all units.
+
+        Returns a dict shape:
+          {
+            "version": <int|None>,
+            "cgroup": <"v1"|"v2"|None>,
+            "units": [<unit_dict>, ...],
+            "drilldowns": {<unit_name>: <drilldown_dict>, ...},
+            "errors": [<error_dict>, ...],
+          }
+        Returns None if systemctl is unavailable.
+        """
+        errors = []
+
+        unit_names, error = self._list_units()
+        if error:
+            errors.append({"step": "list_units", **error})
+            return {
+                "version": SystemdCollector._version,
+                "cgroup": SystemdCollector._hierarchy,
+                "units": [],
+                "drilldowns": {},
+                "errors": errors,
+            }
+
+        if not unit_names:
+            return {
+                "version": SystemdCollector._version,
+                "cgroup": SystemdCollector._hierarchy,
+                "units": [],
+                "drilldowns": {},
+                "errors": errors,
+            }
+
+        unit_props, error = self._show_bulk(unit_names, HEALTH_PROPERTIES)
+        if error:
+            errors.append({"step": "show_bulk", **error})
+
+        units = []
+        newly_failed = []
+        for name in unit_names:
+            props = unit_props.get(name, {})
+            entry = self._build_health_entry(name, props)
+            units.append(entry)
+            if self._is_newly_failed(name, props):
+                newly_failed.append(name)
+
+        drilldowns = {}
+        if newly_failed:
+            drilldowns = self._drilldown_failed_units(newly_failed)
+
+        return {
+            "version": SystemdCollector._version,
+            "cgroup": SystemdCollector._hierarchy,
+            "units": units,
+            "drilldowns": drilldowns,
+            "errors": errors,
+        }
+
+    def _list_units(self):
+        """List unit names of the configured types."""
+        args = [
+            "list-units",
+            f"--type={self.unit_types}",
+            "--all",
+            "--no-legend",
+            "--plain",
+            "--no-pager",
+        ]
+        stdout, error = _run_systemctl(args)
+        if error:
+            return [], error
+        return _parse_list_units(stdout), None
+
+    def _show_bulk(self, unit_names, properties):
+        """Bulk fetch properties for many units in one subprocess call."""
+        args = [
+            "show",
+            f"--property={','.join(properties)}",
+            "--no-pager",
+        ]
+        args.extend(unit_names)
+        stdout, error = _run_systemctl(args)
+        if error:
+            return {}, error
+        return _parse_show_bulk(stdout), None
+
+    def _build_health_entry(self, name, props):
+        """Build the per-tick payload for a single unit."""
+        try:
+            n_restarts = int(props.get("NRestarts", "0") or 0)
+        except (ValueError, TypeError):
+            n_restarts = 0
+
+        cgroup_data = {}
+        hierarchy = SystemdCollector._hierarchy
+        if hierarchy:
+            try:
+                cgroup_data = read_unit_resources(name, hierarchy)
+            except ValueError:
+                # Path-traversal defense raised - extremely unlikely with names
+                # from systemctl, but log and continue.
+                log(f"systemd: invalid unit name from list-units: {name!r}", "error")
+                cgroup_data = {}
+
+        return {
+            "name": name,
+            "load_state": props.get("LoadState", ""),
+            "active_state": props.get("ActiveState", ""),
+            "sub_state": props.get("SubState", ""),
+            "result": props.get("Result", ""),
+            "n_restarts": n_restarts,
+            "active_enter_timestamp": props.get("ActiveEnterTimestamp", ""),
+            "inactive_enter_timestamp": props.get("InactiveEnterTimestamp", ""),
+            "unit_file_state": props.get("UnitFileState", ""),
+            "memory_current": cgroup_data.get("memory_current"),
+            "cpu_usec": cgroup_data.get("cpu_usec"),
+            "oom_kill_count": cgroup_data.get("oom_kill_count"),
+            "cgroup_inception_id": cgroup_data.get("inception_id"),
+        }
+
+    def _is_newly_failed(self, name, props):
+        """Decide whether to drill into this unit on the current tick.
+
+        A unit qualifies if its active_state == "failed" AND its
+        (NRestarts, ActiveEnterTimestamp) signature differs from the cached one.
+        Bounds the cache at FAILURE_SIG_MAX entries (LRU-style).
+        """
+        if props.get("ActiveState") != "failed":
+            # Drop from cache when no longer failed so a future failure re-drills.
+            SystemdCollector._last_failure_signatures.pop(name, None)
+            return False
+        sig = (props.get("NRestarts", "0"), props.get("ActiveEnterTimestamp", ""))
+        prev = SystemdCollector._last_failure_signatures.get(name)
+        if prev == sig:
+            return False
+        SystemdCollector._last_failure_signatures[name] = sig
+        # Bound cache size
+        if len(SystemdCollector._last_failure_signatures) > FAILURE_SIG_MAX:
+            # Drop the oldest entry (Python 3.7+ dict insertion order)
+            oldest = next(iter(SystemdCollector._last_failure_signatures))
+            SystemdCollector._last_failure_signatures.pop(oldest, None)
+        return True
+
+    # ---- Failure drilldown ----
+
+    def _drilldown_failed_units(self, unit_names):
+        """Run journal tail + reverse-deps in parallel for newly-failed units.
+
+        Returns dict keyed by unit name -> {"journal_tail": [...], "reverse_deps": [...] | None}.
+        """
+        results = {}
+        workers = min(len(unit_names), MAX_DRILLDOWN_WORKERS)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {
+                ex.submit(self._drilldown_one, name): name for name in unit_names
+            }
+            for future in concurrent.futures.as_completed(futures):
+                name = futures[future]
+                try:
+                    results[name] = future.result()
+                except Exception as e:
+                    log(f"systemd drilldown error for {name}: {e}", "error")
+                    results[name] = {
+                        "journal_tail": [],
+                        "reverse_deps": None,
+                        "error": str(e),
+                    }
+        return results
+
+    def _drilldown_one(self, unit_name):
+        """Single-unit drilldown: journal tail + reverse deps."""
+        journal = self._journal_tail(unit_name)
+        reverse_deps = self._reverse_deps(unit_name)
+        return {"journal_tail": journal, "reverse_deps": reverse_deps}
+
+    def _journal_tail(self, unit_name):
+        """Last few error-priority journal lines for a unit."""
+        args = [
+            "-u",
+            unit_name,
+            "-n",
+            str(self.journal_tail_lines),
+            "-p",
+            "err",
+            "--output=json",
+            "--no-pager",
+        ]
+        stdout, error = _run_journalctl(args)
+        if error:
+            return []
+        return _parse_journalctl_failed(stdout)
+
+    def _reverse_deps(self, unit_name):
+        """Reverse dependency map for a unit. None on systemd < 230 or failure."""
+        version = SystemdCollector._version
+        if version is None or version < MIN_SYSTEMD_VERSION_REVERSE_DEPS:
+            return None
+        args = [
+            "list-dependencies",
+            "--reverse",
+            "--all",
+            unit_name,
+            "--no-pager",
+        ]
+        stdout, error = _run_systemctl(args, timeout=LIST_DEPS_TIMEOUT)
+        if error:
+            return None
+        return _parse_reverse_deps(stdout)
+
+    # ---- Inventory snapshot ----
+
+    def snapshot_inventory(self):
+        """Build the full inventory snapshot for all units.
+
+        Returns (unit_props_dict, hash, errors) tuple. unit_props_dict is the
+        canonical (hash-stable) form, hash is the SHA-256, errors is a list.
+        """
+        errors = []
+        unit_names, error = self._list_units()
+        if error:
+            errors.append({"step": "list_units", **error})
+            return {}, None, errors
+        if not unit_names:
+            return {}, _canonical_inventory_hash({}), errors
+
+        raw_props, error = self._show_bulk(unit_names, INVENTORY_PROPERTIES)
+        if error:
+            errors.append({"step": "show_bulk_inventory", **error})
+
+        # Canonicalize each unit (strip runtime, normalize Exec/list fields)
+        canon_units = {
+            name: _canonicalize_unit(props) for name, props in raw_props.items()
+        }
+        # Hash the same canonical form we ship
+        blob = json.dumps(
+            {k: canon_units[k] for k in sorted(canon_units)},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+        h = hashlib.sha256(blob).hexdigest()
+        return canon_units, h, errors
+
+    def inventory_sync(self, config, send_fn, force_resend=False):
+        """Compute inventory hash; send if changed (or force_resend)."""
+        scan_config = config.get("systemd")
+        if not isinstance(scan_config, dict) or not scan_config.get("scan"):
+            return
+
+        units, h, errors = self.snapshot_inventory()
+        if h is None:
+            log("systemd inventory snapshot failed; skipping", "debug")
+            return
+
+        server_hash = scan_config.get("last_inventory_hash")
+        local_hash = SystemdCollector._last_local_inventory_hash
+        if not force_resend and h == server_hash and h == local_hash:
+            log("systemd inventory unchanged, skipping", "debug")
+            return
+
+        payload = {
+            "inventory_hash": h,
+            "units": units,
+            "version": SystemdCollector._version,
+            "cgroup": SystemdCollector._hierarchy,
+        }
+        if errors:
+            payload["errors"] = errors
+
+        if dry_run():
+            log(
+                "systemd inventory (dry-run): " + json.dumps(payload, indent=2),
+                "debug",
+            )
+            return
+
+        response = send_fn(payload)
+        if response is not None:
+            SystemdCollector._last_local_inventory_hash = h
+            log("systemd inventory sent successfully", "info")
+        else:
+            log("systemd inventory send failed, will retry", "error")
+
+
+# ---- Module-level singleton + public API ----
+
+_collector = None
+
+
+def _get_collector(unit_types=DEFAULT_UNIT_TYPES):
+    """Return the cached SystemdCollector, creating it on first call."""
+    global _collector
+    if _collector is None or _collector.unit_types != unit_types:
+        _collector = SystemdCollector(unit_types=unit_types)
+    return _collector
+
+
+def reset_collector():
+    """Reset the module-level collector. Used by tests."""
+    global _collector
+    _collector = None
+    SystemdCollector._last_failure_signatures = {}
+    SystemdCollector._last_local_inventory_hash = None
+    SystemdCollector._version = None
+    SystemdCollector._hierarchy = None
+
+
+@debug("systemd_metrics")
+def systemd_metrics(unit_types=DEFAULT_UNIT_TYPES, **_kwargs):
+    """Per-tick collector entry point. Called from collectors registry.
+
+    Extra kwargs are accepted but ignored so future config keys can be added
+    server-side without breaking older agents.
+    """
+    if not shutil.which("systemctl"):
+        return None
+    return _get_collector(unit_types=unit_types).collect()
+
+
+def systemd_inventory_sync(config, send_fn, force_resend=False):
+    """Inventory snapshot push. Called from agent.py per tick (analogous to packages_sync)."""
+    if not shutil.which("systemctl"):
+        return
+    _get_collector().inventory_sync(config, send_fn, force_resend=force_resend)
+
+
+def force_inventory_resend():
+    """Mark next inventory_sync to resend regardless of hash equality.
+
+    Called from agent.py when SIGHUP triggers a permission refresh, so the
+    next inventory check pushes a fresh snapshot even if nothing changed
+    on the host.
+    """
+    SystemdCollector._last_local_inventory_hash = None

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -4,7 +4,6 @@ import sys
 import threading
 from unittest.mock import MagicMock, patch
 
-
 # Mock libvirt before any fivenines_agent imports that transitively need it
 sys.modules.setdefault("libvirt", MagicMock())
 
@@ -306,9 +305,13 @@ def test_packages_sync_telemetry_captures_logged_error(
 # --- _systemd_inventory_sync_with_telemetry ---
 
 
-def _make_agent_with_systemd_state():
+def _make_agent_with_systemd_state(systemd_capable=True):
     agent = make_agent()
     agent._systemd_force_resend = False
+    # Capability probe is checked before each tick's inventory sync. Default
+    # to a systemd-capable host so existing tests do not have to set it.
+    agent.permissions = MagicMock()
+    agent.permissions.get.return_value = systemd_capable
     return agent
 
 
@@ -325,6 +328,22 @@ def test_systemd_inventory_sync_telemetry_early_return(mock_sync):
     assert "duration_ms" in entry
     assert "errors" not in entry
     mock_sync.assert_called_once()
+
+
+@patch("fivenines_agent.agent.systemd_inventory_sync")
+def test_systemd_inventory_sync_skipped_when_systemd_capability_false(mock_sync):
+    """On a host where systemd capability is False (Alpine OpenRC, bare
+    container without its own systemd), the agent must NOT pay subprocess
+    cost on every tick."""
+    agent = _make_agent_with_systemd_state(systemd_capable=False)
+    agent.config = {"enabled": True, "systemd": {"scan": True}}
+
+    agent._systemd_inventory_sync_with_telemetry()
+
+    mock_sync.assert_not_called()
+    # No telemetry entry recorded - we exited before _collect was invoked
+    assert "systemd_inventory_sync" not in agent._telemetry
+    agent.permissions.get.assert_called_once_with("systemd")
 
 
 @patch("fivenines_agent.agent.systemd_inventory_sync")
@@ -381,9 +400,7 @@ def test_systemd_inventory_sync_telemetry_captures_logged_error(mock_sync):
 
 @patch("fivenines_agent.agent.print_capabilities_banner")
 @patch("fivenines_agent.agent.force_inventory_resend")
-def test_handle_permission_refresh_sets_force_flag_on_sighup(
-    mock_force, mock_banner
-):
+def test_handle_permission_refresh_sets_force_flag_on_sighup(mock_force, mock_banner):
     """SIGHUP triggers permission refresh AND marks systemd inventory for resend."""
     from fivenines_agent.agent import refresh_permissions_event
 

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -4,6 +4,7 @@ import sys
 import threading
 from unittest.mock import MagicMock, patch
 
+
 # Mock libvirt before any fivenines_agent imports that transitively need it
 sys.modules.setdefault("libvirt", MagicMock())
 
@@ -300,3 +301,123 @@ def test_packages_sync_telemetry_captures_logged_error(
     assert "duration_ms" in entry
     assert "errors" in entry
     assert "Packages synchronization failed, will retry" in entry["errors"]
+
+
+# --- _systemd_inventory_sync_with_telemetry ---
+
+
+def _make_agent_with_systemd_state():
+    agent = make_agent()
+    agent._systemd_force_resend = False
+    return agent
+
+
+@patch("fivenines_agent.agent.systemd_inventory_sync")
+def test_systemd_inventory_sync_telemetry_early_return(mock_sync):
+    """Telemetry recorded even when systemd_inventory_sync is a no-op."""
+    agent = _make_agent_with_systemd_state()
+    agent.config = {"enabled": True}
+
+    agent._systemd_inventory_sync_with_telemetry()
+
+    assert "systemd_inventory_sync" in agent._telemetry
+    entry = agent._telemetry["systemd_inventory_sync"]
+    assert "duration_ms" in entry
+    assert "errors" not in entry
+    mock_sync.assert_called_once()
+
+
+@patch("fivenines_agent.agent.systemd_inventory_sync")
+def test_systemd_inventory_sync_telemetry_consumes_force_flag(mock_sync):
+    """force_resend flag is consumed (reset to False) after one sync call."""
+    agent = _make_agent_with_systemd_state()
+    agent.config = {"enabled": True, "systemd": {"scan": True}}
+    agent._systemd_force_resend = True
+
+    agent._systemd_inventory_sync_with_telemetry()
+
+    # The flag must be cleared so the next tick does not re-force
+    assert agent._systemd_force_resend is False
+    # And the sync was called with force_resend=True
+    args, kwargs = mock_sync.call_args
+    assert kwargs.get("force_resend") is True
+
+
+@patch("fivenines_agent.agent.systemd_inventory_sync")
+def test_systemd_inventory_sync_telemetry_on_exception(mock_sync):
+    """Telemetry with errors recorded when exception occurs."""
+    agent = _make_agent_with_systemd_state()
+    agent.config = {"enabled": True, "systemd": {"scan": True}}
+    mock_sync.side_effect = RuntimeError("snapshot blew up")
+
+    agent._systemd_inventory_sync_with_telemetry()
+
+    entry = agent._telemetry["systemd_inventory_sync"]
+    assert "duration_ms" in entry
+    assert "errors" in entry
+    assert "snapshot blew up" in entry["errors"]
+
+
+@patch("fivenines_agent.agent.systemd_inventory_sync")
+def test_systemd_inventory_sync_telemetry_captures_logged_error(mock_sync):
+    """Errors logged inside systemd_inventory_sync end up in telemetry."""
+    agent = _make_agent_with_systemd_state()
+    agent.config = {"enabled": True, "systemd": {"scan": True}}
+
+    def fake_sync(_config, _send_fn, force_resend=False):
+        log("systemd inventory send failed, will retry", "error")
+
+    mock_sync.side_effect = fake_sync
+
+    agent._systemd_inventory_sync_with_telemetry()
+
+    entry = agent._telemetry["systemd_inventory_sync"]
+    assert "errors" in entry
+    assert "systemd inventory send failed, will retry" in entry["errors"]
+
+
+# --- _handle_permission_refresh: SIGHUP forces inventory resend ---
+
+
+@patch("fivenines_agent.agent.print_capabilities_banner")
+@patch("fivenines_agent.agent.force_inventory_resend")
+def test_handle_permission_refresh_sets_force_flag_on_sighup(
+    mock_force, mock_banner
+):
+    """SIGHUP triggers permission refresh AND marks systemd inventory for resend."""
+    from fivenines_agent.agent import refresh_permissions_event
+
+    agent = make_agent()
+    agent._systemd_force_resend = False
+    agent.permissions = MagicMock()
+    agent.permissions.get_all.return_value = {"systemd": True}
+    agent.static_data = {}
+    refresh_permissions_event.set()
+
+    try:
+        agent._handle_permission_refresh()
+    finally:
+        refresh_permissions_event.clear()
+
+    mock_force.assert_called_once()
+    assert agent._systemd_force_resend is True
+    assert refresh_permissions_event.is_set() is False
+
+
+@patch("fivenines_agent.agent.force_inventory_resend")
+def test_handle_permission_refresh_periodic_does_not_force_resend(mock_force):
+    """Periodic 5-min re-probe must NOT force inventory resend (only SIGHUP does)."""
+    from fivenines_agent.agent import refresh_permissions_event
+
+    agent = make_agent()
+    agent._systemd_force_resend = False
+    agent.permissions = MagicMock()
+    agent.permissions.refresh_if_needed.return_value = True
+    agent.permissions.get_all.return_value = {"systemd": True}
+    agent.static_data = {}
+    refresh_permissions_event.clear()
+
+    agent._handle_permission_refresh()
+
+    mock_force.assert_not_called()
+    assert agent._systemd_force_resend is False

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from fivenines_agent.cgroup import (
+    _v1_cpu_controller,
     detect_hierarchy,
     read_cpu_usec,
     read_inception_id,
@@ -187,23 +188,91 @@ def test_read_cpu_usec_v2_unparseable():
 
 def test_read_cpu_usec_v1_converts_ns_to_usec():
     """v1 cpuacct.usage is nanoseconds; we want microseconds."""
-    with patch("builtins.open", mock_open(read_data="5000000000\n")):
-        # 5_000_000_000 ns -> 5_000_000 us
-        assert read_cpu_usec("nginx.service", "v1") == 5000000
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value="cpuacct"):
+        with patch("builtins.open", mock_open(read_data="5000000000\n")):
+            # 5_000_000_000 ns -> 5_000_000 us
+            assert read_cpu_usec("nginx.service", "v1") == 5000000
+
+
+def test_read_cpu_usec_v1_combined_mount():
+    """CentOS 7 uses the combined cpu,cpuacct mount; cpu_usec must still resolve."""
+    captured = {}
+
+    def fake_open(path, *args, **kwargs):
+        captured["path"] = path
+        return mock_open(read_data="3000000000\n").return_value
+
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value="cpu,cpuacct"):
+        with patch("builtins.open", side_effect=fake_open):
+            assert read_cpu_usec("nginx.service", "v1") == 3000000
+    assert "/sys/fs/cgroup/cpu,cpuacct/system.slice/nginx.service" in captured["path"]
+
+
+def test_read_cpu_usec_v1_no_cpu_controller():
+    """No cpuacct or cpu,cpuacct mount -> returns None without trying to read."""
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value=None):
+        with patch("builtins.open") as mock_o:
+            assert read_cpu_usec("nginx.service", "v1") is None
+        mock_o.assert_not_called()
 
 
 def test_read_cpu_usec_v1_missing_file():
-    with patch("builtins.open", side_effect=FileNotFoundError):
-        assert read_cpu_usec("nginx.service", "v1") is None
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value="cpuacct"):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            assert read_cpu_usec("nginx.service", "v1") is None
 
 
 def test_read_cpu_usec_v1_invalid():
-    with patch("builtins.open", mock_open(read_data="garbage\n")):
-        assert read_cpu_usec("nginx.service", "v1") is None
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value="cpuacct"):
+        with patch("builtins.open", mock_open(read_data="garbage\n")):
+            assert read_cpu_usec("nginx.service", "v1") is None
 
 
 def test_read_cpu_usec_unsupported_hierarchy():
     assert read_cpu_usec("nginx.service", None) is None
+
+
+# --- _v1_cpu_controller (combined-mount detection) ---
+
+
+def test_v1_cpu_controller_separate_mount():
+    """Older kernels mount cpuacct on its own."""
+    with patch(
+        "fivenines_agent.cgroup.os.path.isdir",
+        side_effect=lambda p: p.endswith("/cpuacct"),
+    ):
+        assert _v1_cpu_controller() == "cpuacct"
+
+
+def test_v1_cpu_controller_combined_mount():
+    """CentOS 7 / RHEL 7: cpuacct lives under cpu,cpuacct."""
+
+    def fake_isdir(p):
+        return p.endswith("/cpu,cpuacct")
+
+    with patch("fivenines_agent.cgroup.os.path.isdir", side_effect=fake_isdir):
+        assert _v1_cpu_controller() == "cpu,cpuacct"
+
+
+def test_v1_cpu_controller_neither_mount_returns_none():
+    with patch("fivenines_agent.cgroup.os.path.isdir", return_value=False):
+        assert _v1_cpu_controller() is None
+
+
+def test_v1_cpu_controller_caches_result():
+    """Detection runs once; subsequent calls hit the cache."""
+    with patch("fivenines_agent.cgroup.os.path.isdir", return_value=True) as mock_isdir:
+        first = _v1_cpu_controller()
+        second = _v1_cpu_controller()
+    assert first == second == "cpuacct"
+    # Only the first probe touches the filesystem
+    assert mock_isdir.call_count == 1
+
+
+def test_v1_cpu_controller_prefers_separate_when_both_present():
+    """If both mounts exist (rare), pick the canonical 'cpuacct' name."""
+    with patch("fivenines_agent.cgroup.os.path.isdir", return_value=True):
+        assert _v1_cpu_controller() == "cpuacct"
 
 
 # --- read_oom_kill_count ---
@@ -325,9 +394,10 @@ def test_read_unit_resources_v1_no_oom():
             return mock_open(read_data="3000000000\n").return_value
         raise FileNotFoundError
 
-    with patch("builtins.open", side_effect=fake_open):
-        with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat):
-            result = read_unit_resources("nginx.service", "v1")
+    with patch("fivenines_agent.cgroup._v1_cpu_controller", return_value="cpuacct"):
+        with patch("builtins.open", side_effect=fake_open):
+            with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat):
+                result = read_unit_resources("nginx.service", "v1")
     assert result == {
         "memory_current": 2048,
         "cpu_usec": 3000000,

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -1,0 +1,344 @@
+"""Tests for fivenines_agent.cgroup module."""
+
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from fivenines_agent.cgroup import (
+    detect_hierarchy,
+    read_cpu_usec,
+    read_inception_id,
+    read_memory_current,
+    read_oom_kill_count,
+    read_unit_resources,
+    reset_cache,
+    unit_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cgroup_cache():
+    reset_cache()
+    yield
+    reset_cache()
+
+
+# --- detect_hierarchy ---
+
+
+def test_detect_hierarchy_v2():
+    def fake_exists(path):
+        return path == "/sys/fs/cgroup/cgroup.controllers"
+
+    with patch("fivenines_agent.cgroup.os.path.exists", side_effect=fake_exists):
+        assert detect_hierarchy() == "v2"
+
+
+def test_detect_hierarchy_v1():
+    def fake_isdir(path):
+        return path == "/sys/fs/cgroup/memory"
+
+    with patch("fivenines_agent.cgroup.os.path.exists", return_value=False):
+        with patch("fivenines_agent.cgroup.os.path.isdir", side_effect=fake_isdir):
+            assert detect_hierarchy() == "v1"
+
+
+def test_detect_hierarchy_none():
+    with patch("fivenines_agent.cgroup.os.path.exists", return_value=False):
+        with patch("fivenines_agent.cgroup.os.path.isdir", return_value=False):
+            assert detect_hierarchy() is None
+
+
+def test_detect_hierarchy_caches_result():
+    """Second call returns cached value without re-probing the filesystem."""
+    with patch(
+        "fivenines_agent.cgroup.os.path.exists", return_value=True
+    ) as mock_exists:
+        first = detect_hierarchy()
+        second = detect_hierarchy()
+    assert first == "v2"
+    assert second == "v2"
+    # exists() called once during the first probe; cache returns on second call
+    assert mock_exists.call_count == 1
+
+
+# --- unit_path ---
+
+
+def test_unit_path_v2_default_slice():
+    assert unit_path("nginx.service", "v2") == (
+        "/sys/fs/cgroup/system.slice/nginx.service"
+    )
+
+
+def test_unit_path_v1_requires_controller():
+    with pytest.raises(ValueError, match="controller is required"):
+        unit_path("nginx.service", "v1")
+
+
+def test_unit_path_v1_with_controller():
+    assert unit_path("nginx.service", "v1", controller="memory") == (
+        "/sys/fs/cgroup/memory/system.slice/nginx.service"
+    )
+
+
+def test_unit_path_unknown_hierarchy():
+    with pytest.raises(ValueError, match="unsupported hierarchy"):
+        unit_path("nginx.service", "v3")
+
+
+def test_unit_path_rejects_path_traversal():
+    """Defense in depth: unit names with '/' must not build cgroup paths."""
+    with pytest.raises(ValueError, match="invalid unit name"):
+        unit_path("../../etc/passwd", "v2")
+
+
+def test_unit_path_rejects_null_byte():
+    with pytest.raises(ValueError, match="invalid unit name"):
+        unit_path("nginx\x00.service", "v2")
+
+
+def test_unit_path_accepts_systemd_special_chars():
+    """systemd unit names with @ and : characters are valid."""
+    p = unit_path("getty@tty1.service", "v2")
+    assert p.endswith("getty@tty1.service")
+
+
+# --- read_memory_current ---
+
+
+def test_read_memory_current_v2_happy():
+    with patch("builtins.open", mock_open(read_data="123456789\n")):
+        assert read_memory_current("nginx.service", "v2") == 123456789
+
+
+def test_read_memory_current_v1_happy():
+    with patch("builtins.open", mock_open(read_data="987654321\n")):
+        assert read_memory_current("nginx.service", "v1") == 987654321
+
+
+def test_read_memory_current_max_returns_none():
+    """memory.current can return literal 'max' on unbounded units."""
+    with patch("builtins.open", mock_open(read_data="max\n")):
+        assert read_memory_current("nginx.service", "v2") is None
+
+
+def test_read_memory_current_file_not_found():
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert read_memory_current("nginx.service", "v2") is None
+
+
+def test_read_memory_current_permission_denied_silent():
+    """EACCES is the expected capability gap; must NOT log."""
+    with patch("builtins.open", side_effect=PermissionError):
+        with patch("fivenines_agent.cgroup.log") as mock_log:
+            result = read_memory_current("nginx.service", "v2")
+        assert result is None
+        mock_log.assert_not_called()
+
+
+def test_read_memory_current_oserror_logs_at_debug():
+    """Other OS errors log at debug level (not error)."""
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        with patch("fivenines_agent.cgroup.log") as mock_log:
+            result = read_memory_current("nginx.service", "v2")
+        assert result is None
+        mock_log.assert_called_once()
+        assert mock_log.call_args[0][1] == "debug"
+
+
+def test_read_memory_current_invalid_value():
+    """Non-integer text returns None."""
+    with patch("builtins.open", mock_open(read_data="not-a-number")):
+        assert read_memory_current("nginx.service", "v2") is None
+
+
+def test_read_memory_current_unsupported_hierarchy():
+    assert read_memory_current("nginx.service", None) is None
+
+
+# --- read_cpu_usec ---
+
+
+CPU_STAT_V2 = """\
+usage_usec 5000000
+user_usec 4500000
+system_usec 500000
+nr_periods 0
+nr_throttled 0
+throttled_usec 0
+"""
+
+
+def test_read_cpu_usec_v2_happy():
+    with patch("builtins.open", mock_open(read_data=CPU_STAT_V2)):
+        assert read_cpu_usec("nginx.service", "v2") == 5000000
+
+
+def test_read_cpu_usec_v2_missing_key():
+    with patch("builtins.open", mock_open(read_data="user_usec 100\n")):
+        assert read_cpu_usec("nginx.service", "v2") is None
+
+
+def test_read_cpu_usec_v2_unparseable():
+    with patch("builtins.open", mock_open(read_data="usage_usec garbage\n")):
+        assert read_cpu_usec("nginx.service", "v2") is None
+
+
+def test_read_cpu_usec_v1_converts_ns_to_usec():
+    """v1 cpuacct.usage is nanoseconds; we want microseconds."""
+    with patch("builtins.open", mock_open(read_data="5000000000\n")):
+        # 5_000_000_000 ns -> 5_000_000 us
+        assert read_cpu_usec("nginx.service", "v1") == 5000000
+
+
+def test_read_cpu_usec_v1_missing_file():
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert read_cpu_usec("nginx.service", "v1") is None
+
+
+def test_read_cpu_usec_v1_invalid():
+    with patch("builtins.open", mock_open(read_data="garbage\n")):
+        assert read_cpu_usec("nginx.service", "v1") is None
+
+
+def test_read_cpu_usec_unsupported_hierarchy():
+    assert read_cpu_usec("nginx.service", None) is None
+
+
+# --- read_oom_kill_count ---
+
+
+MEMORY_EVENTS_V2 = """\
+low 0
+high 0
+max 0
+oom 2
+oom_kill 3
+"""
+
+
+def test_read_oom_kill_count_v2_happy():
+    with patch("builtins.open", mock_open(read_data=MEMORY_EVENTS_V2)):
+        assert read_oom_kill_count("nginx.service", "v2") == 3
+
+
+def test_read_oom_kill_count_v1_returns_none():
+    """v1 has no memory.events equivalent; collector ships null."""
+    assert read_oom_kill_count("nginx.service", "v1") is None
+
+
+def test_read_oom_kill_count_none_hierarchy():
+    assert read_oom_kill_count("nginx.service", None) is None
+
+
+def test_read_oom_kill_count_missing_key():
+    with patch("builtins.open", mock_open(read_data="low 0\nhigh 0\n")):
+        assert read_oom_kill_count("nginx.service", "v2") is None
+
+
+def test_read_oom_kill_count_file_missing():
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert read_oom_kill_count("nginx.service", "v2") is None
+
+
+# --- read_inception_id ---
+
+
+def test_read_inception_id_v2_happy():
+    fake_stat = MagicMock(st_ino=42)
+    with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat) as mock_stat:
+        result = read_inception_id("nginx.service", "v2")
+    assert result == 42
+    mock_stat.assert_called_once_with("/sys/fs/cgroup/system.slice/nginx.service")
+
+
+def test_read_inception_id_v1_uses_memory_controller():
+    fake_stat = MagicMock(st_ino=99)
+    with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat) as mock_stat:
+        result = read_inception_id("nginx.service", "v1")
+    assert result == 99
+    mock_stat.assert_called_once_with(
+        "/sys/fs/cgroup/memory/system.slice/nginx.service"
+    )
+
+
+def test_read_inception_id_no_hierarchy():
+    assert read_inception_id("nginx.service", None) is None
+
+
+def test_read_inception_id_file_not_found():
+    with patch("fivenines_agent.cgroup.os.stat", side_effect=FileNotFoundError):
+        assert read_inception_id("nginx.service", "v2") is None
+
+
+def test_read_inception_id_permission_denied_silent():
+    with patch("fivenines_agent.cgroup.os.stat", side_effect=PermissionError):
+        with patch("fivenines_agent.cgroup.log") as mock_log:
+            assert read_inception_id("nginx.service", "v2") is None
+        mock_log.assert_not_called()
+
+
+def test_read_inception_id_oserror_logs_debug():
+    with patch("fivenines_agent.cgroup.os.stat", side_effect=OSError("err")):
+        with patch("fivenines_agent.cgroup.log") as mock_log:
+            assert read_inception_id("nginx.service", "v2") is None
+        mock_log.assert_called_once()
+        assert mock_log.call_args[0][1] == "debug"
+
+
+# --- read_unit_resources ---
+
+
+def test_read_unit_resources_v2_aggregates_all_metrics():
+    """One call returns all four metrics for v2."""
+    fake_stat = MagicMock(st_ino=7)
+
+    def fake_open(path, *_args, **_kwargs):
+        if path.endswith("memory.current"):
+            return mock_open(read_data="1024\n").return_value
+        if path.endswith("cpu.stat"):
+            return mock_open(read_data=CPU_STAT_V2).return_value
+        if path.endswith("memory.events"):
+            return mock_open(read_data=MEMORY_EVENTS_V2).return_value
+        raise FileNotFoundError
+
+    with patch("builtins.open", side_effect=fake_open):
+        with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat):
+            result = read_unit_resources("nginx.service", "v2")
+    assert result == {
+        "memory_current": 1024,
+        "cpu_usec": 5000000,
+        "oom_kill_count": 3,
+        "inception_id": 7,
+    }
+
+
+def test_read_unit_resources_v1_no_oom():
+    """v1 fills memory + cpu but oom_kill_count stays null."""
+    fake_stat = MagicMock(st_ino=8)
+
+    def fake_open(path, *_args, **_kwargs):
+        if path.endswith("memory.usage_in_bytes"):
+            return mock_open(read_data="2048\n").return_value
+        if path.endswith("cpuacct.usage"):
+            return mock_open(read_data="3000000000\n").return_value
+        raise FileNotFoundError
+
+    with patch("builtins.open", side_effect=fake_open):
+        with patch("fivenines_agent.cgroup.os.stat", return_value=fake_stat):
+            result = read_unit_resources("nginx.service", "v1")
+    assert result == {
+        "memory_current": 2048,
+        "cpu_usec": 3000000,
+        "oom_kill_count": None,
+        "inception_id": 8,
+    }
+
+
+def test_read_unit_resources_no_hierarchy_returns_empty():
+    assert read_unit_resources("nginx.service", None) == {}
+
+
+def test_read_unit_resources_unsupported_hierarchy_returns_empty():
+    assert read_unit_resources("nginx.service", "v9") == {}

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -35,6 +35,7 @@ def test_registry_has_expected_config_keys():
         "caddy",
         "postgresql",
         "proxmox",
+        "systemd",
     ]
     assert config_keys == expected
 

--- a/tests/test_permissions_systemd.py
+++ b/tests/test_permissions_systemd.py
@@ -1,0 +1,209 @@
+"""Tests for the systemd and cgroup capabilities in PermissionProbe."""
+
+import io
+import subprocess
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+from fivenines_agent.permissions import PermissionProbe, print_capabilities_banner
+
+
+def _make_probe():
+    """Create a probe instance without invoking _probe_all in __init__."""
+    probe = PermissionProbe.__new__(PermissionProbe)
+    probe.capabilities = {}
+    return probe
+
+
+# --- _can_probe_systemd ---
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_happy(mock_probe):
+    probe = _make_probe()
+    fake = MagicMock(returncode=0)
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=True):
+        with patch(
+            "fivenines_agent.permissions.shutil.which",
+            return_value="/usr/bin/systemctl",
+        ):
+            with patch("fivenines_agent.permissions.subprocess.run", return_value=fake):
+                assert probe._can_probe_systemd() is True
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_no_run_systemd_directory(mock_probe):
+    """Alpine OpenRC, BusyBox containers: /run/systemd/system absent."""
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=False):
+        assert probe._can_probe_systemd() is False
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_no_systemctl_binary(mock_probe):
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=True):
+        with patch("fivenines_agent.permissions.shutil.which", return_value=None):
+            assert probe._can_probe_systemd() is False
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_timeout(mock_probe):
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=True):
+        with patch(
+            "fivenines_agent.permissions.shutil.which",
+            return_value="/usr/bin/systemctl",
+        ):
+            with patch(
+                "fivenines_agent.permissions.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="systemctl", timeout=5),
+            ):
+                assert probe._can_probe_systemd() is False
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_oserror(mock_probe):
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=True):
+        with patch(
+            "fivenines_agent.permissions.shutil.which",
+            return_value="/usr/bin/systemctl",
+        ):
+            with patch(
+                "fivenines_agent.permissions.subprocess.run",
+                side_effect=OSError("no exec"),
+            ):
+                assert probe._can_probe_systemd() is False
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_can_probe_systemd_non_zero_exit(mock_probe):
+    probe = _make_probe()
+    fake = MagicMock(returncode=1)
+    with patch("fivenines_agent.permissions.os.path.isdir", return_value=True):
+        with patch(
+            "fivenines_agent.permissions.shutil.which",
+            return_value="/usr/bin/systemctl",
+        ):
+            with patch("fivenines_agent.permissions.subprocess.run", return_value=fake):
+                assert probe._can_probe_systemd() is False
+
+
+# --- _detect_cgroup_hierarchy ---
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_detect_cgroup_hierarchy_v2(mock_probe):
+    probe = _make_probe()
+    with patch(
+        "fivenines_agent.permissions.os.path.exists",
+        side_effect=lambda p: p == "/sys/fs/cgroup/cgroup.controllers",
+    ):
+        assert probe._detect_cgroup_hierarchy() == "v2"
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_detect_cgroup_hierarchy_v1(mock_probe):
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.exists", return_value=False):
+        with patch(
+            "fivenines_agent.permissions.os.path.isdir",
+            side_effect=lambda p: p == "/sys/fs/cgroup/memory",
+        ):
+            assert probe._detect_cgroup_hierarchy() == "v1"
+
+
+@patch.object(PermissionProbe, "_probe_all")
+def test_detect_cgroup_hierarchy_none(mock_probe):
+    probe = _make_probe()
+    with patch("fivenines_agent.permissions.os.path.exists", return_value=False):
+        with patch("fivenines_agent.permissions.os.path.isdir", return_value=False):
+            assert probe._detect_cgroup_hierarchy() is None
+
+
+# --- Banner placement ---
+
+
+def _print_banner_with_capabilities(caps):
+    """Helper to capture banner output for a given capabilities dict."""
+
+    class FakeProbe:
+        def get_all(self):
+            return caps
+
+        def get_unavailable(self):
+            return [k for k, v in caps.items() if not v]
+
+    buf = io.StringIO()
+    with patch("fivenines_agent.permissions.get_permissions", return_value=FakeProbe()):
+        with redirect_stdout(buf):
+            print_capabilities_banner()
+    return buf.getvalue()
+
+
+def _full_caps(systemd=False, cgroup=False):
+    """Return a complete capabilities dict for banner rendering."""
+    return {
+        "cpu": True,
+        "memory": True,
+        "load_average": True,
+        "io": True,
+        "network": True,
+        "partitions": True,
+        "file_handles": True,
+        "ports": True,
+        "processes": True,
+        "temperatures": False,
+        "fans": False,
+        "nvidia_gpu": False,
+        "smart_storage": False,
+        "raid_storage": False,
+        "zfs": False,
+        "docker": False,
+        "qemu": False,
+        "proxmox": False,
+        "fail2ban": False,
+        "packages": False,
+        "snmp": False,
+        "systemd": systemd,
+        "cgroup": cgroup,
+    }
+
+
+def test_banner_systemd_in_services_section_when_available():
+    output = _print_banner_with_capabilities(_full_caps(systemd=True))
+    # systemd row should be in the Services section, not Hardware
+    services_idx = output.index("Services:")
+    systemd_idx = output.index("Systemd")
+    assert systemd_idx > services_idx
+    assert "[+] Systemd" in output
+
+
+def test_banner_systemd_unavailable_hint():
+    output = _print_banner_with_capabilities(_full_caps(systemd=False))
+    assert "[-] Systemd (requires: systemd init system)" in output
+
+
+def test_banner_cgroup_v2_renders_with_version_in_name():
+    output = _print_banner_with_capabilities(_full_caps(cgroup="v2"))
+    assert "[+] Cgroup v2" in output
+
+
+def test_banner_cgroup_v1_renders_with_version_in_name():
+    output = _print_banner_with_capabilities(_full_caps(cgroup="v1"))
+    assert "[+] Cgroup v1" in output
+
+
+def test_banner_cgroup_unavailable_hint():
+    output = _print_banner_with_capabilities(_full_caps(cgroup=False))
+    assert "[-] Cgroup (no /sys/fs/cgroup hierarchy found)" in output
+
+
+def test_banner_cgroup_in_hardware_section():
+    """cgroup is a kernel surface, listed under Hardware Sensors."""
+    output = _print_banner_with_capabilities(_full_caps(cgroup="v2"))
+    hardware_idx = output.index("Hardware Sensors:")
+    services_idx = output.index("Services:")
+    cgroup_idx = output.index("Cgroup")
+    assert hardware_idx < cgroup_idx < services_idx

--- a/tests/test_synchronizer_security_scan.py
+++ b/tests/test_synchronizer_security_scan.py
@@ -164,6 +164,34 @@ def test_send_packages_failure(mock_post):
     assert result is None
 
 
+# --- send_systemd_inventory ---
+
+
+@patch.object(Synchronizer, "_post")
+def test_send_systemd_inventory_success(mock_post):
+    sync = make_synchronizer()
+    mock_post.return_value = {"status": "queued"}
+
+    inventory = {
+        "inventory_hash": "deadbeef",
+        "units": {"nginx.service": {"FragmentPath": "/etc/foo"}},
+        "version": 252,
+        "cgroup": "v2",
+    }
+    result = sync.send_systemd_inventory(inventory)
+    assert result == {"status": "queued"}
+    mock_post.assert_called_once_with("/systemd_inventory", inventory)
+
+
+@patch.object(Synchronizer, "_post")
+def test_send_systemd_inventory_failure(mock_post):
+    sync = make_synchronizer()
+    mock_post.return_value = None
+
+    result = sync.send_systemd_inventory({"inventory_hash": "x", "units": {}})
+    assert result is None
+
+
 # --- get_config ---
 
 

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1250,13 +1250,43 @@ def test_systemd_inventory_sync_delegates_to_collector():
     ):
         with patch(
             "fivenines_agent.systemd._get_collector", return_value=fake_collector
-        ):
+        ) as mock_get:
             systemd_inventory_sync(
                 {"systemd": {"scan": True}}, "send_fn", force_resend=True
             )
+    mock_get.assert_called_once_with(unit_types=DEFAULT_UNIT_TYPES)
     fake_collector.inventory_sync.assert_called_once_with(
         {"systemd": {"scan": True}}, "send_fn", force_resend=True
     )
+
+
+def test_systemd_inventory_sync_passes_unit_types_from_config():
+    """Inventory sync must use the same unit_types as the metrics path so the
+    module-level singleton does not get recreated every tick when config
+    overrides the default scope."""
+    fake_collector = MagicMock()
+    config = {"systemd": {"scan": True, "unit_types": "service"}}
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd._get_collector", return_value=fake_collector
+        ) as mock_get:
+            systemd_inventory_sync(config, "send_fn")
+    mock_get.assert_called_once_with(unit_types="service")
+
+
+def test_systemd_inventory_sync_falls_back_to_default_when_config_not_dict():
+    """Bool / truthy non-dict config still works via DEFAULT_UNIT_TYPES."""
+    fake_collector = MagicMock()
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd._get_collector", return_value=fake_collector
+        ) as mock_get:
+            systemd_inventory_sync({"systemd": True}, "send_fn")
+    mock_get.assert_called_once_with(unit_types=DEFAULT_UNIT_TYPES)
 
 
 def test_force_inventory_resend_clears_local_hash():

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,1285 @@
+"""Tests for fivenines_agent.systemd module."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fivenines_agent import systemd
+from fivenines_agent.systemd import (
+    DEFAULT_UNIT_TYPES,
+    EXEC_ARGV_RE,
+    HEALTH_PROPERTIES,
+    INVENTORY_PROPERTIES,
+    LIST_VALUED_PROPERTIES,
+    MAX_DRILLDOWN_WORKERS,
+    MIN_SYSTEMD_VERSION_REVERSE_DEPS,
+    RUNTIME_FIELDS_TO_STRIP,
+    SystemdCollector,
+    _canonical_inventory_hash,
+    _canonicalize_unit,
+    _extract_exec_record,
+    _normalize_property_for_hash,
+    _parse_exec_property,
+    _parse_journalctl_failed,
+    _parse_list_units,
+    _parse_reverse_deps,
+    _parse_show_bulk,
+    _run_subprocess,
+    _systemd_version,
+    force_inventory_resend,
+    reset_collector,
+    systemd_inventory_sync,
+    systemd_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_systemd():
+    """Clear module-level singleton + class-level state between tests."""
+    reset_collector()
+    yield
+    reset_collector()
+
+
+# ============================================================
+# Constants & top-level structure
+# ============================================================
+
+
+def test_runtime_fields_strip_set_includes_main_pid():
+    assert "MainPID" in RUNTIME_FIELDS_TO_STRIP
+    assert "ExecMainStartTimestamp" in RUNTIME_FIELDS_TO_STRIP
+
+
+def test_health_properties_subset_of_inventory():
+    assert set(HEALTH_PROPERTIES).issubset(set(INVENTORY_PROPERTIES))
+
+
+def test_list_valued_properties_in_inventory():
+    assert LIST_VALUED_PROPERTIES.issubset(set(INVENTORY_PROPERTIES))
+
+
+# ============================================================
+# _systemd_version
+# ============================================================
+
+
+def test_systemd_version_returns_int():
+    fake = MagicMock(returncode=0, stdout="systemd 252 (252.4-1ubuntu3.1)\n")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() == 252
+
+
+def test_systemd_version_centos_7_returns_219():
+    fake = MagicMock(returncode=0, stdout="systemd 219\n")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() == 219
+
+
+def test_systemd_version_no_systemctl():
+    with patch("fivenines_agent.systemd.shutil.which", return_value=None):
+        assert _systemd_version() is None
+
+
+def test_systemd_version_timeout():
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="systemctl", timeout=5),
+        ):
+            assert _systemd_version() is None
+
+
+def test_systemd_version_oserror():
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd.subprocess.run", side_effect=OSError("no exec")
+        ):
+            assert _systemd_version() is None
+
+
+def test_systemd_version_non_zero_exit():
+    fake = MagicMock(returncode=1, stdout="")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() is None
+
+
+def test_systemd_version_unparseable_first_line():
+    fake = MagicMock(returncode=0, stdout="not-systemd output\n")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() is None
+
+
+def test_systemd_version_non_int_version():
+    fake = MagicMock(returncode=0, stdout="systemd vNEXT\n")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() is None
+
+
+def test_systemd_version_empty_stdout():
+    fake = MagicMock(returncode=0, stdout="")
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            assert _systemd_version() is None
+
+
+# ============================================================
+# _run_subprocess
+# ============================================================
+
+
+def test_run_subprocess_missing_binary():
+    with patch("fivenines_agent.systemd.shutil.which", return_value=None):
+        stdout, error = _run_subprocess("foo", ["--bar"], 5)
+    assert stdout is None
+    assert error == {"type": "missing", "message": "foo not in PATH"}
+
+
+def test_run_subprocess_success():
+    fake = MagicMock(returncode=0, stdout="hello\n")
+    with patch("fivenines_agent.systemd.shutil.which", return_value="/bin/foo"):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            stdout, error = _run_subprocess("foo", ["bar"], 5)
+    assert stdout == "hello\n"
+    assert error is None
+
+
+def test_run_subprocess_timeout():
+    with patch("fivenines_agent.systemd.shutil.which", return_value="/bin/foo"):
+        with patch(
+            "fivenines_agent.systemd.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="foo", timeout=5),
+        ):
+            stdout, error = _run_subprocess("foo", [], 5)
+    assert stdout is None
+    assert error["type"] == "timeout"
+    assert "5s" in error["message"]
+
+
+def test_run_subprocess_oserror():
+    with patch("fivenines_agent.systemd.shutil.which", return_value="/bin/foo"):
+        with patch(
+            "fivenines_agent.systemd.subprocess.run", side_effect=OSError("boom")
+        ):
+            stdout, error = _run_subprocess("foo", [], 5)
+    assert stdout is None
+    assert error == {"type": "unknown", "message": "boom"}
+
+
+def test_run_subprocess_cli_error_with_stderr():
+    fake = MagicMock(returncode=1, stdout="", stderr="bad arg\n")
+    with patch("fivenines_agent.systemd.shutil.which", return_value="/bin/foo"):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            stdout, error = _run_subprocess("foo", [], 5)
+    assert stdout is None
+    assert error == {"type": "cli_error", "message": "bad arg"}
+
+
+def test_run_systemctl_delegates_to_run_subprocess():
+    """The systemctl wrapper just calls _run_subprocess with 'systemctl'."""
+    with patch(
+        "fivenines_agent.systemd._run_subprocess", return_value=("ok", None)
+    ) as m:
+        from fivenines_agent.systemd import _run_systemctl
+
+        result = _run_systemctl(["status"], timeout=7)
+    assert result == ("ok", None)
+    m.assert_called_once_with("systemctl", ["status"], 7)
+
+
+def test_run_journalctl_delegates_to_run_subprocess():
+    """The journalctl wrapper just calls _run_subprocess with 'journalctl'."""
+    with patch(
+        "fivenines_agent.systemd._run_subprocess", return_value=("log", None)
+    ) as m:
+        from fivenines_agent.systemd import _run_journalctl
+
+        result = _run_journalctl(["-u", "x"], timeout=8)
+    assert result == ("log", None)
+    m.assert_called_once_with("journalctl", ["-u", "x"], 8)
+
+
+def test_run_subprocess_cli_error_empty_stderr():
+    fake = MagicMock(returncode=2, stdout="", stderr="")
+    with patch("fivenines_agent.systemd.shutil.which", return_value="/bin/foo"):
+        with patch("fivenines_agent.systemd.subprocess.run", return_value=fake):
+            stdout, error = _run_subprocess("foo", [], 5)
+    assert stdout is None
+    assert error == {"type": "cli_error", "message": "exit 2"}
+
+
+# ============================================================
+# _parse_list_units
+# ============================================================
+
+
+LIST_UNITS_OUTPUT = """\
+nginx.service     loaded active   running A high performance web server
+fail2ban.service  loaded inactive dead    Authentication failure monitoring
+broken.service    loaded failed   failed  A failing service
+cron.timer        loaded active   waiting Daily cron jobs
+ssh.socket        loaded active   listening OpenBSD Secure Shell
+"""
+
+
+def test_parse_list_units_happy():
+    units = _parse_list_units(LIST_UNITS_OUTPUT)
+    assert units == [
+        "nginx.service",
+        "fail2ban.service",
+        "broken.service",
+        "cron.timer",
+        "ssh.socket",
+    ]
+
+
+def test_parse_list_units_empty_input():
+    assert _parse_list_units("") == []
+
+
+def test_parse_list_units_none_input():
+    assert _parse_list_units(None) == []
+
+
+def test_parse_list_units_skips_not_found():
+    output = (
+        "missing.service     not-found inactive dead Unit not found\n"
+        "real.service        loaded    active   running A real one\n"
+    )
+    assert _parse_list_units(output) == ["real.service"]
+
+
+def test_parse_list_units_skips_short_lines():
+    output = "tooshort\nreal.service loaded active running Real\n"
+    assert _parse_list_units(output) == ["real.service"]
+
+
+def test_parse_list_units_skips_blank_lines():
+    output = "\n\nreal.service loaded active running Real\n\n"
+    assert _parse_list_units(output) == ["real.service"]
+
+
+# ============================================================
+# _parse_show_bulk
+# ============================================================
+
+
+SHOW_BULK_TWO_UNITS = """\
+Id=nginx.service
+LoadState=loaded
+ActiveState=active
+SubState=running
+Result=success
+NRestarts=0
+ActiveEnterTimestamp=Mon 2024-01-15 10:00:00 UTC
+InactiveEnterTimestamp=
+UnitFileState=enabled
+
+Id=fail2ban.service
+LoadState=loaded
+ActiveState=failed
+SubState=failed
+Result=exit-code
+NRestarts=3
+ActiveEnterTimestamp=Mon 2024-01-15 09:00:00 UTC
+InactiveEnterTimestamp=Mon 2024-01-15 09:30:00 UTC
+UnitFileState=enabled
+"""
+
+
+def test_parse_show_bulk_two_units():
+    result = _parse_show_bulk(SHOW_BULK_TWO_UNITS)
+    assert set(result.keys()) == {"nginx.service", "fail2ban.service"}
+    assert result["nginx.service"]["ActiveState"] == "active"
+    assert result["fail2ban.service"]["NRestarts"] == "3"
+
+
+def test_parse_show_bulk_empty():
+    assert _parse_show_bulk("") == {}
+
+
+def test_parse_show_bulk_none():
+    assert _parse_show_bulk(None) == {}
+
+
+def test_parse_show_bulk_block_without_id_skipped():
+    block = (
+        "LoadState=loaded\nActiveState=active\n\nId=real.service\nLoadState=loaded\n"
+    )
+    result = _parse_show_bulk(block)
+    assert list(result.keys()) == ["real.service"]
+
+
+def test_parse_show_bulk_skips_lines_without_equals():
+    block = "Id=nginx.service\nLoadState=loaded\nNot-a-property\n"
+    result = _parse_show_bulk(block)
+    assert result["nginx.service"]["LoadState"] == "loaded"
+    assert "Not-a-property" not in result["nginx.service"]
+
+
+def test_parse_show_bulk_leading_and_trailing_blank_blocks():
+    """Stripped empty blocks are skipped (covers the early-continue path)."""
+    block = "\n\nId=nginx.service\nLoadState=loaded\n\n   \n"
+    result = _parse_show_bulk(block)
+    assert list(result.keys()) == ["nginx.service"]
+
+
+def test_parse_show_bulk_value_with_equals_sign():
+    block = "Id=nginx.service\nEnvironment=PATH=/usr/bin:/bin\n"
+    result = _parse_show_bulk(block)
+    assert result["nginx.service"]["Environment"] == "PATH=/usr/bin:/bin"
+
+
+# ============================================================
+# _parse_journalctl_failed
+# ============================================================
+
+
+def test_parse_journalctl_happy():
+    lines = [
+        json.dumps({"MESSAGE": "Failed to start nginx", "_PID": "1234"}),
+        json.dumps({"MESSAGE": "config error at line 42"}),
+    ]
+    result = _parse_journalctl_failed("\n".join(lines))
+    assert result == ["Failed to start nginx", "config error at line 42"]
+
+
+def test_parse_journalctl_empty():
+    assert _parse_journalctl_failed("") == []
+
+
+def test_parse_journalctl_none():
+    assert _parse_journalctl_failed(None) == []
+
+
+def test_parse_journalctl_malformed_json_skipped():
+    lines = [
+        "not-json",
+        json.dumps({"MESSAGE": "valid message"}),
+    ]
+    assert _parse_journalctl_failed("\n".join(lines)) == ["valid message"]
+
+
+def test_parse_journalctl_byte_array_message():
+    """journalctl emits binary messages as int arrays."""
+    msg_bytes = list(b"binary message")
+    line = json.dumps({"MESSAGE": msg_bytes})
+    assert _parse_journalctl_failed(line) == ["binary message"]
+
+
+def test_parse_journalctl_byte_array_invalid():
+    """Invalid byte arrays don't crash; they're skipped or replaced."""
+    # Wrong type inside list raises TypeError on bytes()
+    line = json.dumps({"MESSAGE": ["not-an-int"]})
+    # Should not raise; falls back to empty
+    result = _parse_journalctl_failed(line)
+    assert result == []
+
+
+def test_parse_journalctl_missing_message_key():
+    line = json.dumps({"_PID": "1234"})
+    assert _parse_journalctl_failed(line) == []
+
+
+def test_parse_journalctl_empty_message():
+    line = json.dumps({"MESSAGE": ""})
+    assert _parse_journalctl_failed(line) == []
+
+
+def test_parse_journalctl_blank_lines_skipped():
+    lines = ["", json.dumps({"MESSAGE": "real"}), "  "]
+    assert _parse_journalctl_failed("\n".join(lines)) == ["real"]
+
+
+# ============================================================
+# _parse_reverse_deps
+# ============================================================
+
+
+REVERSE_DEPS_OUTPUT = """\
+nginx.service
+├─multi-user.target
+│ └─graphical.target
+└─cloudflare-tunnel.service
+"""
+
+
+def test_parse_reverse_deps_happy():
+    deps = _parse_reverse_deps(REVERSE_DEPS_OUTPUT)
+    assert "multi-user.target" in deps
+    assert "graphical.target" in deps
+    assert "cloudflare-tunnel.service" in deps
+    # First line is the queried unit, must NOT be in deps
+    assert "nginx.service" not in deps
+
+
+def test_parse_reverse_deps_empty():
+    assert _parse_reverse_deps("") == []
+
+
+def test_parse_reverse_deps_none():
+    assert _parse_reverse_deps(None) == []
+
+
+def test_parse_reverse_deps_only_root_unit():
+    """Just the queried unit, no deps."""
+    assert _parse_reverse_deps("nginx.service\n") == []
+
+
+def test_parse_reverse_deps_dedup():
+    output = "nginx.service\n" "├─multi-user.target\n" "│ └─multi-user.target\n"
+    deps = _parse_reverse_deps(output)
+    assert deps == ["multi-user.target"]
+
+
+def test_parse_reverse_deps_skip_blank_branch_lines():
+    output = "nginx.service\n  \n└─multi-user.target\n"
+    assert _parse_reverse_deps(output) == ["multi-user.target"]
+
+
+# ============================================================
+# Exec record extraction
+# ============================================================
+
+
+def test_extract_exec_record_happy():
+    rec = _extract_exec_record(
+        " path=/usr/bin/nginx ; argv[]=/usr/bin/nginx -g daemon off ; "
+        "ignore_errors=no ; start_time=[Mon 2024-01-15] ; pid=1234 "
+    )
+    assert rec["path"] == "/usr/bin/nginx"
+    assert rec["argv"] == "/usr/bin/nginx -g daemon off"
+    assert rec["ignore_errors"] == "no"
+    assert "start_time" not in rec
+    assert "pid" not in rec
+
+
+def test_extract_exec_record_no_path_returns_none():
+    """Without path, the record is malformed."""
+    assert _extract_exec_record("argv[]=foo ; ignore_errors=no") is None
+
+
+def test_extract_exec_record_only_path():
+    """argv and ignore_errors are optional in the regex."""
+    rec = _extract_exec_record("path=/bin/true")
+    assert rec == {"path": "/bin/true"}
+
+
+def test_parse_exec_property_single_record():
+    value = "{ path=/usr/bin/foo ; argv[]=foo ; ignore_errors=no }"
+    result = _parse_exec_property(value)
+    assert result == [{"path": "/usr/bin/foo", "argv": "foo", "ignore_errors": "no"}]
+
+
+def test_parse_exec_property_multi_records():
+    value = (
+        "{ path=/usr/bin/pre ; argv[]=pre ; ignore_errors=yes } "
+        "{ path=/usr/bin/main ; argv[]=main arg ; ignore_errors=no }"
+    )
+    result = _parse_exec_property(value)
+    assert len(result) == 2
+    assert result[0]["path"] == "/usr/bin/pre"
+    assert result[1]["path"] == "/usr/bin/main"
+
+
+def test_parse_exec_property_empty_string():
+    assert _parse_exec_property("") == []
+
+
+def test_parse_exec_property_none():
+    assert _parse_exec_property(None) == []
+
+
+def test_parse_exec_property_no_braces():
+    """Malformed value with no braces returns empty list."""
+    assert _parse_exec_property("path=/bin/foo argv[]=foo") == []
+
+
+def test_parse_exec_property_record_without_path_skipped():
+    value = "{ argv[]=foo ; ignore_errors=no }"
+    assert _parse_exec_property(value) == []
+
+
+def test_exec_argv_re_terminates_at_semicolon():
+    """argv[]=value ; next-field — value should not include the semicolon."""
+    m = EXEC_ARGV_RE.search("argv[]=foo bar ; next=x")
+    assert m
+    assert m.group(1) == "foo bar"
+
+
+# ============================================================
+# Hash canonicalization
+# ============================================================
+
+
+def test_normalize_property_for_hash_exec():
+    val = "{ path=/bin/foo ; argv[]=foo arg ; ignore_errors=no }"
+    result = _normalize_property_for_hash("ExecStart", val)
+    assert result == [{"path": "/bin/foo", "argv": "foo arg", "ignore_errors": "no"}]
+
+
+def test_normalize_property_for_hash_list_sorted():
+    val = "zeta.target alpha.target middle.target"
+    assert _normalize_property_for_hash("After", val) == [
+        "alpha.target",
+        "middle.target",
+        "zeta.target",
+    ]
+
+
+def test_normalize_property_for_hash_scalar():
+    assert _normalize_property_for_hash("FragmentPath", "  /etc/foo  ") == "/etc/foo"
+
+
+def test_normalize_property_for_hash_empty_list():
+    assert _normalize_property_for_hash("After", "") == []
+
+
+def test_normalize_property_for_hash_empty_scalar():
+    assert _normalize_property_for_hash("FragmentPath", None) == ""
+
+
+def test_canonicalize_unit_strips_runtime_fields():
+    props = {
+        "Id": "nginx.service",
+        "MainPID": "1234",
+        "ExecMainStartTimestamp": "Mon 2024-01-15",
+        "InvocationID": "abc-def",
+        "FragmentPath": "/etc/systemd/system/nginx.service",
+        "ActiveState": "active",
+    }
+    canon = _canonicalize_unit(props)
+    assert "MainPID" not in canon
+    assert "ExecMainStartTimestamp" not in canon
+    assert "InvocationID" not in canon
+    assert canon["FragmentPath"] == "/etc/systemd/system/nginx.service"
+    assert canon["ActiveState"] == "active"
+
+
+def test_canonical_inventory_hash_stable():
+    """Same inventory in different insertion orders produces same hash."""
+    a = {
+        "nginx.service": {"Id": "nginx.service", "FragmentPath": "/etc/foo"},
+        "cron.service": {"Id": "cron.service", "FragmentPath": "/etc/bar"},
+    }
+    b = {
+        "cron.service": {"Id": "cron.service", "FragmentPath": "/etc/bar"},
+        "nginx.service": {"Id": "nginx.service", "FragmentPath": "/etc/foo"},
+    }
+    assert _canonical_inventory_hash(a) == _canonical_inventory_hash(b)
+
+
+def test_canonical_inventory_hash_stable_across_restarts():
+    """CRITICAL regression test: hash is identical pre and post restart.
+
+    Strip-list correctness is the contract that prevents inventory churn.
+    """
+    pre_restart = {
+        "nginx.service": {
+            "Id": "nginx.service",
+            "FragmentPath": "/etc/systemd/system/nginx.service",
+            "ExecStart": "{ path=/usr/sbin/nginx ; argv[]=nginx ; ignore_errors=no }",
+            "MainPID": "1234",
+            "ExecMainStartTimestamp": "Mon 2024-01-15 10:00:00",
+            "ExecMainStartTimestampMonotonic": "1000000",
+            "ExecMainPID": "1234",
+            "InvocationID": "old-invocation-id",
+            "StateChangeTimestamp": "Mon 2024-01-15 10:00:00",
+            "ActiveEnterTimestampMonotonic": "1000000",
+            "After": "network.target multi-user.target",
+        },
+    }
+    post_restart = {
+        "nginx.service": {
+            "Id": "nginx.service",
+            "FragmentPath": "/etc/systemd/system/nginx.service",
+            "ExecStart": "{ path=/usr/sbin/nginx ; argv[]=nginx ; ignore_errors=no }",
+            "MainPID": "5678",  # different PID
+            "ExecMainStartTimestamp": "Mon 2024-01-15 11:00:00",  # different time
+            "ExecMainStartTimestampMonotonic": "2000000",
+            "ExecMainPID": "5678",
+            "InvocationID": "new-invocation-id",  # different invocation
+            "StateChangeTimestamp": "Mon 2024-01-15 11:00:00",
+            "ActiveEnterTimestampMonotonic": "2000000",
+            "After": "network.target multi-user.target",
+        },
+    }
+    assert _canonical_inventory_hash(pre_restart) == _canonical_inventory_hash(
+        post_restart
+    )
+
+
+def test_canonical_inventory_hash_changes_on_static_field_change():
+    """If FragmentPath changes (admin edit), hash must change."""
+    base = {
+        "nginx.service": {
+            "Id": "nginx.service",
+            "FragmentPath": "/etc/systemd/system/nginx.service",
+        },
+    }
+    mutated = {
+        "nginx.service": {
+            "Id": "nginx.service",
+            "FragmentPath": "/usr/lib/systemd/system/nginx.service",
+        },
+    }
+    assert _canonical_inventory_hash(base) != _canonical_inventory_hash(mutated)
+
+
+def test_canonical_inventory_hash_after_list_reorder_stable():
+    """Reordering the After= list does not flap the hash."""
+    a = {"foo.service": {"Id": "foo.service", "After": "a.target b.target c.target"}}
+    b = {"foo.service": {"Id": "foo.service", "After": "c.target a.target b.target"}}
+    assert _canonical_inventory_hash(a) == _canonical_inventory_hash(b)
+
+
+def test_canonical_inventory_hash_empty_input():
+    """Empty inventory still produces a stable hash."""
+    assert _canonical_inventory_hash({}) == _canonical_inventory_hash({})
+
+
+# ============================================================
+# SystemdCollector.collect
+# ============================================================
+
+
+def _make_collector():
+    """Construct a collector with version and hierarchy pre-set so __init__
+    does not call the real subprocess/filesystem."""
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = "v2"
+    return SystemdCollector()
+
+
+def test_collect_happy_path():
+    coll = _make_collector()
+
+    def fake_run(args, timeout=None):
+        if args[0] == "list-units":
+            return LIST_UNITS_OUTPUT, None
+        if args[0] == "show":
+            return SHOW_BULK_TWO_UNITS, None
+        return "", None
+
+    with patch.object(coll, "_list_units", wraps=coll._list_units) as _:
+        with patch("fivenines_agent.systemd._run_systemctl", side_effect=fake_run):
+            with patch(
+                "fivenines_agent.systemd.read_unit_resources",
+                return_value={
+                    "memory_current": 1000,
+                    "cpu_usec": 500,
+                    "oom_kill_count": 0,
+                    "inception_id": 7,
+                },
+            ):
+                # Drilldown-running units would call _drilldown internally; bypass
+                # by mocking the drilldown method to a no-op for THIS test.
+                with patch.object(coll, "_drilldown_failed_units", return_value={}):
+                    result = coll.collect()
+    assert result["version"] == 252
+    assert result["cgroup"] == "v2"
+    assert len(result["units"]) == 5
+    # Find the failed unit and check fields populated
+    fail = next(u for u in result["units"] if u["name"] == "broken.service")
+    # broken.service is in LIST_UNITS_OUTPUT but not in SHOW_BULK_TWO_UNITS,
+    # so its enriched fields are defaults
+    assert fail["active_state"] == ""
+    nginx = next(u for u in result["units"] if u["name"] == "nginx.service")
+    assert nginx["active_state"] == "active"
+    assert nginx["memory_current"] == 1000
+
+
+def test_collect_list_units_error_returns_empty_with_error():
+    coll = _make_collector()
+    with patch(
+        "fivenines_agent.systemd._run_systemctl",
+        return_value=(None, {"type": "timeout", "message": "x"}),
+    ):
+        result = coll.collect()
+    assert result["units"] == []
+    assert result["drilldowns"] == {}
+    assert any(e["step"] == "list_units" for e in result["errors"])
+
+
+def test_collect_no_units_returns_empty():
+    coll = _make_collector()
+
+    def fake_run(args, timeout=None):
+        if args[0] == "list-units":
+            return "", None
+        return "", None
+
+    with patch("fivenines_agent.systemd._run_systemctl", side_effect=fake_run):
+        result = coll.collect()
+    assert result["units"] == []
+    assert result["errors"] == []
+
+
+def test_collect_show_bulk_error_logged_in_errors():
+    coll = _make_collector()
+
+    def fake_run(args, timeout=None):
+        if args[0] == "list-units":
+            return LIST_UNITS_OUTPUT, None
+        if args[0] == "show":
+            return None, {"type": "timeout", "message": "show timed out"}
+        return "", None
+
+    with patch("fivenines_agent.systemd._run_systemctl", side_effect=fake_run):
+        with patch("fivenines_agent.systemd.read_unit_resources", return_value={}):
+            result = coll.collect()
+    assert any(e["step"] == "show_bulk" for e in result["errors"])
+    # Units still returned with default-value entries
+    assert len(result["units"]) == 5
+
+
+def test_collect_invalid_unit_name_does_not_crash():
+    """If somehow an invalid unit name slips through list-units, log and continue."""
+    coll = _make_collector()
+    # Force list-units to return a bad name
+    with patch.object(coll, "_list_units", return_value=(["bad/name.service"], None)):
+        with patch.object(coll, "_show_bulk", return_value=({}, None)):
+            with patch(
+                "fivenines_agent.systemd.read_unit_resources",
+                side_effect=ValueError("invalid unit name"),
+            ):
+                with patch("fivenines_agent.systemd.log") as mock_log:
+                    result = coll.collect()
+    assert result["units"][0]["name"] == "bad/name.service"
+    assert any("invalid unit name" in str(c) for c in mock_log.call_args_list)
+
+
+def test_collect_no_cgroup_skips_resource_read():
+    """When hierarchy is None, skip cgroup reads and return units with null cgroup fields."""
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = None
+    coll = SystemdCollector()
+    with patch.object(coll, "_list_units", return_value=(["nginx.service"], None)):
+        with patch.object(
+            coll,
+            "_show_bulk",
+            return_value=(
+                {"nginx.service": {"Id": "nginx.service", "ActiveState": "active"}},
+                None,
+            ),
+        ):
+            with patch("fivenines_agent.systemd.read_unit_resources") as mock_read:
+                result = coll.collect()
+    mock_read.assert_not_called()
+    assert result["units"][0]["memory_current"] is None
+
+
+def test_collect_n_restarts_invalid_value():
+    """NRestarts that's not an int defaults to 0 without crashing."""
+    coll = _make_collector()
+    with patch.object(coll, "_list_units", return_value=(["x.service"], None)):
+        with patch.object(
+            coll,
+            "_show_bulk",
+            return_value=(
+                {"x.service": {"Id": "x.service", "NRestarts": "garbage"}},
+                None,
+            ),
+        ):
+            with patch("fivenines_agent.systemd.read_unit_resources", return_value={}):
+                result = coll.collect()
+    assert result["units"][0]["n_restarts"] == 0
+
+
+# ============================================================
+# Failure debounce (_is_newly_failed)
+# ============================================================
+
+
+def test_is_newly_failed_triggers_on_first_failure():
+    coll = _make_collector()
+    props = {"ActiveState": "failed", "NRestarts": "1", "ActiveEnterTimestamp": "T1"}
+    assert coll._is_newly_failed("foo.service", props) is True
+
+
+def test_is_newly_failed_suppresses_repeat_with_same_signature():
+    coll = _make_collector()
+    props = {"ActiveState": "failed", "NRestarts": "1", "ActiveEnterTimestamp": "T1"}
+    coll._is_newly_failed("foo.service", props)
+    # Second call with same signature should NOT trigger drilldown
+    assert coll._is_newly_failed("foo.service", props) is False
+
+
+def test_is_newly_failed_re_triggers_when_signature_changes():
+    coll = _make_collector()
+    coll._is_newly_failed(
+        "foo.service",
+        {"ActiveState": "failed", "NRestarts": "1", "ActiveEnterTimestamp": "T1"},
+    )
+    # NRestarts incremented = new failure
+    assert (
+        coll._is_newly_failed(
+            "foo.service",
+            {
+                "ActiveState": "failed",
+                "NRestarts": "2",
+                "ActiveEnterTimestamp": "T2",
+            },
+        )
+        is True
+    )
+
+
+def test_is_newly_failed_clears_cache_on_recovery():
+    coll = _make_collector()
+    coll._is_newly_failed(
+        "foo.service",
+        {"ActiveState": "failed", "NRestarts": "1", "ActiveEnterTimestamp": "T1"},
+    )
+    assert "foo.service" in SystemdCollector._last_failure_signatures
+    # Recovery
+    coll._is_newly_failed(
+        "foo.service",
+        {"ActiveState": "active", "NRestarts": "1", "ActiveEnterTimestamp": "T1"},
+    )
+    assert "foo.service" not in SystemdCollector._last_failure_signatures
+
+
+def test_is_newly_failed_lru_bound():
+    """Cache is bounded; FAILURE_SIG_MAX entries max."""
+    coll = _make_collector()
+    # Fill cache with FAILURE_SIG_MAX + 5 entries
+    for i in range(systemd.FAILURE_SIG_MAX + 5):
+        coll._is_newly_failed(
+            f"unit_{i}.service",
+            {
+                "ActiveState": "failed",
+                "NRestarts": "1",
+                "ActiveEnterTimestamp": f"T{i}",
+            },
+        )
+    assert len(SystemdCollector._last_failure_signatures) <= systemd.FAILURE_SIG_MAX
+
+
+# ============================================================
+# Drilldown
+# ============================================================
+
+
+def test_drilldown_one_combines_journal_and_deps():
+    coll = _make_collector()
+    with patch.object(coll, "_journal_tail", return_value=["error line"]):
+        with patch.object(coll, "_reverse_deps", return_value=["dep1"]):
+            result = coll._drilldown_one("nginx.service")
+    assert result == {"journal_tail": ["error line"], "reverse_deps": ["dep1"]}
+
+
+def test_drilldown_failed_units_runs_in_parallel():
+    coll = _make_collector()
+    units = ["a.service", "b.service", "c.service"]
+
+    def fake_drill(name):
+        return {"journal_tail": [name], "reverse_deps": []}
+
+    with patch.object(coll, "_drilldown_one", side_effect=fake_drill):
+        result = coll._drilldown_failed_units(units)
+    assert set(result.keys()) == set(units)
+    assert result["a.service"]["journal_tail"] == ["a.service"]
+
+
+def test_drilldown_failed_units_handles_thread_exception():
+    coll = _make_collector()
+
+    def fake_drill(name):
+        if name == "bad.service":
+            raise RuntimeError("blew up")
+        return {"journal_tail": [], "reverse_deps": []}
+
+    with patch.object(coll, "_drilldown_one", side_effect=fake_drill):
+        with patch("fivenines_agent.systemd.log"):
+            result = coll._drilldown_failed_units(["good.service", "bad.service"])
+    assert "error" in result["bad.service"]
+    assert result["bad.service"]["journal_tail"] == []
+    assert "error" not in result["good.service"]
+
+
+def test_drilldown_max_workers_capped():
+    """Worker count caps at MAX_DRILLDOWN_WORKERS for huge failure batches."""
+    coll = _make_collector()
+    units = [f"u{i}.service" for i in range(MAX_DRILLDOWN_WORKERS + 5)]
+    with patch(
+        "fivenines_agent.systemd.concurrent.futures.ThreadPoolExecutor"
+    ) as mock_exec:
+        mock_ctx = mock_exec.return_value.__enter__.return_value
+        mock_ctx.submit.return_value = MagicMock()
+        # as_completed iterates over submitted futures; emulate with empty
+        with patch(
+            "fivenines_agent.systemd.concurrent.futures.as_completed",
+            return_value=iter([]),
+        ):
+            coll._drilldown_failed_units(units)
+    args, kwargs = mock_exec.call_args
+    assert kwargs.get("max_workers") == MAX_DRILLDOWN_WORKERS
+
+
+# ============================================================
+# Journal tail + reverse deps
+# ============================================================
+
+
+def test_journal_tail_happy():
+    coll = _make_collector()
+    with patch(
+        "fivenines_agent.systemd._run_journalctl",
+        return_value=(json.dumps({"MESSAGE": "boom"}), None),
+    ):
+        result = coll._journal_tail("foo.service")
+    assert result == ["boom"]
+
+
+def test_journal_tail_error_returns_empty():
+    coll = _make_collector()
+    with patch(
+        "fivenines_agent.systemd._run_journalctl",
+        return_value=(None, {"type": "timeout", "message": "x"}),
+    ):
+        assert coll._journal_tail("foo.service") == []
+
+
+def test_reverse_deps_modern_systemd():
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = "v2"
+    coll = SystemdCollector()
+    with patch(
+        "fivenines_agent.systemd._run_systemctl",
+        return_value=(REVERSE_DEPS_OUTPUT, None),
+    ):
+        deps = coll._reverse_deps("nginx.service")
+    assert "multi-user.target" in deps
+
+
+def test_reverse_deps_centos_7_returns_none():
+    """systemd 219 < 230, capability gated off."""
+    SystemdCollector._version = 219
+    SystemdCollector._hierarchy = "v1"
+    coll = SystemdCollector()
+    assert coll._reverse_deps("nginx.service") is None
+
+
+def test_reverse_deps_no_systemd_version():
+    SystemdCollector._version = None
+    SystemdCollector._hierarchy = None
+    coll = SystemdCollector()
+    assert coll._reverse_deps("nginx.service") is None
+
+
+def test_reverse_deps_subprocess_error():
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = "v2"
+    coll = SystemdCollector()
+    with patch(
+        "fivenines_agent.systemd._run_systemctl",
+        return_value=(None, {"type": "timeout", "message": "x"}),
+    ):
+        assert coll._reverse_deps("nginx.service") is None
+
+
+def test_reverse_deps_min_version_constant():
+    assert MIN_SYSTEMD_VERSION_REVERSE_DEPS == 230
+
+
+# ============================================================
+# Inventory snapshot + sync
+# ============================================================
+
+
+def test_snapshot_inventory_happy():
+    coll = _make_collector()
+    bulk = (
+        "Id=nginx.service\n"
+        "FragmentPath=/etc/systemd/system/nginx.service\n"
+        "ExecStart={ path=/usr/sbin/nginx ; argv[]=nginx ; ignore_errors=no }\n"
+        "After=network.target\n"
+    )
+    with patch.object(coll, "_list_units", return_value=(["nginx.service"], None)):
+        with patch.object(
+            coll, "_show_bulk", return_value=(_parse_show_bulk(bulk), None)
+        ):
+            units, h, errors = coll.snapshot_inventory()
+    assert "nginx.service" in units
+    assert h is not None
+    assert errors == []
+
+
+def test_snapshot_inventory_list_units_error():
+    coll = _make_collector()
+    with patch.object(
+        coll,
+        "_list_units",
+        return_value=([], {"type": "cli_error", "message": "x"}),
+    ):
+        units, h, errors = coll.snapshot_inventory()
+    assert units == {}
+    assert h is None
+    assert any(e["step"] == "list_units" for e in errors)
+
+
+def test_snapshot_inventory_no_units():
+    coll = _make_collector()
+    with patch.object(coll, "_list_units", return_value=([], None)):
+        units, h, errors = coll.snapshot_inventory()
+    assert units == {}
+    assert h is not None  # Empty inventory still has a stable hash
+    assert errors == []
+
+
+def test_snapshot_inventory_show_bulk_partial_error():
+    coll = _make_collector()
+    with patch.object(coll, "_list_units", return_value=(["x.service"], None)):
+        with patch.object(
+            coll,
+            "_show_bulk",
+            return_value=({}, {"type": "timeout", "message": "x"}),
+        ):
+            units, h, errors = coll.snapshot_inventory()
+    assert any(e["step"] == "show_bulk_inventory" for e in errors)
+    # Still produces a (empty) hash so caller can compare
+    assert h is not None
+
+
+def test_inventory_sync_no_scan_does_nothing():
+    coll = _make_collector()
+    send_fn = MagicMock()
+    coll.inventory_sync({}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_scan_false_does_nothing():
+    coll = _make_collector()
+    send_fn = MagicMock()
+    coll.inventory_sync({"systemd": {"scan": False}}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_scan_not_dict_does_nothing():
+    coll = _make_collector()
+    send_fn = MagicMock()
+    coll.inventory_sync({"systemd": True}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_snapshot_failure_skips_send():
+    coll = _make_collector()
+    send_fn = MagicMock()
+    with patch.object(coll, "snapshot_inventory", return_value=({}, None, [])):
+        coll.inventory_sync({"systemd": {"scan": True}}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_unchanged_skips_send():
+    """When local hash, server hash, and current hash all agree, no send."""
+    coll = _make_collector()
+    send_fn = MagicMock()
+    SystemdCollector._last_local_inventory_hash = "deadbeef"
+    with patch.object(coll, "snapshot_inventory", return_value=({}, "deadbeef", [])):
+        coll.inventory_sync(
+            {"systemd": {"scan": True, "last_inventory_hash": "deadbeef"}},
+            send_fn,
+        )
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_changed_sends():
+    coll = _make_collector()
+    send_fn = MagicMock(return_value={"ok": True})
+    with patch.object(
+        coll,
+        "snapshot_inventory",
+        return_value=({"x.service": {}}, "newhash", []),
+    ):
+        coll.inventory_sync(
+            {"systemd": {"scan": True, "last_inventory_hash": "oldhash"}},
+            send_fn,
+        )
+    send_fn.assert_called_once()
+    payload = send_fn.call_args[0][0]
+    assert payload["inventory_hash"] == "newhash"
+    assert "x.service" in payload["units"]
+    assert SystemdCollector._last_local_inventory_hash == "newhash"
+
+
+def test_inventory_sync_includes_errors():
+    coll = _make_collector()
+    send_fn = MagicMock(return_value={"ok": True})
+    with patch.object(
+        coll,
+        "snapshot_inventory",
+        return_value=({}, "h", [{"step": "x", "type": "timeout", "message": "m"}]),
+    ):
+        coll.inventory_sync({"systemd": {"scan": True}}, send_fn)
+    send_fn.assert_called_once()
+    payload = send_fn.call_args[0][0]
+    assert "errors" in payload
+
+
+def test_inventory_sync_dry_run_does_not_send():
+    coll = _make_collector()
+    send_fn = MagicMock()
+    with patch.object(
+        coll,
+        "snapshot_inventory",
+        return_value=({"x.service": {}}, "h", []),
+    ):
+        with patch("fivenines_agent.systemd.dry_run", return_value=True):
+            coll.inventory_sync({"systemd": {"scan": True}}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_inventory_sync_send_failure_does_not_update_local_hash():
+    coll = _make_collector()
+    send_fn = MagicMock(return_value=None)  # send failed
+    with patch.object(
+        coll,
+        "snapshot_inventory",
+        return_value=({"x.service": {}}, "h", []),
+    ):
+        coll.inventory_sync({"systemd": {"scan": True}}, send_fn)
+    assert SystemdCollector._last_local_inventory_hash is None
+
+
+def test_inventory_sync_force_resend_sends_even_if_unchanged():
+    coll = _make_collector()
+    send_fn = MagicMock(return_value={"ok": True})
+    SystemdCollector._last_local_inventory_hash = "deadbeef"
+    with patch.object(coll, "snapshot_inventory", return_value=({}, "deadbeef", [])):
+        coll.inventory_sync(
+            {"systemd": {"scan": True, "last_inventory_hash": "deadbeef"}},
+            send_fn,
+            force_resend=True,
+        )
+    send_fn.assert_called_once()
+
+
+# ============================================================
+# Public API
+# ============================================================
+
+
+def test_systemd_metrics_no_systemctl():
+    with patch("fivenines_agent.systemd.shutil.which", return_value=None):
+        assert systemd_metrics() is None
+
+
+def test_systemd_metrics_calls_collect():
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = "v2"
+    fake_collector = MagicMock()
+    fake_collector.collect.return_value = {"units": [], "drilldowns": {}}
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd._get_collector", return_value=fake_collector
+        ):
+            result = systemd_metrics()
+    fake_collector.collect.assert_called_once()
+    assert result == {"units": [], "drilldowns": {}}
+
+
+def test_systemd_metrics_accepts_extra_kwargs():
+    """Future-proofing: extra kwargs from server config must not error."""
+    fake_collector = MagicMock()
+    fake_collector.collect.return_value = {}
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd._get_collector", return_value=fake_collector
+        ):
+            systemd_metrics(unit_types="service", future_field=True)
+
+
+def test_systemd_metrics_unit_types_recreates_collector():
+    """Changing unit_types triggers a fresh SystemdCollector instance."""
+    fake_collector_1 = MagicMock(unit_types="service,timer,socket")
+    fake_collector_1.collect.return_value = {}
+    fake_collector_2 = MagicMock(unit_types="service")
+    fake_collector_2.collect.return_value = {}
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd.SystemdCollector",
+            side_effect=[fake_collector_1, fake_collector_2],
+        ):
+            systemd_metrics(unit_types=DEFAULT_UNIT_TYPES)
+            systemd_metrics(unit_types="service")
+    fake_collector_1.collect.assert_called_once()
+    fake_collector_2.collect.assert_called_once()
+
+
+def test_systemd_inventory_sync_no_systemctl():
+    send_fn = MagicMock()
+    with patch("fivenines_agent.systemd.shutil.which", return_value=None):
+        systemd_inventory_sync({"systemd": {"scan": True}}, send_fn)
+    send_fn.assert_not_called()
+
+
+def test_systemd_inventory_sync_delegates_to_collector():
+    fake_collector = MagicMock()
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch(
+            "fivenines_agent.systemd._get_collector", return_value=fake_collector
+        ):
+            systemd_inventory_sync(
+                {"systemd": {"scan": True}}, "send_fn", force_resend=True
+            )
+    fake_collector.inventory_sync.assert_called_once_with(
+        {"systemd": {"scan": True}}, "send_fn", force_resend=True
+    )
+
+
+def test_force_inventory_resend_clears_local_hash():
+    SystemdCollector._last_local_inventory_hash = "abc"
+    force_inventory_resend()
+    assert SystemdCollector._last_local_inventory_hash is None
+
+
+def test_reset_collector_clears_singleton_and_class_state():
+    SystemdCollector._version = 252
+    SystemdCollector._hierarchy = "v2"
+    SystemdCollector._last_local_inventory_hash = "h"
+    SystemdCollector._last_failure_signatures["foo"] = "sig"
+    # Force the module-level singleton to be set
+    with patch(
+        "fivenines_agent.systemd.shutil.which", return_value="/usr/bin/systemctl"
+    ):
+        with patch.object(SystemdCollector, "collect", return_value={}):
+            systemd_metrics()
+    assert systemd._collector is not None
+    reset_collector()
+    assert systemd._collector is None
+    assert SystemdCollector._version is None
+    assert SystemdCollector._hierarchy is None
+    assert SystemdCollector._last_local_inventory_hash is None
+    assert SystemdCollector._last_failure_signatures == {}


### PR DESCRIPTION
## Summary

Adds a new collector for systemd-based hosts that exposes per-unit health every tick plus a hash-delta-synced inventory snapshot. Designed to answer "which service is broken, why, and what's the blast radius?" without bloating payloads on idle hosts.

### Per-tick health (`.service`, `.timer`, `.socket`)
- `state` / `sub_state` / `result` / `NRestarts`
- `unit_file_state` for mask drift detection (security signal)
- `cgroup memory.current`, `cpu.stat usage_usec`, `oom_kill` count + `cgroup_inception_id` so backend can detect counter resets across unit restarts

### Failure drilldown (newly-failed units only, parallel via `ThreadPoolExecutor`)
- 5-line journal tail at `err` priority via `journalctl --output=json`
- Reverse dependency map (gated on systemd >= 230; CentOS 7 systemd 219 receives `null`)
- Debounced by `(NRestarts, ActiveEnterTimestamp)` signature so a unit stuck in `failed` doesn't re-ship the same payload every tick

### Inventory snapshot (delta-synced)
- Mirrors the `packages.py` hash-delta pattern: SHA-256 of canonical inventory; only sent when changed
- Canonicalization strips runtime-mutating fields (`MainPID`, `ExecMainStartTimestamp`, `InvocationID`, etc.) and reduces `Exec*=` records to `(path, argv, ignore_errors)` so the hash stays stable across service restarts
- SIGHUP clears the local hash to force a fresh snapshot resend, piggybacking on the existing `refresh_permissions_event` handler

### Supporting changes
- New `fivenines_agent/cgroup.py`: v1/v2/hybrid hierarchy detection + safe per-unit metric reads. `EACCES` on cgroup files is treated as the expected capability gap (silent `None`, no log spam). Defense in depth: rejects unit names containing `/` or null bytes before path construction.
- `permissions.py`: new `systemd` capability (probes `/run/systemd/system` + `systemctl --version`) and tri-state `cgroup` capability (`v1`/`v2`/`None`). Banner places `cgroup` under Hardware Sensors and `systemd` under Services.
- `synchronizer.py`: new `send_systemd_inventory()` posting to `/systemd_inventory`.

### Performance
Bulk subprocess strategy keeps fork count bounded: one `list-units` + one `systemctl show` for all units per tick. Worst-case 800-unit host with 50 newly-failed: ~7 forks per tick (10-worker drilldown pool). Steady-state idle: 2 forks per tick.

### Compatibility
- CentOS 7 (systemd 219, cgroup v1): everything works except OOM count (returns `null`) and reverse-deps (returns `null`).
- Alpine OpenRC: capability probe returns false, no payload sent, no errors logged.
- Containers without their own systemd: same.

## Test plan

- [x] `make test` equivalent: 447/447 tests pass
- [x] Coverage: 100% on `cgroup.py` and `systemd.py`
- [x] 169 new tests including the critical regression for hash stability across restart (`test_canonical_inventory_hash_stable_across_restarts`) which mutates `MainPID`, `ExecMainStartTimestamp`, and `InvocationID` and asserts the hash is unchanged
- [x] Path traversal rejection (`test_unit_path_rejects_path_traversal`)
- [x] Silent EACCES on cgroup files (`test_read_memory_current_permission_denied_silent`)
- [x] CentOS 7 graceful degradation (`test_reverse_deps_centos_7_returns_none`)
- [x] SIGHUP forces inventory resend (`test_handle_permission_refresh_sets_force_flag_on_sighup`); periodic 5-min re-probe does NOT (`test_handle_permission_refresh_periodic_does_not_force_resend`)
- [x] Bulk drilldown caps at `MAX_DRILLDOWN_WORKERS=10`
- [x] `isort --profile=black`, `black`, `flake8 --ignore=W503,E501`, `mypy`, `bandit -s B608` all clean on new code (pre-existing flake8 issues on `main` untouched)

### Manual on-host verification (post-merge):
- [ ] Run on Ubuntu 22+ (cgroup v2): per-unit memory + cpu + oom_kill populated
- [ ] Run on CentOS 7: per-unit memory + cpu populated, oom_kill and reverse_deps null
- [ ] Run on Alpine 3.18 (OpenRC): no payload, no errors
- [ ] Trigger `systemctl restart nginx` x5 between ticks: payload omits inventory (hash stable)
- [ ] `kill -HUP <agent>`: next tick payload includes inventory
- [ ] `systemctl mask cron`: next tick payload includes inventory (UnitFileState changed)

## Deferred

Three P3 items added to TODOS.md:
- User-mode systemd (`systemctl --user`)
- Event-driven D-Bus subscription (rejected for binary-build constraint)
- OOM journal-parse fallback for cgroup v1