### PR TITLE
Fix: cache get_ip failures to stop journal spam (closes #42)

### DIFF
--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -65,11 +65,14 @@ def _is_public_ip(parsed):
 def _validate_ip(body, ipv6):
     """Return body if it parses as a public address of the expected family.
 
-    Length is checked on the raw body BEFORE stripping, so a hostile or
-    broken upstream cannot smuggle a valid-looking IP inside whitespace
-    padding ("1.2.3.4" + " " * 500 strips to a valid IP).
+    Length is checked on the encoded BYTE length (not character count) so
+    multibyte Unicode whitespace cannot smuggle a valid-looking IP through
+    .strip() ("1.2.3.4" + " " * 57 is 64 chars but 178 bytes). The
+    check happens before .strip() so trailing/leading padding is also caught.
     """
-    if not body or len(body) > MAX_RESPONSE_BODY:
+    if not body:
+        return None
+    if len(body.encode("utf-8", errors="replace")) > MAX_RESPONSE_BODY:
         return None
     candidate = body.strip()
     if not candidate:
@@ -157,9 +160,18 @@ def get_ip(ipv6=False):
         conn.request("GET", "")
         response = conn.getresponse()
         # Cap the read so a misbehaving (or hostile) upstream cannot force
-        # unbounded memory use or log amplification. Strict UTF-8 decode so
-        # non-UTF-8 bytes are not silently dropped to forge a valid-looking IP.
+        # unbounded memory use or log amplification. Reading past the cap is
+        # how we detect oversized bodies (otherwise a 1MB body would just look
+        # like a 64-byte body via silent truncation).
         raw = response.read(MAX_RESPONSE_BODY * 4)
+        if len(raw) > MAX_RESPONSE_BODY:
+            log(
+                f"ip.fivenines.io returned oversized body ({len(raw)} bytes)",
+                "error",
+            )
+            _record_failure(cache)
+            return None
+        # Strict UTF-8 decode so non-UTF-8 bytes are not silently dropped.
         try:
             body = raw.decode("utf-8")
         except UnicodeDecodeError:

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -11,6 +11,12 @@ from fivenines_agent.debug import debug, log
 _ip_v4_cache = { "timestamp": 0, "ip": None }
 _ip_v6_cache = { "timestamp": 0, "ip": None }
 
+# Cache TTLs. The negative cache deliberately runs longer than the positive
+# cache (and longer than the default tick interval) so a host with no IPv6
+# does not log the same connection error every tick. See issue #42.
+POSITIVE_CACHE_TTL = 60
+NEGATIVE_CACHE_TTL = 300
+
 class CustomHTTPSConnection(http.client.HTTPSConnection):
     def __init__(self, host, port=None, ipv6=False, timeout=5, **kwargs):
         super().__init__(host, port, timeout=timeout, **kwargs)
@@ -49,14 +55,17 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
 @debug('get_ip')
 def get_ip(ipv6=False):
     now = time.time()
+    cache = _ip_v6_cache if ipv6 else _ip_v4_cache
+    age = now - cache["timestamp"]
 
-    if ipv6:
-        if now - _ip_v6_cache["timestamp"] < 60:
-            return _ip_v6_cache["ip"]
-    else:
-        if now - _ip_v4_cache["timestamp"] < 60:
-            return _ip_v4_cache["ip"]
+    # Positive cache: short TTL, return the previously-fetched IP.
+    if cache["ip"] is not None and age < POSITIVE_CACHE_TTL:
+        return cache["ip"]
+    # Negative cache: longer TTL, suppress retry storms on broken connectivity.
+    if cache["ip"] is None and cache["timestamp"] > 0 and age < NEGATIVE_CACHE_TTL:
+        return None
 
+    conn = None
     try:
         ssl_context = ssl.create_default_context(cafile=certifi.where())
 
@@ -70,20 +79,25 @@ def get_ip(ipv6=False):
 
         if response.status == 200:
             ip = body.strip()
-            cache = _ip_v6_cache if ipv6 else _ip_v4_cache
             cache["timestamp"] = now
             cache["ip"] = ip
             return ip
 
+        cache["timestamp"] = now
+        cache["ip"] = None
         return None
     except ConnectionError as e:
         # Log the error and optionally retry or handle IPv4 fallback
         log(f"Unexpected error occurred: {e}", 'error')
+        cache["timestamp"] = now
+        cache["ip"] = None
         return None
 
     except Exception as e:
         log(f"Unexpected error occurred: {e}", 'error')
         traceback.print_exc(file=sys.stderr)
+        cache["timestamp"] = now
+        cache["ip"] = None
         return None
     finally:
         if conn:

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -40,8 +40,30 @@ def _negative_backoff(failures):
     return NEGATIVE_BACKOFF_SCHEDULE[idx]
 
 
+def _is_public_ip(parsed):
+    """True if the address is a globally routable public IP.
+
+    Rejects loopback, private (RFC1918 / ULA / CGNAT), link-local, multicast,
+    reserved, unspecified, and IPv4-mapped IPv6 addresses. ip.fivenines.io
+    returning any of these means the upstream is misconfigured (or hostile);
+    we should not cache that as the host's "public IP".
+
+    Uses ipaddress.is_global as the primary discriminator (it correctly
+    flags CGNAT, ULA, loopback, doc-prefix, etc as non-global) and adds
+    explicit multicast and IPv4-mapped-IPv6 rejections that is_global
+    misses.
+    """
+    if not parsed.is_global:
+        return False
+    if parsed.is_multicast:
+        return False
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
+        return False
+    return True
+
+
 def _validate_ip(body, ipv6):
-    """Return body if it parses as the expected family; otherwise None."""
+    """Return body if it parses as a public address of the expected family."""
     if not body:
         return None
     candidate = body.strip()[:MAX_RESPONSE_BODY]
@@ -51,6 +73,8 @@ def _validate_ip(body, ipv6):
         return None
     expected_version = 6 if ipv6 else 4
     if parsed.version != expected_version:
+        return None
+    if not _is_public_ip(parsed):
         return None
     return candidate
 
@@ -125,7 +149,10 @@ def get_ip(ipv6=False):
         conn = CustomHTTPSConnection("ip.fivenines.io", ipv6=ipv6, context=ssl_context)
         conn.request("GET", "")
         response = conn.getresponse()
-        body = response.read().decode("utf-8")
+        # Cap the read so a misbehaving (or hostile) upstream cannot force
+        # unbounded memory use or log amplification. Validation will reject
+        # anything longer than MAX_RESPONSE_BODY anyway.
+        body = response.read(MAX_RESPONSE_BODY * 4).decode("utf-8", errors="ignore")
 
         log(f"Status: {response.status}, Reason: {response.reason}", "debug")
         log(f"Response body: {body}", "debug")

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -63,10 +63,17 @@ def _is_public_ip(parsed):
 
 
 def _validate_ip(body, ipv6):
-    """Return body if it parses as a public address of the expected family."""
-    if not body:
+    """Return body if it parses as a public address of the expected family.
+
+    Length is checked on the raw body BEFORE stripping, so a hostile or
+    broken upstream cannot smuggle a valid-looking IP inside whitespace
+    padding ("1.2.3.4" + " " * 500 strips to a valid IP).
+    """
+    if not body or len(body) > MAX_RESPONSE_BODY:
         return None
-    candidate = body.strip()[:MAX_RESPONSE_BODY]
+    candidate = body.strip()
+    if not candidate:
+        return None
     try:
         parsed = ipaddress.ip_address(candidate)
     except ValueError:
@@ -150,9 +157,18 @@ def get_ip(ipv6=False):
         conn.request("GET", "")
         response = conn.getresponse()
         # Cap the read so a misbehaving (or hostile) upstream cannot force
-        # unbounded memory use or log amplification. Validation will reject
-        # anything longer than MAX_RESPONSE_BODY anyway.
-        body = response.read(MAX_RESPONSE_BODY * 4).decode("utf-8", errors="ignore")
+        # unbounded memory use or log amplification. Strict UTF-8 decode so
+        # non-UTF-8 bytes are not silently dropped to forge a valid-looking IP.
+        raw = response.read(MAX_RESPONSE_BODY * 4)
+        try:
+            body = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            log(
+                f"ip.fivenines.io returned non-UTF-8 body ({len(raw)} bytes)",
+                "error",
+            )
+            _record_failure(cache)
+            return None
 
         log(f"Status: {response.status}, Reason: {response.reason}", "debug")
         log(f"Response body: {body}", "debug")

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -1,4 +1,5 @@
 import http.client
+import ipaddress
 import socket
 import ssl
 import sys
@@ -10,6 +11,8 @@ import certifi
 from fivenines_agent.debug import debug, log
 from fivenines_agent.dns_resolver import DNSResolver
 
+# Cache timestamps are monotonic seconds (not wall-clock) so suspend, NTP
+# rollback, or VM restore cannot suppress retries past the stated cap.
 _ip_v4_cache = {"timestamp": 0, "ip": None, "failures": 0}
 _ip_v6_cache = {"timestamp": 0, "ip": None, "failures": 0}
 
@@ -24,6 +27,10 @@ POSITIVE_CACHE_TTL = 60
 # (no IPv6, no driver) stops spamming the journal. See issue #42.
 NEGATIVE_BACKOFF_SCHEDULE = (60, 120, 240, 300)
 
+# Maximum length of a response body we will attempt to parse as an IP.
+# IPv6 addresses fit in ~45 chars; anything longer is HTML or junk.
+MAX_RESPONSE_BODY = 64
+
 
 def _negative_backoff(failures):
     """How long to suppress retries given the consecutive failure count."""
@@ -31,6 +38,21 @@ def _negative_backoff(failures):
         return 0
     idx = min(failures - 2, len(NEGATIVE_BACKOFF_SCHEDULE) - 1)
     return NEGATIVE_BACKOFF_SCHEDULE[idx]
+
+
+def _validate_ip(body, ipv6):
+    """Return body if it parses as the expected family; otherwise None."""
+    if not body:
+        return None
+    candidate = body.strip()[:MAX_RESPONSE_BODY]
+    try:
+        parsed = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    expected_version = 6 if ipv6 else 4
+    if parsed.version != expected_version:
+        return None
+    return candidate
 
 
 class CustomHTTPSConnection(http.client.HTTPSConnection):
@@ -73,17 +95,17 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
         )
 
 
