### PR TITLE
CI: Remove broken Cloudflare cache purge step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -863,15 +863,3 @@ jobs:
           echo "  - https://releases.fivenines.io/latest/fivenines-agent.service"
           echo "  - https://releases.fivenines.io/latest/fivenines-agent.openrc"
           echo "  - https://releases.fivenines.io/latest/fivenines_script.sh"
-
-      - name: Purge Cloudflare cache for /latest/
-        run: |
-          FILES_JSON=$(ls r2-upload/latest/ | jq -R '"https://releases.fivenines.io/latest/" + .' | jq -s '{"files": .}')
-          curl -sf -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-            --data "$FILES_JSON"
-        env:
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the `Purge Cloudflare cache for /latest/` step from `.github/workflows/build-release.yml` (release-sync job). The step has been broken and provides no value while broken.

## Why this is safe

The rclone upload step immediately above (line ~851) already sets the correct cache headers on the `/latest/` sync:

```
--header-upload "Cache-Control: no-cache, must-revalidate"
```

That tells Cloudflare's edge to revalidate against the R2 origin on every request to `/latest/*`, so a fresh release is served as soon as the upload completes. The explicit purge call was a belt-and-suspenders, and it wasn't working anyway.

Versioned releases under `/${VERSION}/` are unchanged (still immutable, max-age=31536000) and don't need purging by design.

## What I removed

```diff
-      - name: Purge Cloudflare cache for /latest/
-        run: |
-          FILES_JSON=$(ls r2-upload/latest/ | jq -R '"https://releases.fivenines.io/latest/" + .' | jq -s '{"files": .}')
-          curl -sf -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-            --data "$FILES_JSON"
-        env:
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
```

## Follow-up (out of scope)

If we want explicit purging back in the future, options:

1. Use the official `cloudflare/wrangler-action` instead of a raw `curl` against the v4 API.
2. Or rely entirely on the existing `no-cache, must-revalidate` headers (current PR's stance — purge isn't actually needed).

The `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` secrets are still defined in repo settings but are no longer referenced. They can stay until we decide whether to bring purging back, or be cleaned up in a separate housekeeping PR.

## Test plan

- [x] YAML syntax check: file still parses (no leftover indentation issues, end-of-file is clean)
- [ ] Next release run: the release-sync job should succeed end-to-end without the purge step failing