### PR TITLE
Feature: persist a stable machine_id for idempotent enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ For Synology NAS devices running DSM 7 and higher, the agent is distributed as a
 
 > **Note:** To comply with Synology DSM 7's strict security policies, the agent runs as a dedicated low-privilege system user (`sc-fivenines-agent`), not as `root`. Because it cannot use `sudo`, deep system hardware telemetry (like SMART disk health, RAID mapping, and raw `sysfs` temperature sensors) may be gracefully disabled depending on your NAS model permissions. QEMU and Proxmox metrics are also excluded from the Synology build.
 
+### Cloning VMs or building golden images
+
+The agent keeps two per-machine files in its config directory
+(`/etc/fivenines_agent` by default): the per-host `TOKEN` and `MACHINE_ID`, a
+stable identifier the backend uses to recognize a machine across
+re-enrollments. If the agent is installed **and started** before a VM template
+or golden image is captured, both files are baked into the image and every
+clone inherits them, so the backend treats all the clones as one host and
+merges their metrics.
+
+The reliable approach is to install and enroll the agent **after** cloning
+(via cloud-init, a provisioning script, or by hand), so each machine gets its
+own identity.
+
+If the agent must be present in the image, remove its per-machine state before
+capturing the template so each clone regenerates it on first start:
+
+```bash
+sudo rm -f /etc/fivenines_agent/TOKEN /etc/fivenines_agent/MACHINE_ID
+```
+
+Use `~/.config/fivenines_agent` for a user-level install or
+`/boot/config/custom/fivenines_agent` on UNRAID. Each clone then needs the
+agent re-enrolled with a fresh token.
+
 ## Update
 
 ### Standard Update (with sudo/root)

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -23,6 +23,7 @@ from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context
 from fivenines_agent.files import file_handles_limit, file_handles_used
 from fivenines_agent.ip import get_ip
 from fivenines_agent.load_average import load_average
+from fivenines_agent.machine_id import get_machine_id
 from fivenines_agent.packages import packages_sync
 from fivenines_agent.permissions import get_permissions, print_capabilities_banner
 from fivenines_agent.ping import tcp_ping
@@ -75,6 +76,7 @@ class Agent:
             "capabilities": self.permissions.get_all(),
             "capability_reasons": self.permissions.get_reasons(),
             "user_context": get_user_context(CONFIG_DIR),
+            "machine_id": get_machine_id(),
         }
 
         self.queue = SynchronizationQueue(maxsize=100)

--- a/fivenines_agent/machine_id.py
+++ b/fivenines_agent/machine_id.py
@@ -1,0 +1,94 @@
+"""Stable per-agent machine identity.
+
+The agent generates a UUID on first run and persists it next to the TOKEN
+file in the config directory. The same value is returned on every later run,
+which lets the server treat re-enrollment of one machine as idempotent
+instead of creating a duplicate host (see fivenines_server #354).
+
+Resolution order:
+
+    CONFIG_DIR/MACHINE_ID holds a valid UUID  ->  reuse it
+    otherwise                                 ->  generate a uuid4, persist it
+    cannot persist                            ->  return None
+
+Returning None is deliberate: an agent that cannot persist a stable id sends
+no machine_id, and the server falls back to creating a new host per
+enrollment (Phase 1 behavior). A per-run UUID would be worse -- it would look
+like a brand-new machine on every restart.
+"""
+
+import os
+import uuid
+
+from fivenines_agent.debug import log
+from fivenines_agent.env import config_dir
+
+MACHINE_ID_FILENAME = "MACHINE_ID"
+
+
+def _valid_uuid(value):
+    """True when value is a well-formed UUID string."""
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _read_persisted_id(path):
+    """Return the persisted machine id when the file holds a valid UUID."""
+    try:
+        with open(path, "r") as f:
+            content = f.read().strip()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        log(f"Could not read machine id file {path}: {e}", "error")
+        return None
+
+    if _valid_uuid(content):
+        return content
+
+    log(f"Machine id file {path} is invalid, regenerating", "warn")
+    return None
+
+
+def _persist_id(path, value):
+    """Write value to path with owner-only permissions. True on success."""
+    try:
+        with open(path, "w") as f:
+            f.write(value)
+        os.chmod(path, 0o600)
+        return True
+    except OSError as e:
+        log(
+            f"Could not persist machine id to {path}: {e}. "
+            "Sending no machine_id this run.",
+            "warn",
+        )
+        return False
+
+
+def get_machine_id():
+    """Return a stable per-agent UUID, or None when it cannot be persisted.
+
+    Never raises: any unexpected failure degrades to None so machine id
+    resolution can never stop the agent from starting.
+    """
+    try:
+        path = os.path.join(config_dir(), MACHINE_ID_FILENAME)
+
+        persisted = _read_persisted_id(path)
+        if persisted is not None:
+            log("machine_id resolved from persisted file", "info")
+            return persisted
+
+        new_id = str(uuid.uuid4())
+        if _persist_id(path, new_id):
+            log("machine_id generated and persisted", "info")
+            return new_id
+
+        return None
+    except Exception as e:
+        log(f"Unexpected error resolving machine id: {e}", "error")
+        return None