-def _record_failure(cache, now):
-    cache["timestamp"] = now
+def _record_failure(cache):
+    """Stamp the cache as failed at the current monotonic time."""
+    cache["timestamp"] = time.monotonic()
     cache["ip"] = None
     cache["failures"] = cache.get("failures", 0) + 1
 
 
 @debug("get_ip")
 def get_ip(ipv6=False):
-    now = time.time()
     cache = _ip_v6_cache if ipv6 else _ip_v4_cache
-    age = now - cache["timestamp"]
+    age = time.monotonic() - cache["timestamp"]
 
     # Positive cache: short TTL, return the previously-fetched IP.
     if cache["ip"] is not None and age < POSITIVE_CACHE_TTL:
@@ -109,23 +131,31 @@ def get_ip(ipv6=False):
         log(f"Response body: {body}", "debug")
 
         if response.status == 200:
-            ip = body.strip()
-            cache["timestamp"] = now
+            ip = _validate_ip(body, ipv6=ipv6)
+            if ip is None:
+                family = "IPv6" if ipv6 else "IPv4"
+                log(
+                    f"ip.fivenines.io returned non-{family} body: {body[:64]!r}",
+                    "error",
+                )
+                _record_failure(cache)
+                return None
+            cache["timestamp"] = time.monotonic()
             cache["ip"] = ip
             cache["failures"] = 0
             return ip
 
-        _record_failure(cache, now)
+        _record_failure(cache)
         return None
     except ConnectionError as e:
         log(f"Unexpected error occurred: {e}", "error")
-        _record_failure(cache, now)
+        _record_failure(cache)
         return None
 
     except Exception as e:
         log(f"Unexpected error occurred: {e}", "error")
         traceback.print_exc(file=sys.stderr)
-        _record_failure(cache, now)
+        _record_failure(cache)
         return None
     finally:
         if conn:

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -211,6 +211,13 @@ def get_ip(ipv6=False):
             cache["failures"] = 0
             return ip
 
+        # Non-200 responses (503, 429, 404, etc) need to surface in telemetry
+        # too. Without this the first uncached failure looks like a clean
+        # sample with no errors attached.
+        log(
+            f"ip.fivenines.io returned HTTP {response.status} {response.reason}",
+            "error",
+        )
         _record_failure(cache)
         return None
     except ConnectionError as e:

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -11,10 +11,21 @@ import certifi
 from fivenines_agent.debug import debug, log
 from fivenines_agent.dns_resolver import DNSResolver
 
-# Cache timestamps are monotonic seconds (not wall-clock) so suspend, NTP
-# rollback, or VM restore cannot suppress retries past the stated cap.
+# Cache timestamps use CLOCK_BOOTTIME on Linux (counts suspended time) so
+# NTP rollback, suspend, and VM restore all advance the clock as expected.
+# Falls back to time.monotonic() on platforms without CLOCK_BOOTTIME, which
+# is correct for NTP rollback and VM restore but not for suspend.
 _ip_v4_cache = {"timestamp": 0, "ip": None, "failures": 0}
 _ip_v6_cache = {"timestamp": 0, "ip": None, "failures": 0}
+
+
+def _now():
+    """Monotonic seconds; counts suspend on Linux via CLOCK_BOOTTIME."""
+    try:
+        return time.clock_gettime(time.CLOCK_BOOTTIME)
+    except (AttributeError, OSError):
+        return time.monotonic()
+
 
 # Positive cache: short TTL, just deduplicates calls within a single tick.
 POSITIVE_CACHE_TTL = 60
@@ -131,7 +142,7 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
 
 def _record_failure(cache):
     """Stamp the cache as failed at the current monotonic time."""
-    cache["timestamp"] = time.monotonic()
+    cache["timestamp"] = _now()
     cache["ip"] = None
     cache["failures"] = cache.get("failures", 0) + 1
 
@@ -139,7 +150,7 @@ def _record_failure(cache):
 @debug("get_ip")
 def get_ip(ipv6=False):
     cache = _ip_v6_cache if ipv6 else _ip_v4_cache
-    age = time.monotonic() - cache["timestamp"]
+    age = _now() - cache["timestamp"]
 
     # Positive cache: short TTL, return the previously-fetched IP.
     if cache["ip"] is not None and age < POSITIVE_CACHE_TTL:
@@ -195,7 +206,7 @@ def get_ip(ipv6=False):
                 )
                 _record_failure(cache)
                 return None
-            cache["timestamp"] = time.monotonic()
+            cache["timestamp"] = _now()
             cache["ip"] = ip
             cache["failures"] = 0
             return ip

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -67,7 +67,7 @@ def _validate_ip(body, ipv6):
 
     Length is checked on the encoded BYTE length (not character count) so
     multibyte Unicode whitespace cannot smuggle a valid-looking IP through
