### PR TITLE
ci: guard release job against tag/version mismatch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -765,6 +765,19 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
+      - name: Verify tag matches pyproject.toml and cli.py versions
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          FILE_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          CLI_VERSION=$(grep "^VERSION = " fivenines_agent/cli.py | head -1 | cut -d"'" -f2)
+          echo "Tag version:        $TAG_VERSION"
+          echo "pyproject.toml:     $FILE_VERSION"
+          echo "fivenines_agent/cli.py: $CLI_VERSION"
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ] || [ "$TAG_VERSION" != "$CLI_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION disagrees with pyproject.toml ($FILE_VERSION) or fivenines_agent/cli.py ($CLI_VERSION). Bump the version stamps before tagging."
+            exit 1
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Add a `Verify tag matches pyproject.toml and cli.py versions` step to the `release:` job in `.github/workflows/build-release.yml`.
- The check runs between `Extract version from tag` and `Create GitHub Release`. If the pushed `v*` tag disagrees with `pyproject.toml`'s `version` or `fivenines_agent/cli.py`'s `VERSION`, the job fails with a clear error before the GitHub release is created or the R2 sync runs.

## Why
Surfaced by codex outside voice during `/plan-eng-review` for v1.7.0: the previous workflow had **no guard** against tagging the wrong commit (e.g., tagging `v1.7.0` on a commit where `pyproject.toml` still said `1.6.3`). A silent mismatch would publish binaries whose internal `--version` disagreed with the GitHub release name and the R2 mirror path — exactly the kind of confusion that takes hours to debug.

This is a **durable fix** that benefits every future release, not just v1.7.0.

## Behavior
- Tag-only: the `release:` job already has `if: startsWith(github.ref, 'refs/tags/v')`, so this new step only runs on tag pushes.
- Fails fast within the release job (after builds, before publish). Builds aren't wasted — they remain valid artifacts for re-tagging once versions are corrected.
- Error message names both expected values so the contributor knows exactly which stamp to bump.

Sample output on a mismatch:
\`\`\`
Tag version:        1.7.1
pyproject.toml:     1.7.0
fivenines_agent/cli.py: 1.7.0
::error::Tag v1.7.1 disagrees with pyproject.toml (1.7.0) or fivenines_agent/cli.py (1.7.0). Bump the version stamps before tagging.
\`\`\`

## Test plan
- [x] YAML diff is +13 lines, single insertion point, no other steps touched
- [ ] CI `lint` job passes (validates the workflow file syntax indirectly)
- [ ] On the next tag push (e.g., v1.7.0), the new step appears in the release job and shows the version values

🤖 Generated with [Claude Code](https://claude.com/claude-code)