### PR TITLE
Windows post-install + stop hardening (v1.8.1)

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.8.0'
+VERSION = '1.8.1'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_setup.ps1
+++ b/fivenines_setup.ps1
@@ -76,6 +76,13 @@ if ($proc.ExitCode -ne 0) {
 }
 
 Write-Host "Starting service..."
+# Brief pause so the MSI's StartAgentService custom action (sc.exe start)
+# has fully settled in the SCM before we issue Start-Service here. Without
+# it, Start-Service can race the still-completing service reconfiguration
+# from CreateServiceAccount.ps1 and throw "service cannot accept control
+# messages at this time". Start-Service is idempotent against a service
+# already transitioning to Running, so this redundant call is safe.
+Start-Sleep -Seconds 2
 Start-Service -Name "fivenines-agent" -ErrorAction Stop
 Start-Sleep -Seconds 3
 

--- a/fivenines_update.ps1
+++ b/fivenines_update.ps1
@@ -97,8 +97,11 @@ if ($proc.ExitCode -ne 0) {
     exit $proc.ExitCode
 }
 
-# After a MajorUpgrade the service is registered but not started. Start it
-# explicitly so the operator can verify the update without an extra step.
+# After a MajorUpgrade the MSI's StartAgentService CA has already kicked
+# the new service via sc.exe start. Pause briefly so SCM has settled, then
+# Start-Service as an idempotent safety net (no-op if already Running, or
+# kicks it if the MSI's start was lost to a race with reconfiguration).
+Start-Sleep -Seconds 2
 Start-Service -Name "fivenines-agent" -ErrorAction Stop
 Start-Sleep -Seconds 3
 $svc = Get-Service -Name "fivenines-agent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.8.0"
+version = "1.8.1"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/windows/installer/Product.wxs
+++ b/windows/installer/Product.wxs
@@ -150,12 +150,13 @@
 
         <!-- Intentionally NO Start="install": the deferred custom actions
              (WriteTokenAcl, DelegateWmi) run AFTER InstallServices, so if
-             we asked the SCM to start the service here, the agent would
-             try to read TOKEN before it has been written and exit
-             immediately - WinSW would then restart-loop and the MSI would
-             hang waiting for the service to reach Running. The smoke job
-             (or a real-world operator) starts the service explicitly after
-             the install completes. -->
+             we asked the SCM to start the service here via the standard
+             StartServices action, the agent would try to read TOKEN before
+             it has been written and exit immediately - WinSW would then
+             restart-loop and the MSI would hang waiting for Running. The
+             StartAgentService custom action below is sequenced after
+             DelegateWmi (TOKEN written, WMI delegated) and uses sc.exe
+             which is fire-and-forget so the MSI never hangs. -->
         <ServiceControl Id="ControlAgentService"
                         Name="fivenines-agent"
                         Stop="both"
@@ -288,6 +289,23 @@
                   Return="check"
                   BinaryRef="Wix4UtilCA_X64" />
 
+    <!-- Start the service after TOKEN write and WMI delegation are done.
+         sc.exe start returns as soon as the SCM accepts the start request
+         (fire-and-forget), so a crash-looping agent cannot hang the MSI.
+         Return="ignore" so a transient start failure does not roll back a
+         successful install - the operator can Start-Service manually and
+         see WinSW logs. -->
+    <SetProperty Id="StartAgentService"
+                 Value="&quot;sc.exe&quot; start fivenines-agent"
+                 Before="StartAgentService"
+                 Sequence="execute" />
+    <CustomAction Id="StartAgentService"
+                  DllEntry="WixQuietExec"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="ignore"
+                  BinaryRef="Wix4UtilCA_X64" />
+
     <InstallExecuteSequence>
       <!-- Sequence the post-install CAs:
              1. CreateServiceAccount: provision the dedicated low-priv account
@@ -298,11 +316,14 @@
                 + SYSTEM.
              3. DelegateWmi: grant the service account read on the WMI Storage
                 namespace so the disk-health collector works without admin.
-           All three run after InstallServices and before the MSI hands back
-           control. The service is not auto-started during install. -->
+             4. StartAgentService: now that the service account, TOKEN, and
+                WMI delegation are all in place, kick the service. Bootstraps
+                (fivenines_setup.ps1, fivenines_update.ps1) still call
+                Start-Service afterwards for idempotency. -->
       <Custom Action="CreateServiceAccount" After="InstallServices" Condition="NOT Installed" />
       <Custom Action="WriteTokenAcl" After="CreateServiceAccount" Condition="NOT Installed" />
       <Custom Action="DelegateWmi" After="WriteTokenAcl" Condition="NOT Installed" />