-    .strip() ("1.2.3.4" + " " * 57 is 64 chars but 178 bytes). The
+    .strip() ("1.2.3.4" + "\u2003" * 57 is 64 chars but 178 bytes). The
     check happens before .strip() so trailing/leading padding is also caught.
     """
     if not body:

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -170,10 +170,24 @@ def get_ip(ipv6=False):
         conn = CustomHTTPSConnection("ip.fivenines.io", ipv6=ipv6, context=ssl_context)
         conn.request("GET", "")
         response = conn.getresponse()
-        # Cap the read so a misbehaving (or hostile) upstream cannot force
-        # unbounded memory use or log amplification. Reading past the cap is
-        # how we detect oversized bodies (otherwise a 1MB body would just look
-        # like a 64-byte body via silent truncation).
+        log(f"Status: {response.status}, Reason: {response.reason}", "debug")
+
+        # Status check FIRST so non-200 responses (503/429/404 with HTML
+        # error pages, often >64 bytes and possibly non-UTF-8) surface as
+        # the actual HTTP status rather than as a generic "oversized body"
+        # or "non-UTF-8 body" error.
+        if response.status != 200:
+            log(
+                f"ip.fivenines.io returned HTTP {response.status} {response.reason}",
+                "error",
+            )
+            _record_failure(cache)
+            return None
+
+        # 200: validate the body. Cap the read so a misbehaving upstream
+        # cannot force unbounded memory use or log amplification. Reading
+        # past the cap is how we detect oversized bodies (otherwise a 1MB
+        # body would just look like a 64-byte body via silent truncation).
         raw = response.read(MAX_RESPONSE_BODY * 4)
         if len(raw) > MAX_RESPONSE_BODY:
             log(
@@ -193,33 +207,21 @@ def get_ip(ipv6=False):
             _record_failure(cache)
             return None
 
-        log(f"Status: {response.status}, Reason: {response.reason}", "debug")
         log(f"Response body: {body}", "debug")
 
-        if response.status == 200:
-            ip = _validate_ip(body, ipv6=ipv6)
-            if ip is None:
-                family = "IPv6" if ipv6 else "IPv4"
-                log(
-                    f"ip.fivenines.io returned non-{family} body: {body[:64]!r}",
-                    "error",
-                )
-                _record_failure(cache)
-                return None
-            cache["timestamp"] = _now()
-            cache["ip"] = ip
-            cache["failures"] = 0
-            return ip
-
-        # Non-200 responses (503, 429, 404, etc) need to surface in telemetry
-        # too. Without this the first uncached failure looks like a clean
-        # sample with no errors attached.
-        log(
-            f"ip.fivenines.io returned HTTP {response.status} {response.reason}",
-            "error",
-        )
-        _record_failure(cache)
-        return None
+        ip = _validate_ip(body, ipv6=ipv6)
+        if ip is None:
+            family = "IPv6" if ipv6 else "IPv4"
+            log(
+                f"ip.fivenines.io returned non-{family} body: {body[:64]!r}",
+                "error",
+            )
+            _record_failure(cache)
+            return None
+        cache["timestamp"] = _now()
+        cache["ip"] = ip
+        cache["failures"] = 0
+        return ip
     except ConnectionError as e:
         log(f"Unexpected error occurred: {e}", "error")
         _record_failure(cache)

--- a/fivenines_agent/ip.py
+++ b/fivenines_agent/ip.py
@@ -1,21 +1,37 @@
-import sys
-import traceback
+import http.client
 import socket
 import ssl
-import certifi
+import sys
 import time
-import http.client
-from fivenines_agent.dns_resolver import DNSResolver
+import traceback
+
+import certifi
+
 from fivenines_agent.debug import debug, log
+from fivenines_agent.dns_resolver import DNSResolver
 
-_ip_v4_cache = { "timestamp": 0, "ip": None }
-_ip_v6_cache = { "timestamp": 0, "ip": None }
+_ip_v4_cache = {"timestamp": 0, "ip": None, "failures": 0}
+_ip_v6_cache = {"timestamp": 0, "ip": None, "failures": 0}
 
-# Cache TTLs. The negative cache deliberately runs longer than the positive
-# cache (and longer than the default tick interval) so a host with no IPv6
-# does not log the same connection error every tick. See issue #42.
+# Positive cache: short TTL, just deduplicates calls within a single tick.
 POSITIVE_CACHE_TTL = 60
-NEGATIVE_CACHE_TTL = 300
+
+# Negative cache backoff schedule (seconds), indexed by consecutive failure
+# count. The first failure deliberately does NOT cache so a single transient
+# error (one bad packet, a TLS hiccup, ip.fivenines.io 503) recovers on the
+# very next tick without burning a 5 minute window of null payloads. From the
+# second consecutive failure onward we back off so a permanently-broken host
+# (no IPv6, no driver) stops spamming the journal. See issue #42.
+NEGATIVE_BACKOFF_SCHEDULE = (60, 120, 240, 300)
+
+
+def _negative_backoff(failures):
+    """How long to suppress retries given the consecutive failure count."""
+    if failures <= 1:
+        return 0
+    idx = min(failures - 2, len(NEGATIVE_BACKOFF_SCHEDULE) - 1)
+    return NEGATIVE_BACKOFF_SCHEDULE[idx]
+
 
 class CustomHTTPSConnection(http.client.HTTPSConnection):
     def __init__(self, host, port=None, ipv6=False, timeout=5, **kwargs):
@@ -29,7 +45,9 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
         try:
             answers = resolver.resolve(record_type)
             if not answers:
-                raise ConnectionError(f"No DNS records found for {self.host} ({record_type})")
+                raise ConnectionError(
+                    f"No DNS records found for {self.host} ({record_type})"
+                )
         except Exception as e:
             raise ConnectionError(f"DNS resolution failed for {self.host}: {e}")
 
@@ -40,19 +58,28 @@ class CustomHTTPSConnection(http.client.HTTPSConnection):
                 self.sock = socket.socket(af, socket.SOCK_STREAM)
                 self.sock.settimeout(self.timeout)
                 self.sock.connect((ip, self.port))
-                self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+                self.sock = self._context.wrap_socket(
+                    self.sock, server_hostname=self.host
+                )
                 return
             except OSError as e:
                 if self.sock:
                     self.sock.close()
-                log(f"Could not connect to {ip}: {e}", 'error')
+                log(f"Could not connect to {ip}: {e}", "error")
                 continue  # Try next IP
 
         raise ConnectionError(
             f"Could not connect to {self.host} on port {self.port} with family {'IPv6' if self.ipv6 else 'IPv4'}"
         )
 
-@debug('get_ip')
+
+def _record_failure(cache, now):
+    cache["timestamp"] = now
+    cache["ip"] = None
+    cache["failures"] = cache.get("failures", 0) + 1
+
+
+@debug("get_ip")
 def get_ip(ipv6=False):
     now = time.time()
     cache = _ip_v6_cache if ipv6 else _ip_v4_cache
@@ -61,8 +88,12 @@ def get_ip(ipv6=False):
     # Positive cache: short TTL, return the previously-fetched IP.
     if cache["ip"] is not None and age < POSITIVE_CACHE_TTL:
         return cache["ip"]
-    # Negative cache: longer TTL, suppress retry storms on broken connectivity.
-    if cache["ip"] is None and cache["timestamp"] > 0 and age < NEGATIVE_CACHE_TTL:
+
+    # Negative cache: kicks in only after >=2 consecutive failures, with TTL
+    # growing per the backoff schedule. The first failure falls through and
+    # retries on the next call so transients self-heal in one tick.
+    backoff = _negative_backoff(cache.get("failures", 0))
+    if cache["ip"] is None and backoff > 0 and age < backoff:
         return None
 
     conn = None
@@ -74,30 +105,27 @@ def get_ip(ipv6=False):
         response = conn.getresponse()
         body = response.read().decode("utf-8")
 
-        log(f"Status: {response.status}, Reason: {response.reason}", 'debug')
-        log(f"Response body: {body}", 'debug')
+        log(f"Status: {response.status}, Reason: {response.reason}", "debug")
+        log(f"Response body: {body}", "debug")
 
         if response.status == 200:
             ip = body.strip()
             cache["timestamp"] = now
             cache["ip"] = ip
+            cache["failures"] = 0
             return ip
 
-        cache["timestamp"] = now
-        cache["ip"] = None
+        _record_failure(cache, now)
         return None
     except ConnectionError as e:
-        # Log the error and optionally retry or handle IPv4 fallback
-        log(f"Unexpected error occurred: {e}", 'error')
-        cache["timestamp"] = now
-        cache["ip"] = None
+        log(f"Unexpected error occurred: {e}", "error")
+        _record_failure(cache, now)
         return None
 
     except Exception as e:
-        log(f"Unexpected error occurred: {e}", 'error')
+        log(f"Unexpected error occurred: {e}", "error")
         traceback.print_exc(file=sys.stderr)
-        cache["timestamp"] = now
-        cache["ip"] = None
+        _record_failure(cache, now)
         return None
     finally:
         if conn:

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -35,12 +35,12 @@ def test_get_ip_v6_success(mock_conn_cls):
     mock_conn = MagicMock()
     mock_response = MagicMock()
     mock_response.status = 200
-    mock_response.read.return_value = b"::1\n"
+    mock_response.read.return_value = b"2001:4860:4860::8888\n"
     mock_conn.getresponse.return_value = mock_response
     mock_conn_cls.return_value = mock_conn
 
     result = get_ip(ipv6=True)
-    assert result == "::1"
+    assert result == "2001:4860:4860::8888"
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
@@ -70,15 +70,15 @@ def test_get_ip_v6_caches_result(mock_conn_cls):
     mock_conn = MagicMock()
     mock_response = MagicMock()
     mock_response.status = 200
-    mock_response.read.return_value = b"::1\n"
+    mock_response.read.return_value = b"2001:4860:4860::8888\n"
     mock_conn.getresponse.return_value = mock_response
     mock_conn_cls.return_value = mock_conn
 
     result1 = get_ip(ipv6=True)
     result2 = get_ip(ipv6=True)
 
-    assert result1 == "::1"
-    assert result2 == "::1"
+    assert result1 == "2001:4860:4860::8888"
+    assert result2 == "2001:4860:4860::8888"
     assert mock_conn_cls.call_count == 1
 
 
@@ -299,11 +299,11 @@ def test_recovery_after_long_failure_streak(mock_conn_cls):
     mock_conn_cls.return_value.request.side_effect = None
     mock_response = MagicMock()
     mock_response.status = 200
-    mock_response.read.return_value = b"::1\n"
+    mock_response.read.return_value = b"2001:4860:4860::8888\n"
     mock_conn_cls.return_value.getresponse.return_value = mock_response
     ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 400
 
-    assert get_ip(ipv6=True) == "::1"
+    assert get_ip(ipv6=True) == "2001:4860:4860::8888"
     assert ip_module._ip_v6_cache["failures"] == 0
 
 
@@ -342,7 +342,10 @@ def test_validate_ip_accepts_valid_ipv4():
 
 
 def test_validate_ip_accepts_valid_ipv6():
-    assert ip_module._validate_ip("2001:db8::1\n", ipv6=True) == "2001:db8::1"
+    assert (
+        ip_module._validate_ip("2001:4860:4860::8888\n", ipv6=True)
+        == "2001:4860:4860::8888"
+    )
 
 
 def test_validate_ip_rejects_empty_body():
@@ -403,7 +406,7 @@ def test_get_ip_wrong_family_response_does_not_cache(mock_conn_cls):
     mock_conn = MagicMock()
     mock_response = MagicMock()
     mock_response.status = 200
-    mock_response.read.return_value = b"::1\n"
+    mock_response.read.return_value = b"2001:4860:4860::8888\n"
     mock_conn.getresponse.return_value = mock_response
     mock_conn_cls.return_value = mock_conn
 
@@ -435,6 +438,119 @@ def test_invalid_response_does_not_reset_failure_counter(mock_conn_cls):
 
 
 # --- Monotonic clock ---
+
+
+# --- Public-IP filter ---
+
+
+def test_validate_ip_rejects_loopback_v4():
+    assert ip_module._validate_ip("127.0.0.1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_loopback_v6():
+    assert ip_module._validate_ip("::1", ipv6=True) is None
+
+
+def test_validate_ip_rejects_rfc1918_private():
+    assert ip_module._validate_ip("10.0.0.1", ipv6=False) is None
+    assert ip_module._validate_ip("172.16.0.1", ipv6=False) is None
+    assert ip_module._validate_ip("192.168.1.1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_cgnat():
+    """CGNAT (100.64.0.0/10) is private per RFC 6598."""
+    assert ip_module._validate_ip("100.64.0.1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_link_local_v4():
+    assert ip_module._validate_ip("169.254.1.1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_link_local_v6():
+    assert ip_module._validate_ip("fe80::1", ipv6=True) is None
+
+
+def test_validate_ip_rejects_ipv6_unique_local():
+    """fc00::/7 ULA is private."""
+    assert ip_module._validate_ip("fc00::1", ipv6=True) is None
+
+
+def test_validate_ip_rejects_multicast():
+    assert ip_module._validate_ip("224.0.0.1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_unspecified():
+    assert ip_module._validate_ip("0.0.0.0", ipv6=False) is None
+    assert ip_module._validate_ip("::", ipv6=True) is None
+
+
+def test_validate_ip_rejects_ipv4_mapped_ipv6():
+    """::ffff:1.2.3.4 is an IPv4 in v6 clothing; reject when v6 was requested."""
+    assert ip_module._validate_ip("::ffff:1.2.3.4", ipv6=True) is None
+
+
+def test_validate_ip_accepts_real_public_v4():
+    assert ip_module._validate_ip("1.1.1.1", ipv6=False) == "1.1.1.1"
+    assert ip_module._validate_ip("8.8.8.8", ipv6=False) == "8.8.8.8"
+
+
+def test_validate_ip_accepts_real_public_v6():
+    assert (
+        ip_module._validate_ip("2001:4860:4860::8888", ipv6=True)
+        == "2001:4860:4860::8888"
+    )
+
+
+# --- Body read cap ---
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_response_read_is_size_capped(mock_conn_cls):
+    """response.read() must be called with a byte cap, not unbounded."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    get_ip(ipv6=False)
+
+    # Verify the read was bounded; no call should be read() with no args.
+    for call in mock_response.read.call_args_list:
+        args, kwargs = call
+        assert (
+            len(args) == 1 or "amt" in kwargs or "size" in kwargs
+        ), "response.read() must be called with a size limit"
+        size = args[0] if args else (kwargs.get("amt") or kwargs.get("size"))
+        assert size <= 1024, f"read cap is too generous: {size}"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_oversized_response_body_is_rejected(mock_conn_cls):
+    """A multi-megabyte body cannot be cached. Read is capped, validation rejects garbage."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    # Even if the upstream sends a huge body, response.read(N) returns at most N bytes.
+    # Simulate by returning the capped slice.
+
+    def capped_read(size=None):
+        full = b"X" * (10 * 1024 * 1024) + b"1.2.3.4"
+        return full[: size if size else len(full)]
+
+    mock_response.read.side_effect = capped_read
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    assert get_ip(ipv6=False) is None
+    assert ip_module._ip_v4_cache["ip"] is None
+    assert ip_module._ip_v4_cache["failures"] == 1
+
+
+# --- Clock rollback ---
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -377,6 +377,48 @@ def test_validate_ip_rejects_oversized_body():
     assert ip_module._validate_ip(body, ipv6=False) is None
 
 
+def test_validate_ip_rejects_whitespace_padded_oversized_body():
+    """A valid IP padded with 500 spaces of whitespace is still rejected.
+
+    The raw body length check must happen BEFORE stripping; otherwise
+    body.strip() reduces the input to a valid IP and the cap is bypassed.
+    """
+    body = "1.2.3.4" + " " * 500
+    assert ip_module._validate_ip(body, ipv6=False) is None
+
+
+def test_validate_ip_rejects_leading_whitespace_padding():
+    """Same hole, leading whitespace edition."""
+    body = " " * 500 + "1.2.3.4"
+    assert ip_module._validate_ip(body, ipv6=False) is None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_rejects_non_utf8_body(mock_conn_cls):
+    """Non-UTF-8 bytes are surfaced as failures, not silently dropped.
+
+    `b'1.2.3.4\\xff'.decode('utf-8', errors='ignore')` would yield '1.2.3.4'
+    and look like a valid IP. The strict decode + explicit error path here
+    is what stops a hostile upstream from smuggling that.
+    """
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\xff"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
+    assert result is None
+    assert ip_module._ip_v4_cache["ip"] is None
+    assert ip_module._ip_v4_cache["failures"] == 1
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert any("non-UTF-8" in c.args[0] for c in error_logs)
+
+
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
 def test_get_ip_invalid_response_body_does_not_cache(mock_conn_cls):
     """A 200 response with garbage body counts as a failure, not a value to cache."""

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -132,3 +132,135 @@ def test_get_ip_generic_exception(mock_conn_cls):
 
     result = get_ip(ipv6=False)
     assert result is None
+
+
+# --- Negative cache (issue #42) ---
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_suppresses_retry_after_connection_error(mock_conn_cls):
+    """First failure attempts and logs; subsequent calls within TTL return None silently."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError(
+        "Network is unreachable"
+    )
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        first = get_ip(ipv6=True)
+        second = get_ip(ipv6=True)
+        third = get_ip(ipv6=True)
+
+    assert first is None
+    assert second is None
+    assert third is None
+    # Only one HTTP attempt; the cache absorbs the others.
+    assert mock_conn_cls.call_count == 1
+    # And only one error log line, not three.
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert len(error_logs) == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_suppresses_retry_after_generic_exception(mock_conn_cls):
+    """Generic exceptions also populate the negative cache."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = Exception("something broke")
+
+    get_ip(ipv6=False)
+    get_ip(ipv6=False)
+
+    assert mock_conn_cls.call_count == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_suppresses_retry_after_http_non_200(mock_conn_cls):
+    """HTTP non-200 responses populate the negative cache."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 503
+    mock_response.read.return_value = b"unavailable"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    get_ip(ipv6=False)
+    get_ip(ipv6=False)
+
+    assert mock_conn_cls.call_count == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_expires(mock_conn_cls):
+    """After NEGATIVE_CACHE_TTL elapses, a new attempt is made."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    get_ip(ipv6=True)
+    # Force the negative cache to expire (TTL is 300s; jump back 400s).
+    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+
+    get_ip(ipv6=True)
+    assert mock_conn_cls.call_count == 2
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_per_family(mock_conn_cls):
+    """An IPv6 failure does not poison the IPv4 cache."""
+    _reset_caches()
+
+    # IPv6 fails, populates negative cache.
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("v6 unreachable")
+    assert get_ip(ipv6=True) is None
+
+    # IPv4 path is independent and should still be attempted.
+    mock_conn_cls.reset_mock()
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+
+    assert get_ip(ipv6=False) == "1.2.3.4"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_clears_on_recovery(mock_conn_cls):
+    """When connectivity recovers after the TTL, the new IP is cached."""
+    _reset_caches()
+    # First call: fails.
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+    assert get_ip(ipv6=True) is None
+    assert ip_module._ip_v6_cache["ip"] is None
+
+    # Force the negative cache to expire.
+    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+
+    # Second call: succeeds.
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"::1\n"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+
+    assert get_ip(ipv6=True) == "::1"
+    assert ip_module._ip_v6_cache["ip"] == "::1"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_negative_cache_does_not_log_on_cache_hit(mock_conn_cls):
+    """A cache hit should produce zero error logs (the noise fix)."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    # Prime the negative cache (one attempt, one error log).
+    get_ip(ipv6=True)
+
+    # Subsequent calls hit the cache and must be completely silent.
+    with patch("fivenines_agent.ip.log") as mock_log:
+        for _ in range(60):  # simulate one hour of ticks
+            get_ip(ipv6=True)
+
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert error_logs == []
+    # No additional HTTP attempts.
+    assert mock_conn_cls.call_count == 1

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -96,7 +96,7 @@ def test_get_ip_cache_expired(mock_conn_cls):
     # First call populates the cache
     get_ip(ipv6=False)
     # Expire the cache
