### PR TITLE
Feature: include capability failure reasons in logs and API payloads

### DIFF
--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -73,6 +73,7 @@ class Agent:
             "uname": platform.uname()._asdict(),
             "boot_time": psutil.boot_time(),
             "capabilities": self.permissions.get_all(),
+            "capability_reasons": self.permissions.get_reasons(),
             "user_context": get_user_context(CONFIG_DIR),
         }
 
@@ -178,9 +179,11 @@ class Agent:
             refresh_permissions_event.clear()
             self.permissions.force_refresh()
             self.static_data["capabilities"] = self.permissions.get_all()
+            self.static_data["capability_reasons"] = self.permissions.get_reasons()
             print_capabilities_banner()
         elif self.permissions.refresh_if_needed():
             self.static_data["capabilities"] = self.permissions.get_all()
+            self.static_data["capability_reasons"] = self.permissions.get_reasons()
 
     def _wait_interval(self, running_time):
         log(f"Running time: {running_time:.3f}s", "debug")

--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -46,8 +46,32 @@ class PermissionProbe:
 
     def __init__(self):
         self.capabilities = {}
+        # Maps capability name -> short reason string for the most recent
+        # False result. Probe methods record their failure cause via
+        # _set_reason(); _probe() captures it into this dict and clears it
+        # when the capability flips back to True.
+        self._capability_reasons = {}
+        self._current_reason = None
         self._last_probe_time = 0
         self._probe_all()
+
+    def _set_reason(self, msg):
+        """Called by probe methods on a False-return path to record why."""
+        self._current_reason = msg
+
+    def _probe(self, cap_name, probe_callable, *args):
+        """Run a probe method and capture its failure reason if any.
+
+        Probes run sequentially in _probe_all, so the single-slot
+        _current_reason register is safe.
+        """
+        self._current_reason = None
+        result = probe_callable(*args)
+        if result:
+            self._capability_reasons.pop(cap_name, None)
+        elif self._current_reason:
+            self._capability_reasons[cap_name] = self._current_reason
+        return result
 
     def _probe_all(self):
         """Probe all capabilities and cache results."""
@@ -56,54 +80,51 @@ class PermissionProbe:
 
         self.capabilities = {
             # Core metrics - always available via /proc
-            "cpu": self._can_read("/proc/stat"),
-            "memory": self._can_read("/proc/meminfo"),
-            "load_average": self._can_read("/proc/loadavg"),
-            "io": self._can_read("/proc/diskstats"),
-            "network": self._can_read("/proc/net/dev"),
-            "partitions": self._can_read("/proc/mounts"),
-            "file_handles": self._can_read("/proc/sys/fs/file-nr"),
-            "ports": self._can_read("/proc/net/tcp"),
+            "cpu": self._probe("cpu", self._can_read, "/proc/stat"),
+            "memory": self._probe("memory", self._can_read, "/proc/meminfo"),
+            "load_average": self._probe("load_average", self._can_read, "/proc/loadavg"),
+            "io": self._probe("io", self._can_read, "/proc/diskstats"),
+            "network": self._probe("network", self._can_read, "/proc/net/dev"),
+            "partitions": self._probe("partitions", self._can_read, "/proc/mounts"),
+            "file_handles": self._probe("file_handles", self._can_read, "/proc/sys/fs/file-nr"),
+            "ports": self._probe("ports", self._can_read, "/proc/net/tcp"),
             # Processes - works but may have limited visibility
-            "processes": self._can_read("/proc/self/stat"),
+            "processes": self._probe("processes", self._can_read, "/proc/self/stat"),
             # Hardware sensors - may or may not work without root
-            "temperatures": self._can_access_hwmon(),
-            "fans": self._can_access_hwmon(),
+            "temperatures": self._probe("temperatures", self._can_access_hwmon),
+            "fans": self._probe("fans", self._can_access_hwmon),
             # NVIDIA GPU
-            "nvidia_gpu": self._can_access_gpu(),
+            "nvidia_gpu": self._probe("nvidia_gpu", self._can_access_gpu),
             # Storage requiring sudo
-            "smart_storage": self._can_run_sudo("smartctl", "--version"),
-            "raid_storage": self._can_run_sudo("mdadm", "--version"),
+            "smart_storage": self._probe("smart_storage", self._can_run_sudo, "smartctl", "--version"),
+            "raid_storage": self._probe("raid_storage", self._can_run_sudo, "mdadm", "--version"),
             # Security - requires sudo
-            "fail2ban": self._can_run_sudo("fail2ban-client", "status"),
+            "fail2ban": self._probe("fail2ban", self._can_run_sudo, "fail2ban-client", "status"),
             # ZFS - doesn't need sudo but needs permissions or delegation
-            "zfs": self._can_run_zfs(),
+            "zfs": self._probe("zfs", self._can_run_zfs),
             # Docker - needs docker group membership
-            "docker": self._can_access_docker(),
+            "docker": self._probe("docker", self._can_access_docker),
             # QEMU/libvirt - needs libvirt group membership
-            "qemu": self._can_access_libvirt(),
+            "qemu": self._probe("qemu", self._can_access_libvirt),
             # Proxmox VE - needs API access or local node
-            "proxmox": self._can_access_proxmox(),
+            "proxmox": self._probe("proxmox", self._can_access_proxmox),
             # Package listing - for security scanning
-            "packages": self._can_list_packages(),
+            "packages": self._probe("packages", self._can_list_packages),
             # SNMP polling - needs net-snmp CLI tools
-            "snmp": self._has_snmpget(),
+            "snmp": self._probe("snmp", self._has_snmpget),
         }
 
         if not old_capabilities:
