### PR TITLE
v1.6.3

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.6.2'
+VERSION = '1.6.3'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.6.2"
+version = "1.6.3"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"


### PR DESCRIPTION
Patch release.

## Included since v1.6.2

- #45 Feature: include capability failure reasons in logs and API payloads
- #46 Fix: cache get_ip failures to stop journal spam (closes #42)

Once merged, push the `v1.6.3` tag to trigger the build-release workflow:

```
git fetch origin
git tag v1.6.3 origin/main
git push origin v1.6.3
```

Release notes are auto-generated by `softprops/action-gh-release@v2`.