-    ip_module._ip_v4_cache["timestamp"] = time.time() - 120
+    ip_module._ip_v4_cache["timestamp"] = time.monotonic() - 120
 
     get_ip(ipv6=False)
     assert mock_conn_cls.call_count == 2
@@ -194,13 +194,13 @@ def test_backoff_grows_with_consecutive_failures(mock_conn_cls):
     assert ip_module._ip_v6_cache["failures"] == 2
 
     # Skip past the 60s window and retry: 3rd failure caches for 120s.
-    ip_module._ip_v6_cache["timestamp"] = time.time() - 70
+    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 70
     get_ip(ipv6=True)
     assert ip_module._ip_v6_cache["failures"] == 3
     assert ip_module._negative_backoff(3) == 120
 
     # Skip past the 120s window: 4th caches for 240s.
-    ip_module._ip_v6_cache["timestamp"] = time.time() - 130
+    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 130
     get_ip(ipv6=True)
     assert ip_module._ip_v6_cache["failures"] == 4
     assert ip_module._negative_backoff(4) == 240
@@ -217,7 +217,7 @@ def test_success_resets_failure_counter(mock_conn_cls):
     assert ip_module._ip_v4_cache["failures"] == 2
 
     # Skip past the cache window and switch the mock to success.
-    ip_module._ip_v4_cache["timestamp"] = time.time() - 70
+    ip_module._ip_v4_cache["timestamp"] = time.monotonic() - 70
     mock_conn_cls.return_value.request.side_effect = None
     mock_response = MagicMock()
     mock_response.status = 200