-            # Initial probe: surface unavailable capabilities + reason at info
-            # level so operators see WHY a capability is missing without having
-            # to drop to LOG_LEVEL=debug. The detailed exception, if any, is
-            # already in the probe method's debug log.
+            # Initial probe: surface every unavailable capability at info level
+            # so operators see WHY at default LOG_LEVEL. Format:
+            #   Capability 'X' unavailable: <hint> (<probe-method reason>)
             for cap, available in self.capabilities.items():
                 if available:
                     continue
-                hint = CAPABILITY_HINTS.get(cap)
-                if hint:
-                    log(f"Capability '{cap}' unavailable: {hint}", "info")
+                log(self._format_unavailable(cap, "unavailable"), "info")
         else:
-            # Subsequent probes: log only state flips, augmenting unavailability
-            # transitions with the same hint operators saw at startup.
+            # Subsequent probes: log only state flips. Unavailability transitions
+            # carry the same hint+reason payload as the initial probe.
             for cap, available in self.capabilities.items():
                 old_value = old_capabilities.get(cap)
                 if old_value is None or old_value == available:
@@ -111,13 +132,20 @@ class PermissionProbe:
                 if available:
                     log(f"Capability '{cap}' is now AVAILABLE", "info")
                 else:
-                    hint = CAPABILITY_HINTS.get(cap)
-                    msg = f"Capability '{cap}' is now UNAVAILABLE"
-                    if hint:
-                        msg += f": {hint}"
-                    log(msg, "info")
+                    log(self._format_unavailable(cap, "is now UNAVAILABLE"), "info")
 
         return self.capabilities
+
+    def _format_unavailable(self, cap, verb):
+        """Build the operator-facing log line for an unavailable capability."""
+        msg = f"Capability '{cap}' {verb}"
+        hint = CAPABILITY_HINTS.get(cap)
+        if hint:
+            msg += f": {hint}"
+        reason = self._capability_reasons.get(cap)
+        if reason:
+            msg += f" ({reason})"
+        return msg
 
     def refresh_if_needed(self):
         """Re-probe capabilities if enough time has passed."""
@@ -139,6 +167,7 @@ class PermissionProbe:
             exists = os.path.exists(path)
             if not exists:
                 log(f"_can_read: '{path}' does not exist", "debug")
+                self._set_reason(f"{path} does not exist")
                 return False
 
             readable = os.access(path, os.R_OK)
