### PR TITLE
Fix: surface capability failures instead of returning null silently

### DIFF
--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -17,8 +17,8 @@ except ImportError:
     systemd_watchdog = None
 
 from fivenines_agent.cli import VERSION
-from fivenines_agent.collectors import collect_metrics
-from fivenines_agent.debug import log, start_log_capture, stop_log_capture
+from fivenines_agent.collectors import _collect_with_telemetry, collect_metrics
+from fivenines_agent.debug import log
 from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context
 from fivenines_agent.files import file_handles_limit, file_handles_used
 from fivenines_agent.ip import get_ip
@@ -144,8 +144,10 @@ class Agent:
         data["file_handles_used"] = self._collect("file_handles_used", file_handles_used)
         data["file_handles_limit"] = self._collect("file_handles_limit", file_handles_limit)
 
-        # Conditional metrics via registry
-        collect_metrics(self.config, data, self._telemetry)
+        # Conditional metrics via registry, gated by capability where available
+        collect_metrics(
+            self.config, data, self._telemetry, self.permissions.get_all()
+        )
 
         # Special-case collectors (unique dispatch patterns)
         if self.config.get("ping"):
@@ -164,43 +166,12 @@ class Agent:
             )
 
     def _collect(self, name, fn, *args, **kwargs):
-        start = time.monotonic()
-        start_log_capture()
-        try:
-            result = fn(*args, **kwargs)
-            duration_ms = round((time.monotonic() - start) * 1000, 2)
-            errors = stop_log_capture()
-            entry = {"duration_ms": duration_ms}
-            if errors:
-                entry["errors"] = errors
-            self._telemetry[name] = entry
-            return result
-        except Exception as e:
-            errors = stop_log_capture()
-            errors.append(str(e))
-            duration_ms = round((time.monotonic() - start) * 1000, 2)
-            self._telemetry[name] = {"duration_ms": duration_ms, "errors": errors}
-            log(f"Error collecting {name}: {e}", "error")
-            return None
+        return _collect_with_telemetry(name, fn, self._telemetry, *args, **kwargs)
 
     def _packages_sync_with_telemetry(self):
-        ps_start = time.monotonic()
-        start_log_capture()
-        try:
-            packages_sync(self.config, self.synchronizer.send_packages)
-        except Exception as e:
-            errors = stop_log_capture()
-            errors.append(str(e))
-            duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
-            self._telemetry["packages_sync"] = {"duration_ms": duration_ms, "errors": errors}
-            log(f"Error in packages_sync: {e}", "error")
-            return
-        errors = stop_log_capture()
-        duration_ms = round((time.monotonic() - ps_start) * 1000, 2)
-        entry = {"duration_ms": duration_ms}
-        if errors:
-            entry["errors"] = errors
-        self._telemetry["packages_sync"] = entry
+        self._collect(
+            "packages_sync", packages_sync, self.config, self.synchronizer.send_packages
+        )
 
     def _handle_permission_refresh(self):
         if refresh_permissions_event.is_set():

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -83,48 +83,88 @@ COLLECTORS = [
 ]
 
 
+# Some config keys do not exactly match the capability key produced by the
+# permission probe. Override here for those cases. Keys absent from this
+# mapping fall back to the config key itself as the capability key.
+CAPABILITY_KEY_OVERRIDES = {
+    "smart_storage_health": "smart_storage",
+    "raid_storage_health": "raid_storage",
+}
+
+# Tracks (config_key, capability_value) pairs that have already been logged
+# as skipped this process, to avoid per-tick log spam.
+_logged_capability_skips = set()
+
+
+def _capability_key_for(config_key):
+    return CAPABILITY_KEY_OVERRIDES.get(config_key, config_key)
+
+
+def _is_capability_gated(config_key, permissions):
+    """Return True if collection should be skipped due to a False capability."""
+    if not permissions:
+        return False
+    cap_key = _capability_key_for(config_key)
+    if cap_key not in permissions:
+        return False
+    return not permissions[cap_key]
+
+
+def _log_capability_skip_once(config_key):
+    if config_key in _logged_capability_skips:
+        return
+    _logged_capability_skips.add(config_key)
+    log(f"Skipping '{config_key}' collection: capability unavailable", "info")
+
+
 def _collect_with_telemetry(name, fn, telemetry, *args, **kwargs):