@@ -291,7 +291,7 @@ def test_recovery_after_long_failure_streak(mock_conn_cls):
     # Force a long streak.
     for _ in range(5):
         get_ip(ipv6=True)
-        ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+        ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 400
 
     assert ip_module._ip_v6_cache["failures"] >= 2
 
@@ -301,7 +301,7 @@ def test_recovery_after_long_failure_streak(mock_conn_cls):
     mock_response.status = 200
     mock_response.read.return_value = b"::1\n"
     mock_conn_cls.return_value.getresponse.return_value = mock_response
-    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 400
 
     assert get_ip(ipv6=True) == "::1"
     assert ip_module._ip_v6_cache["failures"] == 0
@@ -332,3 +332,133 @@ def test_failures_counted_for_generic_exception(mock_conn_cls):
     get_ip(ipv6=False)
     get_ip(ipv6=False)
     assert ip_module._ip_v4_cache["failures"] == 2
+
+
+# --- Response validation ---
+
+
+def test_validate_ip_accepts_valid_ipv4():
+    assert ip_module._validate_ip("1.2.3.4\n", ipv6=False) == "1.2.3.4"
+
+
+def test_validate_ip_accepts_valid_ipv6():
+    assert ip_module._validate_ip("2001:db8::1\n", ipv6=True) == "2001:db8::1"
+
+
+def test_validate_ip_rejects_empty_body():
+    assert ip_module._validate_ip("", ipv6=False) is None
+    assert ip_module._validate_ip("   \n", ipv6=False) is None
+
+
+def test_validate_ip_rejects_html_body():
+    assert ip_module._validate_ip("<html>error</html>", ipv6=False) is None
+
+
+def test_validate_ip_rejects_garbage():
+    assert ip_module._validate_ip("not an ip", ipv6=False) is None
+
+
+def test_validate_ip_rejects_wrong_family_v4_for_v6():
+    """An IPv4 address returned for an IPv6 request is rejected."""
+    assert ip_module._validate_ip("1.2.3.4", ipv6=True) is None
+
+
+def test_validate_ip_rejects_wrong_family_v6_for_v4():
+    """An IPv6 address returned for an IPv4 request is rejected."""
+    assert ip_module._validate_ip("::1", ipv6=False) is None
+
+
+def test_validate_ip_rejects_oversized_body():
+    """A body larger than MAX_RESPONSE_BODY chars is rejected even if it starts with a valid IP."""
+    body = "1.2.3.4" + "X" * 500
+    assert ip_module._validate_ip(body, ipv6=False) is None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_invalid_response_body_does_not_cache(mock_conn_cls):
+    """A 200 response with garbage body counts as a failure, not a value to cache."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"<html>upstream error</html>"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
+    assert result is None
+    assert ip_module._ip_v4_cache["ip"] is None
+    assert ip_module._ip_v4_cache["failures"] == 1
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert len(error_logs) == 1
+    assert "non-IPv4 body" in error_logs[0].args[0]
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_wrong_family_response_does_not_cache(mock_conn_cls):
+    """If ip.fivenines.io returns an IPv6 for an IPv4 request, treat as failure."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"::1\n"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    assert get_ip(ipv6=False) is None
+    assert ip_module._ip_v4_cache["ip"] is None
+    assert ip_module._ip_v4_cache["failures"] == 1
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_invalid_response_does_not_reset_failure_counter(mock_conn_cls):
+    """Garbage response must NOT clear an existing failure streak."""
+    _reset_caches()
+
+    # First fail with ConnectionError to get failures=1.
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+    get_ip(ipv6=False)
+    assert ip_module._ip_v4_cache["failures"] == 1
+
+    # Then a 200 with garbage body. Must keep counter incrementing, not reset.
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"<html>error</html>"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+
+    get_ip(ipv6=False)
+    assert ip_module._ip_v4_cache["failures"] == 2
+    assert ip_module._ip_v4_cache["ip"] is None
+
+
+# --- Monotonic clock ---
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_clock_rollback_does_not_extend_suppression(mock_conn_cls):
+    """A wall-clock backward jump (NTP, suspend, VM restore) cannot keep the cache suppressed past the cap.
+
+    With monotonic timestamps the age math is rollback-immune by construction.
+    A negative wall-clock skew would have made `age < backoff` true forever
+    on the previous (time.time()-based) version. We simulate the rollback by
+    forcing the cache timestamp into the future and verifying the next call
+    still re-attempts after the backoff window.
+    """
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    # Establish 2 consecutive failures (cache active for 60s).
+    get_ip(ipv6=True)
+    get_ip(ipv6=True)
+    assert ip_module._ip_v6_cache["failures"] == 2
+    attempts_so_far = mock_conn_cls.call_count
+
+    # Force the timestamp >300s in the past on the monotonic clock. Any
+    # cap-respecting implementation should attempt again.
+    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 1000
+
+    get_ip(ipv6=True)
+    assert mock_conn_cls.call_count == attempts_so_far + 1

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -127,6 +127,59 @@ def test_get_ip_http_error(mock_conn_cls):
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_http_error_with_html_body_logs_status_not_body(mock_conn_cls):
+    """A 503 with a large HTML error page must log HTTP status, not "oversized body".
+
+    Real-world error responses are commonly multi-KB HTML pages. The status
+    check must happen BEFORE body length/encoding checks so operators see
+    the actual HTTP failure, not a generic body validation error.
+    """
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 503
+    mock_response.reason = "Service Unavailable"
+    mock_response.read.return_value = (
+        b"<html><body>Service Unavailable</body></html>" * 50
+    )
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
+    assert result is None
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert len(error_logs) == 1
+    assert "503" in error_logs[0].args[0]
+    # The log must NOT be the generic "oversized body" or "non-UTF-8 body".
+    assert "oversized body" not in error_logs[0].args[0]
+    assert "non-UTF-8" not in error_logs[0].args[0]
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_http_error_with_non_utf8_body_logs_status_not_body(mock_conn_cls):
+    """A 502 with a non-UTF-8 body must still log the HTTP status."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 502
+    mock_response.reason = "Bad Gateway"
+    mock_response.read.return_value = b"\xff\xfe\xff garbage"
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
+    assert result is None
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert len(error_logs) == 1
+    assert "502" in error_logs[0].args[0]
+    assert "non-UTF-8" not in error_logs[0].args[0]
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
 def test_get_ip_connection_error(mock_conn_cls):
     _reset_caches()
     mock_conn_cls.return_value.request.side_effect = ConnectionError("refused")

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -104,16 +104,26 @@ def test_get_ip_cache_expired(mock_conn_cls):
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
 def test_get_ip_http_error(mock_conn_cls):
+    """A non-200 response returns None and emits an error log so the failure
+    surfaces in telemetry on the FIRST uncached attempt, not just after the
+    second consecutive failure."""
     _reset_caches()
     mock_conn = MagicMock()
     mock_response = MagicMock()
-    mock_response.status = 500
+    mock_response.status = 503
+    mock_response.reason = "Service Unavailable"
     mock_response.read.return_value = b"error"
     mock_conn.getresponse.return_value = mock_response
     mock_conn_cls.return_value = mock_conn
 
-    result = get_ip(ipv6=False)
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
     assert result is None
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert len(error_logs) == 1
+    assert "503" in error_logs[0].args[0]
+    assert "Service Unavailable" in error_logs[0].args[0]
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -96,7 +96,7 @@ def test_get_ip_cache_expired(mock_conn_cls):
     # First call populates the cache
     get_ip(ipv6=False)
     # Expire the cache
-    ip_module._ip_v4_cache["timestamp"] = time.monotonic() - 120
+    ip_module._ip_v4_cache["timestamp"] = ip_module._now() - 120
 
     get_ip(ipv6=False)
     assert mock_conn_cls.call_count == 2
@@ -170,6 +170,28 @@ def test_second_consecutive_failure_caches_for_60s(mock_conn_cls):
     assert [c for c in mock_log.call_args_list if c.args[1] == "error"] == []
 
 
+def test_now_returns_monotonic_seconds():
+    """_now() returns a monotonically-increasing float (seconds since some fixed point)."""
+    a = ip_module._now()
+    b = ip_module._now()
+    assert isinstance(a, float)
+    assert b >= a
+
+
+def test_now_falls_back_when_clock_boottime_attribute_missing():
+    """On platforms without CLOCK_BOOTTIME, _now() falls back to time.monotonic()."""
+    with patch.object(time, "clock_gettime", side_effect=AttributeError):
+        result = ip_module._now()
+    assert isinstance(result, float)
+
+
+def test_now_falls_back_when_clock_boottime_syscall_unsupported():
+    """On platforms where clock_gettime(CLOCK_BOOTTIME) fails, _now() falls back."""
+    with patch.object(time, "clock_gettime", side_effect=OSError("EINVAL")):
+        result = ip_module._now()
+    assert isinstance(result, float)
+
+
 def test_negative_backoff_schedule():
     """The backoff schedule starts at 0, then 60, 120, 240, 300, capped."""
     assert ip_module._negative_backoff(0) == 0
@@ -194,13 +216,13 @@ def test_backoff_grows_with_consecutive_failures(mock_conn_cls):
     assert ip_module._ip_v6_cache["failures"] == 2
 
     # Skip past the 60s window and retry: 3rd failure caches for 120s.
-    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 70
+    ip_module._ip_v6_cache["timestamp"] = ip_module._now() - 70
     get_ip(ipv6=True)
     assert ip_module._ip_v6_cache["failures"] == 3
     assert ip_module._negative_backoff(3) == 120
 
     # Skip past the 120s window: 4th caches for 240s.
-    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 130
+    ip_module._ip_v6_cache["timestamp"] = ip_module._now() - 130
     get_ip(ipv6=True)
     assert ip_module._ip_v6_cache["failures"] == 4
     assert ip_module._negative_backoff(4) == 240
@@ -217,7 +239,7 @@ def test_success_resets_failure_counter(mock_conn_cls):
     assert ip_module._ip_v4_cache["failures"] == 2
 
     # Skip past the cache window and switch the mock to success.
-    ip_module._ip_v4_cache["timestamp"] = time.monotonic() - 70
+    ip_module._ip_v4_cache["timestamp"] = ip_module._now() - 70
     mock_conn_cls.return_value.request.side_effect = None
     mock_response = MagicMock()
     mock_response.status = 200
@@ -291,7 +313,7 @@ def test_recovery_after_long_failure_streak(mock_conn_cls):
     # Force a long streak.
     for _ in range(5):
         get_ip(ipv6=True)
-        ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 400
+        ip_module._ip_v6_cache["timestamp"] = ip_module._now() - 400
 
     assert ip_module._ip_v6_cache["failures"] >= 2
 
@@ -301,7 +323,7 @@ def test_recovery_after_long_failure_streak(mock_conn_cls):
     mock_response.status = 200
     mock_response.read.return_value = b"2001:4860:4860::8888\n"
     mock_conn_cls.return_value.getresponse.return_value = mock_response
-    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 400
+    ip_module._ip_v6_cache["timestamp"] = ip_module._now() - 400
 
     assert get_ip(ipv6=True) == "2001:4860:4860::8888"
     assert ip_module._ip_v6_cache["failures"] == 0
@@ -651,7 +673,7 @@ def test_clock_rollback_does_not_extend_suppression(mock_conn_cls):
 
     # Force the timestamp >300s in the past on the monotonic clock. Any
     # cap-respecting implementation should attempt again.
-    ip_module._ip_v6_cache["timestamp"] = time.monotonic() - 1000
+    ip_module._ip_v6_cache["timestamp"] = ip_module._now() - 1000
 
     get_ip(ipv6=True)
     assert mock_conn_cls.call_count == attempts_so_far + 1

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -393,6 +393,41 @@ def test_validate_ip_rejects_leading_whitespace_padding():
     assert ip_module._validate_ip(body, ipv6=False) is None
 
 
+def test_validate_ip_rejects_multibyte_whitespace_padding():
+    """Multibyte Unicode whitespace counts as 1 char but 3+ bytes.
+
+    `"1.2.3.4" + "\\u2003" * 57` is 64 chars (under the char-cap) but 178
+    bytes (over the byte-cap). str.strip() removes U+2003 EM SPACE, so the
+    naive char-length check would let this through.
+    """
+    body = "1.2.3.4" + " " * 57
+    assert len(body) == 64  # passes char count
+    assert len(body.encode("utf-8")) > 64  # fails byte count
+    assert ip_module._validate_ip(body, ipv6=False) is None
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_get_ip_rejects_oversized_response_at_caller(mock_conn_cls):
+    """The caller must reject oversized raw bodies before decode/validate."""
+    _reset_caches()
+    mock_conn = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = 200
+    # 200 bytes is over MAX_RESPONSE_BODY (64) but under the read cap (256).
+    mock_response.read.return_value = b"1.2.3.4" + b" " * 200
+    mock_conn.getresponse.return_value = mock_response
+    mock_conn_cls.return_value = mock_conn
+
+    with patch("fivenines_agent.ip.log") as mock_log:
+        result = get_ip(ipv6=False)
+
+    assert result is None
+    assert ip_module._ip_v4_cache["ip"] is None
+    assert ip_module._ip_v4_cache["failures"] == 1
+    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
+    assert any("oversized body" in c.args[0] for c in error_logs)
+
+
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
 def test_get_ip_rejects_non_utf8_body(mock_conn_cls):
     """Non-UTF-8 bytes are surfaced as failures, not silently dropped.

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -400,7 +400,7 @@ def test_validate_ip_rejects_multibyte_whitespace_padding():
     bytes (over the byte-cap). str.strip() removes U+2003 EM SPACE, so the
     naive char-length check would let this through.
     """
-    body = "1.2.3.4" + " " * 57
+    body = "1.2.3.4" + "\u2003" * 57
     assert len(body) == 64  # passes char count
     assert len(body.encode("utf-8")) > 64  # fails byte count
     assert ip_module._validate_ip(body, ipv6=False) is None

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -9,10 +9,10 @@ from fivenines_agent.ip import get_ip
 
 def _reset_caches():
     """Reset module-level caches between tests."""
-    ip_module._ip_v4_cache["timestamp"] = 0
-    ip_module._ip_v4_cache["ip"] = None
-    ip_module._ip_v6_cache["timestamp"] = 0
-    ip_module._ip_v6_cache["ip"] = None
+    for cache in (ip_module._ip_v4_cache, ip_module._ip_v6_cache):
+        cache["timestamp"] = 0
+        cache["ip"] = None
+        cache["failures"] = 0
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
@@ -134,47 +134,182 @@ def test_get_ip_generic_exception(mock_conn_cls):
     assert result is None
 
 
-# --- Negative cache (issue #42) ---
+# --- Negative-cache backoff (issue #42) ---
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_suppresses_retry_after_connection_error(mock_conn_cls):
-    """First failure attempts and logs; subsequent calls within TTL return None silently."""
+def test_first_failure_does_not_cache(mock_conn_cls):
+    """A single transient failure must NOT engage the negative cache.
+
+    On main, transients self-heal next tick; the negative cache must not
+    regress that. So failure #1 is logged and re-attempted on the next call.
+    """
     _reset_caches()
-    mock_conn_cls.return_value.request.side_effect = ConnectionError(
-        "Network is unreachable"
-    )
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    assert get_ip(ipv6=True) is None
+    assert get_ip(ipv6=True) is None
+    # Both calls attempted the network (no cache yet).
+    assert mock_conn_cls.call_count == 2
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_second_consecutive_failure_caches_for_60s(mock_conn_cls):
+    """After 2 consecutive failures, a third call within 60s hits the cache."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    get_ip(ipv6=True)  # failures=1, no cache
+    get_ip(ipv6=True)  # failures=2, caches for 60s
+    assert mock_conn_cls.call_count == 2
 
     with patch("fivenines_agent.ip.log") as mock_log:
