### PR TITLE
test: make SPK fixture libname version-agnostic

### DIFF
--- a/tests/test_spk_structure.py
+++ b/tests/test_spk_structure.py
@@ -34,8 +34,11 @@ def fake_binary(tmp_path):
         binary = binary_dir / "fivenines-agent"
         binary.write_text("#!/bin/sh\necho fake-agent")
         binary.chmod(0o755)
-        # Simulate a shared library alongside the binary
-        (binary_dir / "libpython3.9.so").write_text("fake-lib")
+        # Simulate a shared library alongside the binary.
+        # Name is intentionally version-agnostic: the SPK test verifies that
+        # any non-binary file in the dist dir gets packaged, not which Python
+        # minor the real build bundles.
+        (binary_dir / "libstub.so").write_text("fake-lib")
     return tmp_path
 
 
@@ -111,7 +114,7 @@ def test_build_spk_package_tgz_contains_binary(fake_binary):
             members = [m.name for m in pkg.getmembers()]
         assert "./bin/fivenines-agent" in members
         # Shared libs should also be included
-        assert "./bin/libpython3.9.so" in members
+        assert "./bin/libstub.so" in members
         # Logrotate config must be inside package.tgz (target/conf/)
         assert "./conf/logrotate.conf" in members
     finally:


### PR DESCRIPTION
## Summary
- Rename the fake `.so` stub in `tests/test_spk_structure.py` from `libpython3.9.so` to `libstub.so` so the name doesn't go stale on future Python floor bumps.
- Add a comment clarifying that the test verifies **any** non-binary file in the dist dir gets packaged by `build_spk.sh`'s `rsync`, not that a specific Python version is bundled.

## Why
After v1.7.0 drops the Python 3.9 floor, real Synology builds bundle `libpython3.10.so`. The fixture name had become misleading. Codex (during `/plan-eng-review` outside voice) flagged that simply bumping `3.9 → 3.10` re-creates the same staleness — a neutral name is the durable fix.

## Test plan
- [x] `pytest tests/test_spk_structure.py -v` passes locally (5/5 ✓)
- [x] Diff is a 4-line change in one file; no functional behavior change
- [x] CI `lint` / build / distro / SELinux all green (note: CI does not run pytest — this was validated locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)