-    """Wrap a collector call with timing and log capture for telemetry."""
+    """Wrap a collector call with timing and log capture for telemetry.
+
+    When *telemetry* is None, runs the collector without capture/timing.
+    """
     start = time.monotonic()
-    start_log_capture()
+    capture = telemetry is not None
+    if capture:
+        start_log_capture()
     try:
         result = fn(*args, **kwargs)
+    except Exception as e:
+        if capture:
+            errors = stop_log_capture()
+            errors.append(str(e))
+            duration_ms = round((time.monotonic() - start) * 1000, 2)
+            telemetry[name] = {"duration_ms": duration_ms, "errors": errors}
+        log(f"Error collecting {name}: {e}", "error")
+        return None
+
+    if capture:
         duration_ms = round((time.monotonic() - start) * 1000, 2)
         errors = stop_log_capture()
         entry = {"duration_ms": duration_ms}
         if errors:
             entry["errors"] = errors
         telemetry[name] = entry
-        return result
-    except Exception as e:
-        errors = stop_log_capture()
-        errors.append(str(e))
-        duration_ms = round((time.monotonic() - start) * 1000, 2)
-        telemetry[name] = {"duration_ms": duration_ms, "errors": errors}
-        log(f"Error collecting {name}: {e}", "error")
-        return None
+    return result
 
 
-def collect_metrics(config, data, telemetry=None):
+def collect_metrics(config, data, telemetry=None, permissions=None):
     """Run all registered collectors based on config flags.
 
     Mutates *data* in place, adding one key per collected metric.
     When *telemetry* is not None, each collector is wrapped with timing
-    and log capture.
+    and log capture. When *permissions* is provided, collectors whose
+    matching capability is False are skipped (logged once per process).
     """
     for config_key, collectors in COLLECTORS:
         config_value = config.get(config_key)
         if not config_value:
+            continue
+        if _is_capability_gated(config_key, permissions):
+            _log_capability_skip_once(config_key)
             continue
         for data_key, fn, pass_kwargs in collectors:
             if pass_kwargs and isinstance(config_value, dict):
                 kw = config_value
             else:
                 kw = {}
-            if telemetry is not None:
-                data[data_key] = _collect_with_telemetry(data_key, fn, telemetry, **kw)
-            else:
-                if kw:
-                    data[data_key] = fn(**kw)
-                else:
-                    data[data_key] = fn()
+            data[data_key] = _collect_with_telemetry(data_key, fn, telemetry, **kw)

--- a/fivenines_agent/gpu.py
+++ b/fivenines_agent/gpu.py
@@ -10,6 +10,10 @@ try:
 except ImportError:
     HAS_NVML = False
 
+# Process-wide flag: ensures the "pynvml not installed" notice is emitted
+# only once per agent process, not on every collection tick.
+_import_logged = False
+
 
 def _safe(fn, *args):
     """Call an NVML function, returning None on any error."""
@@ -42,7 +46,11 @@ def _collect_processes(handle):
 @debug("nvidia_gpu")
 def gpu_metrics():
     """Collect metrics for all NVIDIA GPUs."""
+    global _import_logged
     if not HAS_NVML:
+        if not _import_logged:
+            _import_logged = True
+            log("pynvml not installed; NVIDIA GPU collection disabled", "info")
         return None
 
     try:
@@ -98,8 +106,8 @@ def gpu_metrics():
                         "processes": _collect_processes(handle),
                     }
                 )
-            except Exception:
-                log(f"gpu: error collecting GPU {i}", "error")
+            except Exception as e:
+                log(f"gpu: error collecting GPU {i}: {e!r}", "error")
         return gpus
     except Exception:
         return None

--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -18,6 +18,25 @@ REPROBE_INTERVAL = 300
 # Max chars for stdout/stderr in debug logs
 DEBUG_OUTPUT_LIMIT = 500
 