-        first = get_ip(ipv6=True)
-        second = get_ip(ipv6=True)
-        third = get_ip(ipv6=True)
+        assert get_ip(ipv6=True) is None  # cache hit, silent
 
-    assert first is None
-    assert second is None
-    assert third is None
-    # Only one HTTP attempt; the cache absorbs the others.
-    assert mock_conn_cls.call_count == 1
-    # And only one error log line, not three.
-    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
-    assert len(error_logs) == 1
+    assert mock_conn_cls.call_count == 2  # no new HTTP call
+    assert [c for c in mock_log.call_args_list if c.args[1] == "error"] == []
+
+
+def test_negative_backoff_schedule():
+    """The backoff schedule starts at 0, then 60, 120, 240, 300, capped."""
+    assert ip_module._negative_backoff(0) == 0
+    assert ip_module._negative_backoff(1) == 0
+    assert ip_module._negative_backoff(2) == 60
+    assert ip_module._negative_backoff(3) == 120
+    assert ip_module._negative_backoff(4) == 240
+    assert ip_module._negative_backoff(5) == 300
+    assert ip_module._negative_backoff(50) == 300  # cap
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_suppresses_retry_after_generic_exception(mock_conn_cls):
-    """Generic exceptions also populate the negative cache."""
+def test_backoff_grows_with_consecutive_failures(mock_conn_cls):
+    """Each retry after the cached window starts a longer suppression."""
     _reset_caches()