+      <Custom Action="StartAgentService" After="DelegateWmi" Condition="NOT Installed" />
     </InstallExecuteSequence>
 
     <Feature Id="MainFeature" Title="Fivenines Agent" Level="1">

--- a/windows/winsw/fivenines-agent.xml
+++ b/windows/winsw/fivenines-agent.xml
@@ -49,4 +49,16 @@
   <onfailure action="restart" delay="30 sec"/>
   <onfailure action="restart" delay="60 sec"/>
   <resetfailure>1 hour</resetfailure>
+
+  <!-- Stop semantics. WinSW's default Ctrl+C signaling requires the child
+       to share an interactive console, which a Windows Service never has -
+       Python's signal.signal(SIGINT, ...) handler in agent.py never fires.
+       After stoptimeout WinSW calls TerminateProcess on the child, but
+       PyInstaller's onedir layout runs the agent as a bootloader + Python
+       interpreter pair: killing the bootloader alone leaves the interpreter
+       orphaned (Get-Service Stopped, Get-Process still alive). Setting
+       stopparentprocessfirst=true reverses the order so the bootloader dies
+       first, which forces the Python interpreter to exit too. -->
+  <stoptimeout>10 sec</stoptimeout>
+  <stopparentprocessfirst>true</stopparentprocessfirst>
 </service>


### PR DESCRIPTION
## Summary

Three Windows lifecycle bugs uncovered on production VMs after v1.8.0 shipped.

### 1. MSI now auto-starts the service
`Product.wxs` adds a `StartAgentService` custom action sequenced **after** `DelegateWmi`, so the service starts on its own as part of the MSI install. Direct `msiexec` calls (wizard one-liners, Ansible, Chef, anyone who bypasses `fivenines_setup.ps1`) no longer leave the agent stopped after install.

- Uses `sc.exe start` (fire-and-forget) so a crash-looping agent cannot hang the MSI — the original reason for the no-auto-start design
- `Return="ignore"` so a transient start failure doesn't roll back a successful install; the operator can still `Start-Service` manually
- Sequenced after `WriteTokenAcl` + `DelegateWmi` so TOKEN is on disk and WMI is delegated before the service spins up

### 2. WinSW kills the PyInstaller bootloader before its Python child
`windows/winsw/fivenines-agent.xml` gains `stopparentprocessfirst=true` and `stoptimeout=10 sec`.

- WinSW's default Ctrl+C signaling is a no-op for console-less Windows Services, so the agent's `signal.signal(SIGINT, ...)` handler in `agent.py:78` never fires
- After timeout WinSW falls back to `TerminateProcess` — but PyInstaller onedir runs as bootloader + interpreter, and killing the bootloader alone leaves the interpreter orphaned (reproduced today: `Get-Service Stopped` but `Get-Process fivenines-agent-windows-amd64` still alive)
- `stopparentprocessfirst=true` reverses the kill order so the Python interpreter dies with its bootloader parent

### 3. Bootstraps wait 2s before their own `Start-Service`
`fivenines_setup.ps1` and `fivenines_update.ps1` add `Start-Sleep -Seconds 2` before `Start-Service`. The bootstraps' call is now an idempotent safety net behind the MSI's `StartAgentService`; the pause lets SCM finish the service-account flip from `CreateServiceAccount.ps1` so we don't race with `"service cannot accept control messages at this time"`.

### Version bumps
- `pyproject.toml`: 1.8.0 -> 1.8.1
- `fivenines_agent/cli.py`: 1.8.0 -> 1.8.1

## Test plan
- [ ] Fresh install on a clean Windows VM via direct `msiexec /i ... TOKEN=...` (no bootstrap): service ends up `Running` without manual `Start-Service`
- [ ] Fresh install via `fivenines_setup.ps1 -Token ...`: still works (bootstrap's `Start-Service` is now a no-op)
- [ ] `Stop-Service fivenines-agent`: confirm `Get-Process fivenines-agent-windows-amd64` returns nothing (no orphan)
- [ ] `fivenines_uninstall.ps1`: same — no orphan process after uninstall
- [ ] `fivenines_update.ps1` from a v1.8.0 install: service ends up `Running` on the new version, no orphan from the old
- [ ] CI's Windows smoke job stays green