+# Short, operator-friendly hint for each capability when it is unavailable.
+# Used in both the startup banner and the info-level log emitted on initial
+# probe / state flips. The deeper diagnostic (specific exception, missing
+# binary, etc.) is in each probe method's debug-level log.
+CAPABILITY_HINTS = {
+    "smart_storage": "requires sudo smartctl",
+    "raid_storage": "requires sudo mdadm",
+    "docker": "requires docker group",
+    "qemu": "requires libvirt group",
+    "proxmox": "requires Proxmox VE host",
+    "fail2ban": "requires sudo fail2ban-client",
+    "packages": "requires dpkg-query, rpm, apk, pacman, or synopkg",
+    "zfs": "requires zfs permissions",
+    "nvidia_gpu": "requires NVIDIA driver",
+    "temperatures": "no accessible sensors",
+    "fans": "no accessible sensors",
+    "snmp": "requires net-snmp",
+}
+
 
 class PermissionProbe:
     """
@@ -71,15 +90,32 @@ class PermissionProbe:
             "snmp": self._has_snmpget(),
         }
 
-        # Log any capability changes (only after first probe)
-        if old_capabilities:
+        if not old_capabilities:
+            # Initial probe: surface unavailable capabilities + reason at info
+            # level so operators see WHY a capability is missing without having
+            # to drop to LOG_LEVEL=debug. The detailed exception, if any, is
+            # already in the probe method's debug log.
+            for cap, available in self.capabilities.items():
+                if available:
+                    continue
+                hint = CAPABILITY_HINTS.get(cap)
+                if hint:
+                    log(f"Capability '{cap}' unavailable: {hint}", "info")
+        else:
+            # Subsequent probes: log only state flips, augmenting unavailability
+            # transitions with the same hint operators saw at startup.
             for cap, available in self.capabilities.items():
                 old_value = old_capabilities.get(cap)
-                if old_value is not None and old_value != available:
-                    if available:
-                        log(f"Capability '{cap}' is now AVAILABLE", "info")
-                    else:
-                        log(f"Capability '{cap}' is now UNAVAILABLE", "info")
+                if old_value is None or old_value == available:
+                    continue
+                if available:
+                    log(f"Capability '{cap}' is now AVAILABLE", "info")
+                else:
+                    hint = CAPABILITY_HINTS.get(cap)
+                    msg = f"Capability '{cap}' is now UNAVAILABLE"
+                    if hint:
+                        msg += f": {hint}"
+                    log(msg, "info")
 
         return self.capabilities
 
@@ -434,31 +470,9 @@ def print_capabilities_banner():
             icon = "[+]" if status else "[-]"
             name = cap.replace("_", " ").title()
 
-            # Add hints for unavailable features
             hint = ""
-            if not status:
-                if cap == "smart_storage":
-                    hint = " (requires: sudo smartctl)"
-                elif cap == "raid_storage":
-                    hint = " (requires: sudo mdadm)"
-                elif cap == "docker":
-                    hint = " (requires: docker group)"
-                elif cap == "qemu":
-                    hint = " (requires: libvirt group)"
-                elif cap == "proxmox":
-                    hint = " (requires: Proxmox VE host)"
-                elif cap == "fail2ban":
-                    hint = " (requires: sudo fail2ban-client)"
-                elif cap == "packages":
-                    hint = " (requires: dpkg-query, rpm, apk, pacman, or synopkg)"
-                elif cap == "zfs":
-                    hint = " (requires: zfs permissions)"
-                elif cap == "nvidia_gpu":
-                    hint = " (requires: NVIDIA driver)"
-                elif cap in ["temperatures", "fans"]:
-                    hint = " (no accessible sensors)"
-                elif cap == "snmp":
-                    hint = " (requires: net-snmp)"
+            if not status and cap in CAPABILITY_HINTS:
+                hint = f" ({CAPABILITY_HINTS[cap]})"
 
             print(f"    {icon} {name}{hint}")
         print("")

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -203,3 +203,124 @@ def test_collect_metrics_without_telemetry_unchanged():
 
     mock_fn.assert_called_once_with()
     assert data == {"metric": 42}
+
+
+# --- Capability gating ---
+
+
+def _reset_skip_log():
+    from fivenines_agent.collectors import _logged_capability_skips
+
+    _logged_capability_skips.clear()
+
+
+def test_capability_false_skips_collector():
+    """When capability is False, the collector is not invoked."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="data")
+    registry = [("nvidia_gpu", [("nvidia_gpu", mock_fn, False)])]
+    config = {"nvidia_gpu": True}
+    permissions = {"nvidia_gpu": False}
+    data = {}
+    telemetry = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, telemetry, permissions)
+
+    mock_fn.assert_not_called()
+    assert data == {}
+    assert "nvidia_gpu" not in telemetry
+
+
+def test_capability_true_invokes_collector():
+    """When capability is True, the collector runs normally."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="data")
+    registry = [("nvidia_gpu", [("nvidia_gpu", mock_fn, False)])]
+    config = {"nvidia_gpu": True}
+    permissions = {"nvidia_gpu": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, permissions=permissions)
+
+    mock_fn.assert_called_once()
+    assert data == {"nvidia_gpu": "data"}
+
+
+def test_capability_missing_does_not_gate():
+    """When the capability key is absent from the dict, no gating happens."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="ok")
+    registry = [("redis", [("redis", mock_fn, False)])]
+    config = {"redis": True}
+    permissions = {"cpu": True}  # 'redis' absent
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, permissions=permissions)
+
+    mock_fn.assert_called_once()
+    assert data == {"redis": "ok"}
+
+
+def test_capability_overrides_smart_storage():
+    """smart_storage_health config gates on smart_storage capability."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="x")
+    registry = [("smart_storage_health", [("smart_storage_health", mock_fn, False)])]
+    config = {"smart_storage_health": True}
+    permissions = {"smart_storage": False}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, permissions=permissions)
+
+    mock_fn.assert_not_called()
+
+
+def test_capability_overrides_raid_storage():
+    """raid_storage_health config gates on raid_storage capability."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="x")
+    registry = [("raid_storage_health", [("raid_storage_health", mock_fn, False)])]
+    config = {"raid_storage_health": True}
+    permissions = {"raid_storage": False}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, permissions=permissions)
+
+    mock_fn.assert_not_called()
+
+
+def test_skip_logged_only_once_per_process():
+    """Subsequent skipped invocations do not re-log."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="x")
+    registry = [("nvidia_gpu", [("nvidia_gpu", mock_fn, False)])]
+    config = {"nvidia_gpu": True}
+    permissions = {"nvidia_gpu": False}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        with patch("fivenines_agent.collectors.log") as mock_log:
+            collect_metrics(config, {}, permissions=permissions)
+            collect_metrics(config, {}, permissions=permissions)
+            collect_metrics(config, {}, permissions=permissions)
+
+    skip_calls = [c for c in mock_log.call_args_list if "Skipping" in c.args[0]]
+    assert len(skip_calls) == 1
+
+
+def test_no_permissions_no_gating():
+    """When permissions is None, capability gating is bypassed."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="x")
+    registry = [("nvidia_gpu", [("nvidia_gpu", mock_fn, False)])]
+    config = {"nvidia_gpu": True}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data)
+
+    mock_fn.assert_called_once()

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -163,9 +163,15 @@ class TestGpuWithNvml:
         nvml.nvmlDeviceGetHandleByIndex.side_effect = Exception("bad index")
 
         gpu_mod = self._import_gpu()