-    mock_conn_cls.return_value.request.side_effect = Exception("something broke")
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
 
-    get_ip(ipv6=False)
-    get_ip(ipv6=False)
+    # 1st: no cache
+    get_ip(ipv6=True)
+    # 2nd: caches for 60s
+    get_ip(ipv6=True)
+    assert ip_module._ip_v6_cache["failures"] == 2
 
-    assert mock_conn_cls.call_count == 1
+    # Skip past the 60s window and retry: 3rd failure caches for 120s.
+    ip_module._ip_v6_cache["timestamp"] = time.time() - 70
+    get_ip(ipv6=True)
+    assert ip_module._ip_v6_cache["failures"] == 3
+    assert ip_module._negative_backoff(3) == 120
+
+    # Skip past the 120s window: 4th caches for 240s.
+    ip_module._ip_v6_cache["timestamp"] = time.time() - 130
+    get_ip(ipv6=True)
+    assert ip_module._ip_v6_cache["failures"] == 4
+    assert ip_module._negative_backoff(4) == 240
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_suppresses_retry_after_http_non_200(mock_conn_cls):
-    """HTTP non-200 responses populate the negative cache."""
+def test_success_resets_failure_counter(mock_conn_cls):
+    """A successful fetch must reset the failure counter to 0."""
+    _reset_caches()
+
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+    get_ip(ipv6=False)
+    get_ip(ipv6=False)
+    assert ip_module._ip_v4_cache["failures"] == 2
+
+    # Skip past the cache window and switch the mock to success.
+    ip_module._ip_v4_cache["timestamp"] = time.time() - 70
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+
+    assert get_ip(ipv6=False) == "1.2.3.4"
+    assert ip_module._ip_v4_cache["failures"] == 0
+    assert ip_module._ip_v4_cache["ip"] == "1.2.3.4"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_backoff_per_family(mock_conn_cls):
+    """An IPv6 failure streak does not back off the IPv4 path."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("v6 unreachable")
+    get_ip(ipv6=True)
+    get_ip(ipv6=True)
+    assert ip_module._ip_v6_cache["failures"] == 2
+
+    # IPv4 should still attempt with no suppression.
+    mock_conn_cls.reset_mock()
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"1.2.3.4\n"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+
+    assert get_ip(ipv6=False) == "1.2.3.4"
+    assert ip_module._ip_v4_cache["failures"] == 0
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_persistent_failure_steady_state_quiet(mock_conn_cls):
+    """A permanently broken host hits the 300s cap and stays mostly quiet.
+
+    Simulates 60 minutes of ticks (3600s) for a host with no IPv6.
+    Expectation: ~12 HTTP attempts (1 every 5 min once steady state), not 60.
+    """
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    attempts = 0
+    for _ in range(60):
+        # Pretend the agent ticked once per minute.
+        if ip_module._ip_v6_cache["timestamp"] != 0:
+            ip_module._ip_v6_cache["timestamp"] -= 60
+        before = mock_conn_cls.call_count
+        get_ip(ipv6=True)
+        if mock_conn_cls.call_count > before:
+            attempts += 1
+
+    # Backoff schedule for 60 ticks (1/min):
+    # tick 1: attempt (failures=1, no cache)
+    # tick 2: attempt (failures=2, cache 60s)
+    # tick 3: attempt (failures=3, cache 120s)
+    # tick 5: attempt (failures=4, cache 240s)
+    # tick 9: attempt (failures=5, cache 300s)
+    # ticks 14, 19, 24, ...: attempt every 5 min after that
+    # Expected attempts in 60 ticks: ~14 (well under one-per-tick).
+    assert attempts < 20, f"too many attempts: {attempts}"
+    assert attempts > 5, f"backoff suppressed too aggressively: {attempts}"
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_recovery_after_long_failure_streak(mock_conn_cls):
+    """When a permanently-broken host comes back online, the next probe succeeds."""
+    _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
+
+    # Force a long streak.
+    for _ in range(5):
+        get_ip(ipv6=True)
+        ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+
+    assert ip_module._ip_v6_cache["failures"] >= 2
+
+    # Network recovers.
+    mock_conn_cls.return_value.request.side_effect = None
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b"::1\n"
+    mock_conn_cls.return_value.getresponse.return_value = mock_response
+    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
+
+    assert get_ip(ipv6=True) == "::1"
+    assert ip_module._ip_v6_cache["failures"] == 0
+
+
+@patch("fivenines_agent.ip.CustomHTTPSConnection")
+def test_failures_counted_for_http_non_200(mock_conn_cls):
+    """HTTP non-200 responses count as failures for backoff purposes."""
     _reset_caches()
     mock_conn = MagicMock()
     mock_response = MagicMock()
@@ -185,82 +320,15 @@ def test_negative_cache_suppresses_retry_after_http_non_200(mock_conn_cls):
 
     get_ip(ipv6=False)
     get_ip(ipv6=False)
-
-    assert mock_conn_cls.call_count == 1
-
-
-@patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_expires(mock_conn_cls):
-    """After NEGATIVE_CACHE_TTL elapses, a new attempt is made."""
-    _reset_caches()
-    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
-
-    get_ip(ipv6=True)
-    # Force the negative cache to expire (TTL is 300s; jump back 400s).
-    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
-
-    get_ip(ipv6=True)
-    assert mock_conn_cls.call_count == 2
+    assert ip_module._ip_v4_cache["failures"] == 2
 
 
 @patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_per_family(mock_conn_cls):
-    """An IPv6 failure does not poison the IPv4 cache."""
+def test_failures_counted_for_generic_exception(mock_conn_cls):
+    """Generic exceptions count as failures for backoff purposes."""
     _reset_caches()
+    mock_conn_cls.return_value.request.side_effect = Exception("something broke")
 
-    # IPv6 fails, populates negative cache.
-    mock_conn_cls.return_value.request.side_effect = ConnectionError("v6 unreachable")
-    assert get_ip(ipv6=True) is None
-
-    # IPv4 path is independent and should still be attempted.
-    mock_conn_cls.reset_mock()
-    mock_conn_cls.return_value.request.side_effect = None
-    mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.read.return_value = b"1.2.3.4\n"
-    mock_conn_cls.return_value.getresponse.return_value = mock_response
-
-    assert get_ip(ipv6=False) == "1.2.3.4"
-
-
-@patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_clears_on_recovery(mock_conn_cls):
-    """When connectivity recovers after the TTL, the new IP is cached."""
-    _reset_caches()
-    # First call: fails.
-    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
-    assert get_ip(ipv6=True) is None
-    assert ip_module._ip_v6_cache["ip"] is None
-
-    # Force the negative cache to expire.
-    ip_module._ip_v6_cache["timestamp"] = time.time() - 400
-
-    # Second call: succeeds.
-    mock_conn_cls.return_value.request.side_effect = None
-    mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.read.return_value = b"::1\n"
-    mock_conn_cls.return_value.getresponse.return_value = mock_response
-
-    assert get_ip(ipv6=True) == "::1"
-    assert ip_module._ip_v6_cache["ip"] == "::1"
-
-
-@patch("fivenines_agent.ip.CustomHTTPSConnection")
-def test_negative_cache_does_not_log_on_cache_hit(mock_conn_cls):
-    """A cache hit should produce zero error logs (the noise fix)."""
-    _reset_caches()
-    mock_conn_cls.return_value.request.side_effect = ConnectionError("unreachable")
-
-    # Prime the negative cache (one attempt, one error log).
-    get_ip(ipv6=True)
-
-    # Subsequent calls hit the cache and must be completely silent.
-    with patch("fivenines_agent.ip.log") as mock_log:
-        for _ in range(60):  # simulate one hour of ticks
-            get_ip(ipv6=True)
-
-    error_logs = [c for c in mock_log.call_args_list if c.args[1] == "error"]
-    assert error_logs == []
-    # No additional HTTP attempts.
-    assert mock_conn_cls.call_count == 1
+    get_ip(ipv6=False)
+    get_ip(ipv6=False)
+    assert ip_module._ip_v4_cache["failures"] == 2


### PR DESCRIPTION
## Summary

Closes #42.

On hosts with broken or absent IPv6 connectivity, `get_ip(ipv6=True)` fails on every tick. Each failure produces 2 error lines in the systemd journal (the inner `Could not connect to <ip>` from `CustomHTTPSConnection.connect` and the outer `Unexpected error occurred` from `get_ip`). At default 60s tick, that's ~5760 lines/day for a single broken host. Surfaced during the GPU silent-failure investigation (#43).

The agent had a 60s positive cache (`ip.py:54-58`) for successful fetches, but no corresponding negative cache. Every failure path through lines 79-87 re-attempted the network call and re-logged the same error.

## What changes

`fivenines_agent/ip.py`:

- New module constant `NEGATIVE_CACHE_TTL = 300` (5 minutes -- longer than the 60s positive cache and longer than the default tick interval, so a broken host doesn't flap into the cache window every minute).
- Every failure path (HTTP non-200, `ConnectionError`, generic `Exception`) now updates the cache: `ip=None, timestamp=now`. Subsequent calls within 300s short-circuit at the new check and return `None` silently.
- Cache check refactored into one block at the top of `get_ip`:
  - Positive hit (`ip is not None and age < 60s`) returns the cached IP.
  - Negative hit (`ip is None and timestamp > 0 and age < 300s`) returns `None` silently.
  - Otherwise falls through to a fresh fetch.
- `conn = None` initialized before the `try` block to keep the `finally` clause correct on early exits (was a latent NameError if `ssl.create_default_context` ever raised).

## Operator-visible result on the diagnosed host

Before:
```
[ERROR] Could not connect to 2a01:4f8:c013:ad01::1: [Errno 101] Network is unreachable
[ERROR] Unexpected error occurred: Could not connect to ip.fivenines.io on port 443 with family IPv6
[ERROR] Could not connect to 2a01:4f8:c013:ad01::1: [Errno 101] Network is unreachable
[ERROR] Unexpected error occurred: Could not connect to ip.fivenines.io on port 443 with family IPv6
... (every 60 seconds, forever)
```

After:
```
[ERROR] Could not connect to 2a01:4f8:c013:ad01::1: [Errno 101] Network is unreachable
[ERROR] Unexpected error occurred: Could not connect to ip.fivenines.io on port 443 with family IPv6
... (silence for 5 minutes)
[ERROR] Could not connect to 2a01:4f8:c013:ad01::1: [Errno 101] Network is unreachable
[ERROR] Unexpected error occurred: Could not connect to ip.fivenines.io on port 443 with family IPv6
... (silence for 5 minutes)
```

That's a 60x reduction in error volume per failed host, while still leaving a periodic heartbeat so the operator knows the failure mode is current.

## Recovery

Recovery is automatic: once the 300s negative TTL expires, the next call re-attempts. On success, the cache transitions cleanly from `(ip=None)` to `(ip=<new IP>)` and the next 60s of calls return the cached IP.

## Test plan

- [x] 376 tests pass (7 new in `test_ip.py`)
- [x] Existing 8 tests still pass (positive cache, expiration, all three failure modes)
- [x] New tests cover:
  - `ConnectionError` populates negative cache; 60 subsequent calls produce zero log entries and zero HTTP attempts
  - Generic `Exception` populates negative cache
  - HTTP non-200 populates negative cache
  - `NEGATIVE_CACHE_TTL` expiration triggers a fresh attempt
  - IPv6 failure does not poison IPv4 cache (and vice versa)
  - Recovery: after TTL expires, success replaces cached `None` with the new IP

## Out of scope

- Detecting IPv6 stack absence at startup and gating `get_ip(ipv6=True)` via the capability system. Considered in #42 as option #2 -- defer until needed.
- Exponential backoff. Considered in #42 as option #3 -- the symmetric cache is simpler and matches the existing positive-cache pattern.