### PR TITLE
v1.6.2

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.6.1'
+VERSION = '1.6.2'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.6.1"
+version = "1.6.2"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"


### PR DESCRIPTION
Patch release.

## Included since v1.6.1

- #43 Fix: surface capability failures instead of returning null silently

Once merged, push the `v1.6.2` tag to trigger the build-release workflow:

```
git tag v1.6.2 <merge-commit-sha>
git push origin v1.6.2
```

The release notes are auto-generated from merged PRs by `softprops/action-gh-release@v2`.