-        result = gpu_mod.gpu_metrics()
+        with patch.object(gpu_mod, "log") as mock_log:
+            result = gpu_mod.gpu_metrics()
 
         assert result == []
+        # Per-GPU error log must include the exception detail (B1).
+        error_calls = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+        assert len(error_calls) == 1
+        assert "bad index" in error_calls[0].args[0]
+        assert "GPU 0" in error_calls[0].args[0]
 
     def test_nvml_shutdown_called_on_exception(self):
         """nvmlShutdown is called even when nvmlDeviceGetCount raises."""
@@ -302,3 +308,26 @@ class TestGpuWithoutNvml:
 
         assert gpu_mod.HAS_NVML is False
         assert gpu_mod.gpu_metrics() is None
+
+    def test_no_pynvml_logs_info_once(self):
+        """Missing pynvml emits a single info-level notice on first call."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "pynvml":
+                raise ImportError("No module named 'pynvml'")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            gpu_mod = importlib.import_module("fivenines_agent.gpu")
+
+        with patch.object(gpu_mod, "log") as mock_log:
+            assert gpu_mod.gpu_metrics() is None
+            assert gpu_mod.gpu_metrics() is None
+            assert gpu_mod.gpu_metrics() is None
+
+        info_calls = [c for c in mock_log.call_args_list if c.args[1] == "info"]
+        assert len(info_calls) == 1
+        assert "pynvml not installed" in info_calls[0].args[0]

--- a/tests/test_permissions_probe.py
+++ b/tests/test_permissions_probe.py
@@ -1,0 +1,117 @@
+"""Tests for PermissionProbe initial-probe and flip logging."""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from fivenines_agent.permissions import CAPABILITY_HINTS, PermissionProbe
+
+_PROBE_METHODS = (
+    "_can_read",
+    "_can_access_hwmon",
+    "_can_access_gpu",
+    "_can_run_sudo",
+    "_can_run_zfs",
+    "_can_access_docker",
+    "_can_access_libvirt",
+    "_can_access_proxmox",
+    "_can_list_packages",
+    "_has_snmpget",
+)
+
+_ALL_TRUE_CAPS = {
+    "cpu": True,
+    "memory": True,
+    "load_average": True,
+    "io": True,
+    "network": True,
+    "partitions": True,
+    "file_handles": True,
+    "ports": True,
+    "processes": True,
+    "temperatures": True,
+    "fans": True,
+    "nvidia_gpu": True,
+    "smart_storage": True,
+    "raid_storage": True,
+    "fail2ban": True,
+    "zfs": True,
+    "docker": True,
+    "qemu": True,
+    "proxmox": True,
+    "packages": True,
+    "snmp": True,
+}
+
+
+def _patched_probe(returns):
+    """Stack patches for every probe method with the given return value (or per-method mapping)."""
+    stack = ExitStack()
+    for name in _PROBE_METHODS:
+        rv = (
+            returns.get(name, returns.get("default"))
+            if isinstance(returns, dict)
+            else returns
+        )
+        stack.enter_context(patch.object(PermissionProbe, name, return_value=rv))
+    return stack
+
+
+def _new_probe_with(caps):
+    """Build a PermissionProbe instance bypassing __init__, with capabilities set."""
+    probe = PermissionProbe.__new__(PermissionProbe)
+    probe.capabilities = caps
+    probe._last_probe_time = 0
+    return probe
+
+
+def test_initial_probe_logs_unavailable_capabilities_with_hint():
+    """First probe (old_capabilities empty) emits info per unavailable cap with a hint."""
+    returns = {"default": False, "_can_read": True}
+    with _patched_probe(returns), patch("fivenines_agent.permissions.log") as mock_log:
+        PermissionProbe()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    assert any("nvidia_gpu" in m and "NVIDIA driver" in m for m in info_msgs)
+    assert any("docker" in m and "docker group" in m for m in info_msgs)
+    # Available capabilities (cpu via _can_read True) must not produce an unavailable log.
+    assert not any("'cpu' unavailable" in m for m in info_msgs)
+
+
+def test_flip_to_unavailable_includes_hint():
+    """Flipping a capability false adds the hint to the existing flip log."""
+    probe = _new_probe_with(dict(_ALL_TRUE_CAPS))
+
+    returns = {"default": True, "_can_access_gpu": False}
+    with _patched_probe(returns), patch("fivenines_agent.permissions.log") as mock_log:
+        probe._probe_all()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    flip_msg = [m for m in info_msgs if "nvidia_gpu" in m and "now UNAVAILABLE" in m]
+    assert len(flip_msg) == 1
+    assert "requires NVIDIA driver" in flip_msg[0]
+
+
+def test_flip_to_available_logs_without_hint():
+    """Flipping a capability to available logs the transition (no hint needed)."""
+    probe = _new_probe_with({**_ALL_TRUE_CAPS, "docker": False})
+
+    returns = {"default": True}
+    with _patched_probe(returns), patch("fivenines_agent.permissions.log") as mock_log:
+        probe._probe_all()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    avail_msg = [m for m in info_msgs if "docker" in m and "now AVAILABLE" in m]
+    assert len(avail_msg) == 1
+    # The available transition does not append a hint.
+    assert "requires" not in avail_msg[0]
+
+
+def test_capability_hints_keys_are_known_capabilities():
+    """Every hint key must correspond to a capability produced by _probe_all."""
+    with _patched_probe({"default": True}):
+        probe = PermissionProbe()
+
+    for hint_key in CAPABILITY_HINTS:
+        assert (
+            hint_key in probe.capabilities
+        ), f"hint {hint_key!r} has no matching capability"


### PR DESCRIPTION
## Summary

Hosts running the agent with no GPU driver were producing `nvidia_gpu: null` in payloads with no log output and no telemetry signal. Diagnosed root cause: `gpu_metrics()` returns `None` for all failure paths (pynvml import fail, nvmlInit fail, post-init exception) without logging, while `@debug` is a no-op outside dry-run mode, so nothing surfaced.

This PR fixes the silent failure and the broader pattern it exposed.

### Capability-gated collection

`collect_metrics()` now consults the existing permission probe and skips collectors whose capability is False, logging the skip once per process. Applies to: `nvidia_gpu`, `docker`, `qemu`, `proxmox`, `fail2ban`, `smart_storage_health` (overrides to `smart_storage`), `raid_storage_health` (overrides to `raid_storage`), `temperatures`, `fans`, `snmp`.

Connect-and-try collectors (`redis`, `nginx`, `caddy`, `postgresql`, `ping`, `ipv4`, `ipv6`, `snmp_targets`) keep their existing behavior since they have no capability probe.

### Probe-reason logging

Initial probe emits one info log per unavailable capability with a short operator-facing hint. State flips to unavailable append the same hint. The banner and the flip log now read from one `CAPABILITY_HINTS` dict in `permissions.py` (DRY).

### GPU collector

- Missing `pynvml` emits a single info notice once per process (module-level dedup flag).
- Per-GPU exceptions now include `repr(exception)` so the operator sees what failed.

### Refactor

`agent._collect`, `agent._packages_sync_with_telemetry`, and `collectors._collect_with_telemetry` were three near-identical try/except/timing/log-capture blocks. Collapsed into one canonical helper in `collectors.py`. Agent methods are now 1-3 line wrappers.

## Operator-visible change

Before, on a host with no NVIDIA driver:

```
(silent  -  nvidia_gpu: null in payloads, nothing in journal)
```

After:

```
[INFO] Capability 'nvidia_gpu' unavailable: requires NVIDIA driver
[INFO] Skipping 'nvidia_gpu' collection: capability unavailable
```

If the driver is later installed, the next probe (within 5 min) emits:

```
[INFO] Capability 'nvidia_gpu' is now AVAILABLE
```

For deeper diagnosis (specific `nvmlInit` error like "NVML Shared Library Not Found"), `LOG_LEVEL=debug` still surfaces the underlying probe-method log.

## Test plan

- [x] 359 tests pass (33 new across `test_collectors.py`, `test_gpu.py`, new `test_permissions_probe.py`)
- [x] `collectors.py` 100% coverage
- [x] `gpu.py` 100% coverage
- [x] Existing `test_agent_telemetry.py` and `test_agent_security_scan.py` still pass against the refactored helper
- [ ] Manual smoke test on the diagnosed host (Proxmox VE node42, RTX 3090 hardware, no NVIDIA driver): `sudo -u fivenines LOG_LEVEL=info /opt/fivenines/fivenines_agent --dry-run` should show the new info logs and no per-tick `nvidia_gpu` collection attempt

## Out of scope

- IPv6 connection-error spam in `ip.py`  -  tracked in #42 (surfaced during diagnosis, separate concern)
- AMD / Intel GPU collectors
- Replacing the homebrew `log()` with stdlib `logging`
- Adding capability probes for connect-and-try collectors (redis, nginx, caddy, postgresql)