@@ -146,9 +175,12 @@ class PermissionProbe:
                 f"_can_read: '{path}' -> {'READABLE' if readable else 'NOT READABLE'}",
                 "debug",
             )
+            if not readable:
+                self._set_reason(f"{path} is not readable")
             return readable
         except Exception as e:
             log(f"_can_read: '{path}' exception: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"{path}: {type(e).__name__}: {e}")
             return False
 
     def _can_run_sudo(self, cmd, *args):
@@ -162,6 +194,7 @@ class PermissionProbe:
 
         if not cmd_path:
             log(f"_can_run_sudo: '{cmd}' not found in PATH", "debug")
+            self._set_reason(f"{cmd} not found in PATH")
             return False
 
         log(f"_can_run_sudo: '{cmd}' found at {cmd_path}", "debug")
@@ -191,12 +224,17 @@ class PermissionProbe:
                 f"_can_run_sudo: '{cmd}' -> {'AVAILABLE' if success else 'UNAVAILABLE'}",
                 "debug",
             )
+            if not success:
+                detail = stderr.splitlines()[0] if stderr else f"returncode {result.returncode}"
+                self._set_reason(f"sudo -n {cmd}: {detail}")
             return success
         except subprocess.TimeoutExpired:
             log(f"_can_run_sudo: '{cmd}' timed out after 5s", "debug")
