### PR TITLE
v1.6.1

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.6.0"
+version = "1.6.1"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"


### PR DESCRIPTION
## Summary

Release v1.6.1 — bumps version in `pyproject.toml` and `fivenines_agent/cli.py`.

## What's in this release

- **Fix: Proxmox QEMU disk_read and disk_write always 0** ([#39](https://github.com/Five-Nines-io/fivenines_agent/pull/39))
  Adds `?full=1` to the QEMU listing API call so Proxmox actually returns disk I/O counters. Also adds null coercion across all four collectors and backfills `proxmox.py` test coverage from ~5% to 100% (79 specs).

- **CI: Remove broken Cloudflare cache purge step** ([#40](https://github.com/Five-Nines-io/fivenines_agent/pull/40))
  The R2 sync step already sets `Cache-Control: no-cache, must-revalidate` on `/latest/`, so the explicit purge call was redundant — and it was failing.

## Post-merge

After this PR merges, tag the release:

```bash
git fetch origin main
git tag v1.6.1 origin/main
git push origin v1.6.1
```

The tag push will trigger the release workflow (`.github/workflows/build-release.yml`) which builds binaries, publishes to GHCR + R2, and updates `releases.fivenines.io/latest/`.

## Test plan

- [x] Both fixes already merged to main and shipping in this release
- [ ] Tag pushed after merge → release workflow builds and publishes successfully
- [ ] `releases.fivenines.io/latest/` serves the new binaries (R2 sync + cache headers handle this without explicit purge)