--- a/tests/test_machine_id.py
+++ b/tests/test_machine_id.py
@@ -1,0 +1,117 @@
+"""Tests for the persistent per-agent machine id."""
+
+import os
+import uuid
+from unittest.mock import patch
+
+from fivenines_agent.machine_id import (
+    MACHINE_ID_FILENAME,
+    _persist_id,
+    _read_persisted_id,
+    _valid_uuid,
+    get_machine_id,
+)
+
+# --- _valid_uuid -----------------------------------------------------------
+
+
+def test_valid_uuid_accepts_uuid4():
+    assert _valid_uuid(str(uuid.uuid4())) is True
+
+
+def test_valid_uuid_rejects_garbage():
+    assert _valid_uuid("not-a-uuid") is False
+
+
+def test_valid_uuid_rejects_empty_string():
+    assert _valid_uuid("") is False
+
+
+def test_valid_uuid_rejects_non_string():
+    assert _valid_uuid(None) is False
+
+
+# --- _read_persisted_id ----------------------------------------------------
+
+
+def test_read_persisted_id_returns_valid_uuid(tmp_path):
+    path = tmp_path / MACHINE_ID_FILENAME
+    value = str(uuid.uuid4())
+    path.write_text(value)
+    assert _read_persisted_id(str(path)) == value
+
+
+def test_read_persisted_id_returns_none_when_missing(tmp_path):
+    path = tmp_path / MACHINE_ID_FILENAME
+    assert _read_persisted_id(str(path)) is None
+
+
+def test_read_persisted_id_returns_none_when_corrupt(tmp_path):
+    path = tmp_path / MACHINE_ID_FILENAME
+    path.write_text("not-a-valid-uuid")
+    assert _read_persisted_id(str(path)) is None
+
+
+def test_read_persisted_id_returns_none_on_os_error(tmp_path):
+    # A directory where a file is expected raises IsADirectoryError, an
+    # OSError that is not FileNotFoundError -- exercises the OSError branch.
+    path = tmp_path / MACHINE_ID_FILENAME
+    path.mkdir()
+    assert _read_persisted_id(str(path)) is None
+
+
+# --- _persist_id -----------------------------------------------------------
+
+
+def test_persist_id_writes_file_owner_only(tmp_path):
+    path = tmp_path / MACHINE_ID_FILENAME
+    value = str(uuid.uuid4())
+    assert _persist_id(str(path), value) is True
+    assert path.read_text() == value
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_persist_id_returns_false_on_os_error(tmp_path):
+    # Parent directory does not exist -> FileNotFoundError (an OSError).
+    path = tmp_path / "missing_dir" / MACHINE_ID_FILENAME
+    assert _persist_id(str(path), str(uuid.uuid4())) is False
+
+
+# --- get_machine_id --------------------------------------------------------
+
+
+def test_get_machine_id_generates_and_persists(tmp_path):
+    with patch("fivenines_agent.machine_id.config_dir", return_value=str(tmp_path)):
+        result = get_machine_id()
+    assert _valid_uuid(result)
+    assert (tmp_path / MACHINE_ID_FILENAME).read_text() == result
+
+
+def test_get_machine_id_reuses_existing_file(tmp_path):
+    existing = str(uuid.uuid4())
+    (tmp_path / MACHINE_ID_FILENAME).write_text(existing)
+    with patch("fivenines_agent.machine_id.config_dir", return_value=str(tmp_path)):
+        assert get_machine_id() == existing
+
+
+def test_get_machine_id_is_stable_across_calls(tmp_path):
+    with patch("fivenines_agent.machine_id.config_dir", return_value=str(tmp_path)):
+        first = get_machine_id()
+        second = get_machine_id()
+    assert first == second
+
+
+def test_get_machine_id_returns_none_when_not_persistable(tmp_path):
+    # config_dir points at a directory that does not exist, so neither the
+    # read nor the write can succeed.
+    unwritable = os.path.join(str(tmp_path), "missing_dir")
+    with patch("fivenines_agent.machine_id.config_dir", return_value=unwritable):
+        assert get_machine_id() is None
+
+
+def test_get_machine_id_never_raises():
+    with patch(
+        "fivenines_agent.machine_id.config_dir",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        assert get_machine_id() is None


### PR DESCRIPTION
## Summary

Phase 2 of the enrollment host-collision fix: the agent generates a per-machine UUID on first run, persists it at `CONFIG_DIR/MACHINE_ID`, and sends it as `machine_id` on every `/collect` so the server can treat re-enrollment of one machine as idempotent instead of creating a duplicate host. `get_machine_id()` never raises and degrades to `None` on any read or persist failure, so older agents and unwritable config dirs keep the existing per-enrollment behavior. The README documents the VM-template caveat (clones must drop `MACHINE_ID` and `TOKEN` before imaging), and `tests/test_machine_id.py` covers every branch at 100%.

Server-side counterpart: Five-Nines-io/fivenines_server#354.

## Test plan
- [ ] `make test` passes; `test_machine_id.py` keeps coverage at 100%
- [ ] Fresh host: first run creates `CONFIG_DIR/MACHINE_ID`; value appears in the `/collect` payload
- [ ] Restart: the same `machine_id` is reused, no new host created
- [ ] Unwritable config dir: agent still starts and omits `machine_id`