+            self._set_reason(f"sudo -n {cmd} timed out after 5s")
             return False
         except Exception as e:
             log(f"_can_run_sudo: '{cmd}' exception: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"sudo -n {cmd}: {type(e).__name__}: {e}")
             return False
 
     def _can_access_hwmon(self):
@@ -206,6 +244,7 @@ class PermissionProbe:
 
         if not os.path.exists(hwmon_path):
             log(f"_can_access_hwmon: {hwmon_path} does not exist", "debug")
+            self._set_reason(f"{hwmon_path} does not exist")
             return False
 
         try:
@@ -253,9 +292,11 @@ class PermissionProbe:
             log(
                 "_can_access_hwmon: -> UNAVAILABLE (no readable sensors found)", "debug"
             )
+            self._set_reason(f"no readable sensors under {hwmon_path}")
             return False
         except Exception as e:
             log(f"_can_access_hwmon: exception: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"{hwmon_path}: {type(e).__name__}: {e}")
             return False
 
     def _can_access_gpu(self):
@@ -264,12 +305,14 @@ class PermissionProbe:
             import pynvml
         except ImportError:
             log("_can_access_gpu: pynvml not installed", "debug")
+            self._set_reason("pynvml not installed")
             return False
 
         try:
             pynvml.nvmlInit()
         except Exception as e:
             log(f"_can_access_gpu: nvmlInit failed: {e}", "debug")
+            self._set_reason(f"nvmlInit failed: {e}")
             return False
 
         try:
@@ -280,9 +323,12 @@ class PermissionProbe:
                 f"{'AVAILABLE' if available else 'UNAVAILABLE'}",
                 "debug",
             )
+            if not available:
+                self._set_reason("0 GPUs detected")
             return available
         except Exception as e:
             log(f"_can_access_gpu: exception: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"{type(e).__name__}: {e}")
             return False
         finally:
             pynvml.nvmlShutdown()
@@ -292,6 +338,7 @@ class PermissionProbe:
         zpool_path = shutil.which("zpool")
         if not zpool_path:
             log("_can_run_zfs: 'zpool' not found in PATH", "debug")
+            self._set_reason("zpool not found in PATH")
             return False
 
         log(f"_can_run_zfs: 'zpool' found at {zpool_path}", "debug")
@@ -324,12 +371,16 @@ class PermissionProbe:
                 return True
 
             log("_can_run_zfs: -> UNAVAILABLE", "debug")
+            detail = stderr.splitlines()[0] if stderr else f"returncode {result.returncode}"
+            self._set_reason(f"zpool list: {detail}")
             return False
         except subprocess.TimeoutExpired:
             log("_can_run_zfs: timed out after 5s", "debug")
+            self._set_reason("zpool list timed out after 5s")
             return False
         except Exception as e:
             log(f"_can_run_zfs: exception: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"zpool list: {type(e).__name__}: {e}")
             return False
 
     def _can_access_docker(self):
@@ -339,6 +390,7 @@ class PermissionProbe:
 
         if not os.path.exists(docker_socket):
             log(f"_can_access_docker: {docker_socket} does not exist", "debug")
+            self._set_reason(f"{docker_socket} does not exist")
             return False
 
         readable = os.access(docker_socket, os.R_OK)
@@ -350,6 +402,10 @@ class PermissionProbe:
             f"_can_access_docker: -> {'AVAILABLE' if accessible else 'UNAVAILABLE'}",
             "debug",
         )
+        if not accessible:
+            self._set_reason(
+                f"{docker_socket} not accessible (readable={readable}, writable={writable})"
+            )
         return accessible
 
     def _can_access_libvirt(self):
@@ -374,6 +430,7 @@ class PermissionProbe:
                 return True
 
         log("_can_access_libvirt: -> UNAVAILABLE (no accessible sockets)", "debug")
+        self._set_reason(f"no readable libvirt socket at {' or '.join(socket_paths)}")
         return False
 
     def _can_access_proxmox(self):
@@ -385,6 +442,7 @@ class PermissionProbe:
         # Also check for pvesh command (Proxmox shell)
         if shutil.which("pvesh"):
             return True
+        self._set_reason("/etc/pve missing and pvesh not in PATH")
         return False
 
     def _has_snmpget(self):
@@ -394,6 +452,8 @@ class PermissionProbe:
             "_has_snmpget: {}".format("found" if found else "not found"),
             "debug",
         )
+        if not found:
+            self._set_reason("snmpget not found in PATH")
         return found
 
     def _can_list_packages(self):
@@ -403,6 +463,7 @@ class PermissionProbe:
                 log(f"_can_list_packages: found '{cmd}'", "debug")
                 return True
         log("_can_list_packages: no supported package manager found", "debug")
+        self._set_reason("no supported package manager (dpkg-query, rpm, apk, pacman, synopkg)")
         return False
 
     def get(self, capability, default=False):
@@ -412,6 +473,16 @@ class PermissionProbe:
     def get_all(self):
         """Get all capability statuses."""
         return self.capabilities.copy()
+
+    def get_reasons(self):
+        """Return {capability: reason} for capabilities currently unavailable.
+
+        Reason is a short string captured by the probe method (e.g.,
+        "nvmlInit failed: NVML Shared Library Not Found"). Sent to the
+        backend in static_data so dashboards can show per-host failure
+        reasons without an SSH session.
+        """
+        return self._capability_reasons.copy()
 
     def get_unavailable(self):
         """Get list of unavailable capabilities."""

--- a/tests/test_agent_capability_reasons.py
+++ b/tests/test_agent_capability_reasons.py
@@ -1,0 +1,70 @@
+"""Tests verifying capability_reasons is threaded through Agent.static_data."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock libvirt before any fivenines_agent imports that transitively need it
+sys.modules.setdefault("libvirt", MagicMock())
+
+import fivenines_agent.agent as agent_module  # noqa: E402
+from fivenines_agent.agent import Agent  # noqa: E402
+
+
+def _make_agent():
+    agent = Agent.__new__(Agent)
+    agent.permissions = MagicMock()
+    agent.permissions.get_all.return_value = {"nvidia_gpu": False, "cpu": True}
+    agent.permissions.get_reasons.return_value = {
+        "nvidia_gpu": "nvmlInit failed: NVML Shared Library Not Found"
+    }
+    agent.permissions.refresh_if_needed.return_value = False
+    agent.static_data = {
+        "capabilities": agent.permissions.get_all(),
+        "capability_reasons": agent.permissions.get_reasons(),
+    }
+    return agent
+
+
+def test_force_refresh_updates_capability_reasons():
+    """SIGHUP-triggered force refresh writes both capabilities and reasons to static_data."""
+    agent = _make_agent()
+    agent.permissions.get_all.return_value = {"nvidia_gpu": True, "cpu": True}
+    agent.permissions.get_reasons.return_value = {}
+
+    agent_module.refresh_permissions_event.set()
+    with patch("fivenines_agent.agent.print_capabilities_banner"):
+        agent._handle_permission_refresh()
+
+    agent.permissions.force_refresh.assert_called_once()
+    assert agent.static_data["capabilities"] == {"nvidia_gpu": True, "cpu": True}
+    assert agent.static_data["capability_reasons"] == {}
+
+
+def test_periodic_refresh_updates_capability_reasons():
+    """Time-based refresh writes both capabilities and reasons to static_data."""
+    agent = _make_agent()
+    agent.permissions.refresh_if_needed.return_value = True
+    agent.permissions.get_all.return_value = {"nvidia_gpu": False, "cpu": True}
+    agent.permissions.get_reasons.return_value = {
+        "nvidia_gpu": "nvmlInit failed: driver removed"
+    }
+
+    agent_module.refresh_permissions_event.clear()
+    agent._handle_permission_refresh()
+
+    assert (
+        agent.static_data["capability_reasons"]["nvidia_gpu"]
+        == "nvmlInit failed: driver removed"
+    )
+
+
+def test_no_refresh_leaves_static_data_unchanged():
+    """When neither path triggers, static_data is not touched."""
+    agent = _make_agent()
+    agent.permissions.refresh_if_needed.return_value = False
+    snapshot_before = dict(agent.static_data)
+
+    agent_module.refresh_permissions_event.clear()
+    agent._handle_permission_refresh()
+
+    assert agent.static_data == snapshot_before

--- a/tests/test_permissions_gpu.py
+++ b/tests/test_permissions_gpu.py
@@ -39,7 +39,7 @@ def test_can_access_gpu_zero_devices(mock_probe):
 
 @patch.object(PermissionProbe, "_probe_all")
 def test_can_access_gpu_init_fails(mock_probe):
-    """nvmlInit failure returns False."""
+    """nvmlInit failure returns False and records the reason."""
     probe = PermissionProbe.__new__(PermissionProbe)
     probe.capabilities = {}
 
@@ -48,11 +48,12 @@ def test_can_access_gpu_init_fails(mock_probe):
 
     with patch.dict(sys.modules, {"pynvml": mock_nvml}):
         assert probe._can_access_gpu() is False
+        assert probe._current_reason == "nvmlInit failed: driver not loaded"
 
 
 @patch.object(PermissionProbe, "_probe_all")
 def test_can_access_gpu_no_pynvml(mock_probe):
-    """pynvml not installed returns False."""
+    """pynvml not installed returns False and records the reason."""
     probe = PermissionProbe.__new__(PermissionProbe)
     probe.capabilities = {}
 
@@ -70,6 +71,7 @@ def test_can_access_gpu_no_pynvml(mock_probe):
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
             assert probe._can_access_gpu() is False
+            assert probe._current_reason == "pynvml not installed"
     finally:
         if saved is not None:
             sys.modules["pynvml"] = saved

--- a/tests/test_permissions_probe.py
+++ b/tests/test_permissions_probe.py
@@ -43,10 +43,16 @@ _ALL_TRUE_CAPS = {
 }
 
 
-def _patched_probe(returns):
-    """Stack patches for every probe method with the given return value (or per-method mapping)."""
+def _patched_probe(returns, exclude=()):
+    """Stack patches for every probe method with the given return value.
+
+    Pass *exclude* to skip patching specific methods so the caller can patch
+    them separately (e.g. with a side_effect).
+    """
     stack = ExitStack()
     for name in _PROBE_METHODS:
+        if name in exclude:
+            continue
         rv = (
             returns.get(name, returns.get("default"))
             if isinstance(returns, dict)
@@ -60,6 +66,8 @@ def _new_probe_with(caps):
     """Build a PermissionProbe instance bypassing __init__, with capabilities set."""
     probe = PermissionProbe.__new__(PermissionProbe)
     probe.capabilities = caps
+    probe._capability_reasons = {}
+    probe._current_reason = None
     probe._last_probe_time = 0
     return probe
 
@@ -115,3 +123,125 @@ def test_capability_hints_keys_are_known_capabilities():
         assert (
             hint_key in probe.capabilities
         ), f"hint {hint_key!r} has no matching capability"
+
+
+# --- Reason capture ---
+
+
+def test_probe_captures_failure_reason():
+    """Probe wrapper records the probe method's set_reason on False return."""
+    probe = _new_probe_with({})
+
+    def fake_probe(self):
+        self._set_reason("specific failure")
+        return False
+
+    with patch.object(
+        PermissionProbe, "_can_access_gpu", autospec=True, side_effect=fake_probe
+    ):
+        result = probe._probe("nvidia_gpu", probe._can_access_gpu)
+
+    assert result is False
+    assert probe._capability_reasons["nvidia_gpu"] == "specific failure"
+
+
+def test_probe_clears_reason_when_capability_recovers():
+    """A previously-unavailable capability that returns True clears its reason."""
+    probe = _new_probe_with({})
+    probe._capability_reasons["nvidia_gpu"] = "stale reason"
+
+    with patch.object(
+        PermissionProbe, "_can_access_gpu", autospec=True, return_value=True
+    ):
+        result = probe._probe("nvidia_gpu", probe._can_access_gpu)
+
+    assert result is True
+    assert "nvidia_gpu" not in probe._capability_reasons
+
+
+def test_probe_no_reason_set_does_not_record():
+    """If a probe returns False without calling _set_reason, no reason is recorded."""
+    probe = _new_probe_with({})
+
+    with patch.object(
+        PermissionProbe, "_can_access_gpu", autospec=True, return_value=False
+    ):
+        result = probe._probe("nvidia_gpu", probe._can_access_gpu)
+
+    assert result is False
+    assert "nvidia_gpu" not in probe._capability_reasons
+
+
+def test_get_reasons_returns_copy():
+    """get_reasons returns a snapshot the caller can safely mutate."""
+    probe = _new_probe_with({})
+    probe._capability_reasons["nvidia_gpu"] = (
+        "nvmlInit failed: NVML Shared Library Not Found"
+    )
+
+    snapshot = probe.get_reasons()
+    snapshot["nvidia_gpu"] = "tampered"
+
+    assert (
+        probe._capability_reasons["nvidia_gpu"]
+        == "nvmlInit failed: NVML Shared Library Not Found"
+    )
+
+
+def test_initial_probe_log_includes_reason():
+    """Initial probe info log appends the captured reason inline."""
+
+    def gpu_unavailable_with_reason(self):
+        self._set_reason("nvmlInit failed: NVML Shared Library Not Found")
+        return False
+
+    returns = {"default": True}
+    with _patched_probe(returns, exclude=["_can_access_gpu"]), patch.object(
+        PermissionProbe,
+        "_can_access_gpu",
+        autospec=True,
+        side_effect=gpu_unavailable_with_reason,
+    ), patch("fivenines_agent.permissions.log") as mock_log:
+        PermissionProbe()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    gpu_msg = next(m for m in info_msgs if "nvidia_gpu" in m and "unavailable" in m)
+    assert "requires NVIDIA driver" in gpu_msg
+    assert "(nvmlInit failed: NVML Shared Library Not Found)" in gpu_msg
+
+
+def test_flip_to_unavailable_log_includes_reason():
+    """Flip-to-unavailable info log appends the captured reason inline."""
+    probe = _new_probe_with(dict(_ALL_TRUE_CAPS))
+
+    def gpu_unavailable_with_reason(self):
+        self._set_reason("nvmlInit failed: driver removed")
+        return False
+
+    returns = {"default": True}
+    with _patched_probe(returns, exclude=["_can_access_gpu"]), patch.object(
+        PermissionProbe,
+        "_can_access_gpu",
+        autospec=True,
+        side_effect=gpu_unavailable_with_reason,
+    ), patch("fivenines_agent.permissions.log") as mock_log:
+        probe._probe_all()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    flip_msg = next(
+        m for m in info_msgs if "nvidia_gpu" in m and "now UNAVAILABLE" in m
+    )
+    assert "requires NVIDIA driver" in flip_msg
+    assert "(nvmlInit failed: driver removed)" in flip_msg
+
+
+def test_unavailable_log_without_reason_omits_parens():
+    """When no reason was captured, the log line ends after the hint."""
+    returns = {"default": False, "_can_read": True}
+    with _patched_probe(returns), patch("fivenines_agent.permissions.log") as mock_log:
+        PermissionProbe()
+
+    info_msgs = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    docker_msg = next(m for m in info_msgs if "docker" in m and "unavailable" in m)
+    # Patched probe returns False without calling _set_reason -> no parens.
+    assert docker_msg.endswith("docker group")


### PR DESCRIPTION
## Summary

Follow-up to v1.6.2 (#43, #44). The previous release surfaced unavailable capabilities at info level with a short hint ("requires NVIDIA driver"), but the actual probe error stayed at debug, and nothing reached the backend. This PR closes both gaps so operators can diagnose unavailable capabilities without ever SSH-ing into a host.

## What changes

### Probe methods record a short failure reason

Each `_can_*` probe in `PermissionProbe` now calls `self._set_reason("...")` on every False-return path. Examples:

| Probe | Failure path | Reason captured |
|-------|-------------|-----------------|
| `_can_access_gpu` | `pynvml` import fails | `pynvml not installed` |
| `_can_access_gpu` | `nvmlInit` raises | `nvmlInit failed: <error>` |
| `_can_access_docker` | socket exists, perms denied | `/var/run/docker.sock not accessible (readable=False, writable=False)` |
| `_can_run_sudo` | command times out | `sudo -n smartctl timed out after 5s` |
| `_can_run_zfs` | zpool not in PATH | `zpool not found in PATH` |

A new `_probe()` wrapper in `_probe_all` captures the reason into `self._capability_reasons` and clears it when the capability flips back to True. Probes run sequentially, so the single-slot `_current_reason` register is safe.

### Info logs include the reason inline

Initial probe and flip-to-unavailable transitions now print:

```
[INFO] Capability 'nvidia_gpu' unavailable: requires NVIDIA driver (nvmlInit failed: NVML Shared Library Not Found)
[INFO] Capability 'docker' is now UNAVAILABLE: requires docker group (/var/run/docker.sock not accessible (readable=False, writable=False))
```

Logs without a captured reason still work (e.g., when probe returns False without calling `_set_reason`) -- the line just ends after the hint.

### `capability_reasons` ships with every payload

`PermissionProbe.get_reasons()` returns the `{capability: reason}` map. `Agent.static_data` now includes it alongside `capabilities`:

```json
{
  "capabilities": {"nvidia_gpu": false, "docker": true, ...},
  "capability_reasons": {"nvidia_gpu": "nvmlInit failed: NVML Shared Library Not Found"}
}
```

Refresh paths (SIGHUP and the 5-min auto-refresh) update both `capabilities` and `capability_reasons` in lockstep. The field is additive -- backends that don't know about it can ignore it without breaking.

## Operator-visible result on the diagnosed Proxmox host

Before this PR (with v1.6.2):
```
[INFO] Capability 'nvidia_gpu' unavailable: requires NVIDIA driver
```
Operator still has to SSH and run `LOG_LEVEL=debug` to see why.

After this PR:
```
[INFO] Capability 'nvidia_gpu' unavailable: requires NVIDIA driver (nvmlInit failed: NVML Shared Library Not Found)
```
And the same reason is in every payload going to fivenines.io.

## Test plan

- [x] 369 tests pass (10 new across `test_permissions_gpu.py`, `test_permissions_probe.py`, new `test_agent_capability_reasons.py`)
- [x] All 10 probe methods updated; reasons cover ImportError, subprocess timeouts, missing files, permission errors, command-not-in-PATH
- [x] Recovery path tested: capability returning True clears its stored reason
- [x] `Agent._handle_permission_refresh` writes both fields on SIGHUP and on time-based refresh