### PR TITLE
feat: backend-controlled permission re-check with reliable QEMU probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 /TOKEN
 
 .install.stamp
+.gstack/

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -17,7 +17,12 @@ except ImportError:
     systemd_watchdog = None
 
 from fivenines_agent.cli import VERSION
-from fivenines_agent.collectors import _collect_with_telemetry, collect_metrics
+from fivenines_agent.collectors import (
+    COLLECTORS,
+    _capability_key_for,
+    _collect_with_telemetry,
+    collect_metrics,
+)
 from fivenines_agent.debug import log
 from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context, is_windows
 from fivenines_agent.files import file_handles_limit, file_handles_used, handle_count
@@ -38,6 +43,11 @@ load_dotenv(dotenv_path=env_file())
 exit_event = Event()
 # Event to signal permission refresh needed
 refresh_permissions_event = Event()
+
+# Sentinel for "no permissions_recheck_token observed yet", so the first
+# observation (including a real token already set when the agent restarts)
+# only baselines and does not fire a spurious reprobe.
+_RECHECK_UNSET = object()
 
 
 # Permissive config used only in --dry-run so every collector that has the
@@ -77,8 +87,8 @@ def _on_sighup(signum, frame):
 def setup_signals():
     signal.signal(signal.SIGTERM, _on_exit_signal)
     signal.signal(signal.SIGINT, _on_exit_signal)
-    # SIGHUP is Linux-only; on Windows the agent relies on the 5-minute
-    # auto-reprobe in PermissionProbe.refresh_if_needed (D9).
+    # SIGHUP is Linux-only; on Windows the agent relies on the periodic
+    # auto-reprobe in PermissionProbe.refresh_due (D9).
     if hasattr(signal, "SIGHUP"):
         signal.signal(signal.SIGHUP, _on_sighup)
 
@@ -96,6 +106,9 @@ class Agent:
         # Load token
         self._load_file("TOKEN")
 
+        # Last permissions_recheck_token acted on (see _recheck_token_changed).
+        self._last_recheck_token = _RECHECK_UNSET
+
         # Static info sent with every request
         self.static_data = {
             "version": VERSION,
@@ -103,6 +116,7 @@ class Agent:
             "boot_time": psutil.boot_time(),
             "capabilities": self.permissions.get_all(),
             "capability_reasons": self.permissions.get_reasons(),
+            "pending_capabilities": [],
             "user_context": get_user_context(CONFIG_DIR),
             "machine_id": get_machine_id(),
         }
@@ -141,14 +155,20 @@ class Agent:
             while not exit_event.is_set():
                 if wd is not None:
                     wd.notify()
-                self._handle_permission_refresh()
+                self._handle_sighup_refresh()
 
                 # Refresh config if disabled. In --dry-run we use a static
                 # permissive config so we never contact the API.
                 if self.synchronizer is None:
                     self.config = _DRY_RUN_CONFIG
+                    self._apply_config_driven_refresh(self.config)
                 else:
                     self.config = self.synchronizer.get_config()
+                    # Run config-driven permission refresh in BOTH the enabled
+                    # and the disabled branch so the on-demand recheck token and
+                    # fast gap detection work for not-yet-enabled onboarding
+                    # hosts too.
+                    self._apply_config_driven_refresh(self.config)
                     if not self.config.get("enabled", False):
                         self.queue.put({"get_config": True, **self.static_data})
                         exit_event.wait(25)
@@ -238,20 +258,97 @@ class Agent:
             "packages_sync", packages_sync, self.config, self.synchronizer.send_packages
         )
 
-    def _handle_permission_refresh(self):
+    def _handle_sighup_refresh(self):
+        """SIGHUP-triggered full reprobe. Kept at the top of the loop (needs no
+        config) so it stays responsive even when the backend is unreachable."""
         if refresh_permissions_event.is_set():
             refresh_permissions_event.clear()
             self.permissions.force_refresh()
             self.static_data["capabilities"] = self.permissions.get_all()
             self.static_data["capability_reasons"] = self.permissions.get_reasons()
             print_capabilities_banner()
-        elif self.permissions.refresh_if_needed():
-            self.static_data["capabilities"] = self.permissions.get_all()
-            self.static_data["capability_reasons"] = self.permissions.get_reasons()
+
+    def _apply_config_driven_refresh(self, config):
+        """Run config-driven permission refresh for this tick, then republish
+        capability state for the next payload.
+
+        - On-demand: a changed permissions_recheck_token forces a full reprobe.
+        - Otherwise: full probe every REPROBE_INTERVAL plus a cheap selective
+          gap re-probe (only enabled-but-missing capabilities) on the throttle
+          cadence (default: every tick).
+        """
+        if self._recheck_token_changed(config.get("permissions_recheck_token")):
+            self.permissions.force_refresh()
+        else:
+            interval = self._collection_interval(config)
+            gap_interval = self._gap_probe_interval(config, interval)
+            pending = self._pending_capabilities(config)
+            self.permissions.refresh_due(pending, gap_interval)
+        self.static_data["capabilities"] = self.permissions.get_all()
+        self.static_data["capability_reasons"] = self.permissions.get_reasons()
+        self.static_data["pending_capabilities"] = self._pending_capabilities(config)
+
+    def _recheck_token_changed(self, token):
+        """Nonce state machine for the on-demand "re-detect now" button.
+
+        The first observation only baselines (even a non-null token already set
+        when the agent restarts), so a restart never triggers a spurious
+        reprobe. A null/absent token resets the baseline. Only a transition to a
+        different non-null value fires.
+        """
+        last = self._last_recheck_token
+        if last is _RECHECK_UNSET:
+            self._last_recheck_token = token
+            return False
+        if token is None:
+            self._last_recheck_token = None
+            return False
+        if token != last:
+            self._last_recheck_token = token
+            return True
+        return False
+
+    def _collection_interval(self, config):
+        """Collection interval, clamped: a low warmup value (e.g. 5s) is allowed,
+        but 0/negative/non-numeric falls back to 60s to avoid a tight loop."""
+        interval = config.get("interval", 60)
+        if isinstance(interval, bool) or not isinstance(interval, (int, float)):
+            return 60
+        if interval <= 0:
+            return 60
+        return interval
+
+    def _gap_probe_interval(self, config, interval):
+        """Seconds between selective gap re-probes. Default 0 = every tick;
+        permissions_recheck_interval can only THROTTLE (floored at the
+        collection interval, since the probe runs once per tick) and is capped
+        at 3600."""
+        raw = config.get("permissions_recheck_interval")
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+            return 0
+        return max(interval, min(raw, 3600))
+
+    def _pending_capabilities(self, config):
+        """Capabilities the operator enabled (config flag truthy) that are
+        currently probed False. Drives the selective gap re-probe and is sent in
+        the payload for the dashboard "pending + reason" view. Reuses the
+        collectors config-key <-> capability-key mapping so the override
+        (smart_storage_health -> smart_storage) lives in one place."""
+        caps = self.permissions.get_all()
+        pending = []
+        for config_key, _collectors in COLLECTORS:
+            if not config.get(config_key):
+                continue
+            cap_key = _capability_key_for(config_key)
+            if cap_key in caps and not caps[cap_key]:
+                pending.append(cap_key)
+        if config.get("snmp_targets") and caps.get("snmp") is False:
+            pending.append("snmp")
+        return list(dict.fromkeys(pending))
 
     def _wait_interval(self, running_time):
         log(f"Running time: {running_time:.3f}s", "debug")
-        interval = self.config.get("interval", 60)
+        interval = self._collection_interval(self.config)
         sleep_time = max(interval - running_time, 0.1)
         log(f"Sleeping time: {sleep_time * 1000:.0f} ms", "debug")
         exit_event.wait(sleep_time)

--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -6,6 +6,7 @@ Detects what capabilities are available based on user permissions.
 import os
 import shutil
 import subprocess
+import threading
 import time
 
 import psutil
@@ -15,8 +16,16 @@ from fivenines_agent.env import is_windows
 from fivenines_agent.subprocess_utils import get_clean_env
 
 
-# Re-probe interval in seconds (5 minutes)
+# Full re-probe interval in seconds (5 minutes): every capability is re-checked
+# on this cadence to catch regressions and newly-relevant capabilities.
 REPROBE_INTERVAL = 300
+
+# Hard timeout (seconds) for the libvirt openReadOnly probe. The probe runs in a
+# worker thread and is abandoned past this deadline: a wedged libvirt stack
+# (socket activation, daemon handshake, polkit, NSS) can otherwise block, and
+# the probe runs synchronously in the agent's main loop -> it would stall ALL
+# metric collection, not just QEMU.
+LIBVIRT_PROBE_TIMEOUT = 3
 
 # Max chars for stdout/stderr in debug logs
 DEBUG_OUTPUT_LIMIT = 500
@@ -80,6 +89,7 @@ class PermissionProbe:
         self._capability_reasons = {}
         self._current_reason = None
         self._last_probe_time = 0
+        self._last_gap_probe_time = 0
         self._probe_all()
 
     def _set_reason(self, msg):
@@ -137,42 +147,68 @@ class PermissionProbe:
 
         return self.capabilities
 
+    def _linux_probe_specs(self):
+        """Single source of truth: capability name -> (probe_callable, args).
+
+        Used by both the full build (_build_linux_capabilities) and the
+        selective gap re-probe (_reprobe_capabilities), so the method<->capability
+        mapping lives in exactly one place (no duplication).
+        """
+        return {
+            # Core metrics - always available via /proc
+            "cpu": (self._can_read, ("/proc/stat",)),
+            "memory": (self._can_read, ("/proc/meminfo",)),
+            "load_average": (self._can_read, ("/proc/loadavg",)),
+            "io": (self._can_read, ("/proc/diskstats",)),
+            "network": (self._can_read, ("/proc/net/dev",)),
+            "partitions": (self._can_read, ("/proc/mounts",)),
+            "file_handles": (self._can_read, ("/proc/sys/fs/file-nr",)),
+            "ports": (self._can_read, ("/proc/net/tcp",)),
+            # Processes - works but may have limited visibility
+            "processes": (self._can_read, ("/proc/self/stat",)),
+            # Hardware sensors - may or may not work without root
+            "temperatures": (self._can_access_hwmon, ()),
+            "fans": (self._can_access_hwmon, ()),
+            # NVIDIA GPU
+            "nvidia_gpu": (self._can_access_gpu, ()),
+            # Storage requiring sudo
+            "smart_storage": (self._can_run_sudo, ("smartctl", "--version")),
+            "raid_storage": (self._can_run_sudo, ("mdadm", "--version")),
+            # Security - requires sudo
+            "fail2ban": (self._can_run_sudo, ("fail2ban-client", "status")),
+            # ZFS - doesn't need sudo but needs permissions or delegation
+            "zfs": (self._can_run_zfs, ()),
+            # Docker - needs docker group membership
+            "docker": (self._can_access_docker, ()),
+            # QEMU/libvirt - needs libvirt group membership
+            "qemu": (self._can_access_libvirt, ()),
+            # Proxmox VE - needs API access or local node
+            "proxmox": (self._can_access_proxmox, ()),
+            # Package listing - for security scanning
+            "packages": (self._can_list_packages, ()),
+            # SNMP polling - needs net-snmp CLI tools
+            "snmp": (self._has_snmpget, ()),
+        }
+
     def _build_linux_capabilities(self):
         """Linux capability set: /proc, /sys, sudo, sockets, package managers."""
         return {
-            # Core metrics - always available via /proc
-            "cpu": self._probe("cpu", self._can_read, "/proc/stat"),
-            "memory": self._probe("memory", self._can_read, "/proc/meminfo"),
-            "load_average": self._probe("load_average", self._can_read, "/proc/loadavg"),
-            "io": self._probe("io", self._can_read, "/proc/diskstats"),
-            "network": self._probe("network", self._can_read, "/proc/net/dev"),
-            "partitions": self._probe("partitions", self._can_read, "/proc/mounts"),
-            "file_handles": self._probe("file_handles", self._can_read, "/proc/sys/fs/file-nr"),
-            "ports": self._probe("ports", self._can_read, "/proc/net/tcp"),
-            # Processes - works but may have limited visibility
-            "processes": self._probe("processes", self._can_read, "/proc/self/stat"),
-            # Hardware sensors - may or may not work without root
-            "temperatures": self._probe("temperatures", self._can_access_hwmon),
-            "fans": self._probe("fans", self._can_access_hwmon),
-            # NVIDIA GPU
-            "nvidia_gpu": self._probe("nvidia_gpu", self._can_access_gpu),
-            # Storage requiring sudo
-            "smart_storage": self._probe("smart_storage", self._can_run_sudo, "smartctl", "--version"),
-            "raid_storage": self._probe("raid_storage", self._can_run_sudo, "mdadm", "--version"),
-            # Security - requires sudo
-            "fail2ban": self._probe("fail2ban", self._can_run_sudo, "fail2ban-client", "status"),
-            # ZFS - doesn't need sudo but needs permissions or delegation
-            "zfs": self._probe("zfs", self._can_run_zfs),
-            # Docker - needs docker group membership
-            "docker": self._probe("docker", self._can_access_docker),
-            # QEMU/libvirt - needs libvirt group membership
-            "qemu": self._probe("qemu", self._can_access_libvirt),
-            # Proxmox VE - needs API access or local node
-            "proxmox": self._probe("proxmox", self._can_access_proxmox),
-            # Package listing - for security scanning
-            "packages": self._probe("packages", self._can_list_packages),
-            # SNMP polling - needs net-snmp CLI tools
-            "snmp": self._probe("snmp", self._has_snmpget),
+            name: self._probe(name, probe_callable, *args)
+            for name, (probe_callable, args) in self._linux_probe_specs().items()
+        }
+
+    def _windows_probe_specs(self):
+        """Probed Windows capabilities -> (probe_callable, args). The always-True
+        core metrics are added separately in _build_windows_capabilities."""
+        return {
+            # Hardware sensors - psutil reports if any are exposed
+            "temperatures": (self._can_query_psutil_sensors, ("temperatures",)),
+            "fans": (self._can_query_psutil_sensors, ("fans",)),
+            "nvidia_gpu": (self._can_access_gpu, ()),
+            # Windows-native: WMI MSFT_PhysicalDisk + reliability counters
+            "disk_health": (self._can_query_wmi_storage, ()),
+            # Windows-native: registry Uninstall key (classic Win32 installed programs)
+            "software_inventory": (self._can_read_uninstall_registry, ()),
         }
 
     def _build_windows_capabilities(self):
@@ -185,13 +221,13 @@ class PermissionProbe:
         Windows-native entries: disk_health (WMI Storage), software_inventory
         (registry Uninstall key).
         """
-        return {
-            # Core metrics - psutil handles these cross-platform.
-            # load_average is intentionally absent: Windows has no equivalent
-            # (no D-state, no real load avg in the kernel), and psutil's
-            # emulation samples CPU activity only and reads zero on idle
-            # systems. Omit rather than ship misleading data (D13 - send a
-            # Windows-shaped payload rather than Linux keys marked N/A).
+        # Core metrics - psutil handles these cross-platform.
+        # load_average is intentionally absent: Windows has no equivalent
+        # (no D-state, no real load avg in the kernel), and psutil's
+        # emulation samples CPU activity only and reads zero on idle
+        # systems. Omit rather than ship misleading data (D13 - send a
+        # Windows-shaped payload rather than Linux keys marked N/A).
+        capabilities = {
             "cpu": True,
             "memory": True,
             "io": True,
@@ -200,15 +236,15 @@ class PermissionProbe:
             "file_handles": True,
             "ports": True,
             "processes": True,
-            # Hardware sensors - psutil reports if any are exposed
-            "temperatures": self._probe("temperatures", self._can_query_psutil_sensors, "temperatures"),
-            "fans": self._probe("fans", self._can_query_psutil_sensors, "fans"),
-            "nvidia_gpu": self._probe("nvidia_gpu", self._can_access_gpu),
-            # Windows-native: WMI MSFT_PhysicalDisk + reliability counters
-            "disk_health": self._probe("disk_health", self._can_query_wmi_storage),
-            # Windows-native: registry Uninstall key (classic Win32 installed programs)
-            "software_inventory": self._probe("software_inventory", self._can_read_uninstall_registry),
         }
+        for name, (probe_callable, args) in self._windows_probe_specs().items():
+            capabilities[name] = self._probe(name, probe_callable, *args)
+        return capabilities
+
+    def _probe_specs(self):
+        """OS-appropriate {capability: (probe_callable, args)} map for selective
+        re-probing. Mirrors whichever set _probe_all built."""
+        return self._windows_probe_specs() if is_windows() else self._linux_probe_specs()
 
     def _format_unavailable(self, cap, verb):
         """Build the operator-facing log line for an unavailable capability."""
@@ -221,12 +257,54 @@ class PermissionProbe:
             msg += f" ({reason})"
         return msg
 
-    def refresh_if_needed(self):
-        """Re-probe capabilities if enough time has passed."""
-        if time.time() - self._last_probe_time >= REPROBE_INTERVAL:
+    def _reprobe_capabilities(self, only):
+        """Re-probe only the named capabilities (cheap selective gap probe).
+
+        Logs state flips at info level (same payload as the full probe) and
+        returns True if any of the named capabilities flipped. Names not in the
+        OS probe spec are ignored.
+        """
+        specs = self._probe_specs()
+        flipped = False
+        for name in only:
+            spec = specs.get(name)
+            if spec is None:
+                continue
+            probe_callable, args = spec
+            old_value = self.capabilities.get(name)
+            new_value = self._probe(name, probe_callable, *args)
+            self.capabilities[name] = new_value
+            if old_value != new_value:
+                flipped = True
+                if new_value:
+                    log(f"Capability '{name}' is now AVAILABLE", "info")
+                else:
+                    log(self._format_unavailable(name, "is now UNAVAILABLE"), "info")
+        return flipped
+
+    def refresh_due(self, gap_capabilities=(), gap_interval=0):
+        """Run timed re-probes; return True if any capability flipped.
+
+        - Full probe of every capability every REPROBE_INTERVAL (regressions and
+          newly-relevant capabilities).
+        - Otherwise a cheap selective re-probe of *gap_capabilities* (the
+          enabled-but-missing set) every *gap_interval* seconds. gap_interval=0
+          means "every call"; an empty gap set is a no-op.
+
+        The gap probe is what makes a late-arriving capability (libvirtd coming
+        up, sudoers granted) appear within ~one collection interval instead of
+        waiting for the 5-minute full-probe cycle.
+        """
+        now = time.time()
+        if now - self._last_probe_time >= REPROBE_INTERVAL:
             log("Re-probing capabilities...", "debug")
+            old = self.capabilities.copy()
             self._probe_all()
-            return True
+            self._last_gap_probe_time = now
+            return old != self.capabilities
+        if gap_capabilities and now - self._last_gap_probe_time >= gap_interval:
+            self._last_gap_probe_time = now
+            return self._reprobe_capabilities(gap_capabilities)
         return False
 
     def force_refresh(self):
@@ -483,28 +561,57 @@ class PermissionProbe:
         return accessible
 
     def _can_access_libvirt(self):
-        """Check if libvirt socket is accessible."""
-        # Common libvirt socket paths
-        socket_paths = [
-            "/var/run/libvirt/libvirt-sock-ro",
-            "/var/run/libvirt/libvirt-sock",
-        ]
-        log(f"_can_access_libvirt: checking socket paths: {socket_paths}", "debug")
+        """Probe QEMU/libvirt the way the collector connects: attempt
+        libvirt.openReadOnly("qemu:///system").
 
-        for path in socket_paths:
-            exists = os.path.exists(path)
-            if not exists:
-                log(f"_can_access_libvirt: {path} does not exist", "debug")
-                continue
+        This mirrors qemu.py exactly, so True means the collector can actually
+        connect - no guessing about socket paths or permission bits, which had
+        diverged from the collector (os.access(R_OK) vs the read-only connect)
+        and missed the modular-daemon socket layout (virtqemud/virtproxyd).
 
-            readable = os.access(path, os.R_OK)
-            log(f"_can_access_libvirt: {path} exists, readable={readable}", "debug")
-            if readable:
-                log(f"_can_access_libvirt: -> AVAILABLE (via {path})", "debug")
-                return True
+        The connection runs in a worker thread with a hard timeout: a wedged
+        libvirt stack can block indefinitely, and this probe runs synchronously
+        in the agent's main collection loop, so an unbounded call would stall
+        ALL metrics, not just QEMU.
+        """
+        try:
+            import libvirt
+        except ImportError as e:
+            log(f"_can_access_libvirt: libvirt module not importable: {e}", "debug")
+            self._set_reason("libvirt module not available")
+            return False
 
-        log("_can_access_libvirt: -> UNAVAILABLE (no accessible sockets)", "debug")
-        self._set_reason(f"no readable libvirt socket at {' or '.join(socket_paths)}")
+        result = {}
+
+        def attempt():
+            conn = None
+            try:
+                conn = libvirt.openReadOnly("qemu:///system")
+                result["ok"] = conn is not None
+                if conn is None:
+                    result["reason"] = "openReadOnly returned None"
+            except Exception as e:
+                result["reason"] = f"{type(e).__name__}: {e}"
+            finally:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+
+        worker = threading.Thread(target=attempt, daemon=True)
+        worker.start()
+        worker.join(LIBVIRT_PROBE_TIMEOUT)
+        if worker.is_alive():
+            log("_can_access_libvirt: probe timed out", "debug")
+            self._set_reason("libvirt probe timed out")
+            return False
+        if result.get("ok"):
+            log("_can_access_libvirt: -> AVAILABLE (openReadOnly)", "debug")
+            return True
+        reason = result.get("reason", "openReadOnly failed")
+        log(f"_can_access_libvirt: -> UNAVAILABLE ({reason})", "debug")
+        self._set_reason(reason)
         return False
 
     def _can_access_proxmox(self):

--- a/tests/test_agent_capability_reasons.py
+++ b/tests/test_agent_capability_reasons.py
@@ -17,10 +17,12 @@ def _make_agent():
     agent.permissions.get_reasons.return_value = {
         "nvidia_gpu": "nvmlInit failed: NVML Shared Library Not Found"
     }
-    agent.permissions.refresh_if_needed.return_value = False
+    agent.permissions.refresh_due.return_value = False
+    agent._last_recheck_token = agent_module._RECHECK_UNSET
     agent.static_data = {
         "capabilities": agent.permissions.get_all(),
         "capability_reasons": agent.permissions.get_reasons(),
+        "pending_capabilities": [],
     }
     return agent
 
@@ -33,38 +35,38 @@ def test_force_refresh_updates_capability_reasons():
 
     agent_module.refresh_permissions_event.set()
     with patch("fivenines_agent.agent.print_capabilities_banner"):
-        agent._handle_permission_refresh()
+        agent._handle_sighup_refresh()
 
     agent.permissions.force_refresh.assert_called_once()
     assert agent.static_data["capabilities"] == {"nvidia_gpu": True, "cpu": True}
     assert agent.static_data["capability_reasons"] == {}
 
 
-def test_periodic_refresh_updates_capability_reasons():
-    """Time-based refresh writes both capabilities and reasons to static_data."""
+def test_config_driven_refresh_updates_capability_reasons():
+    """The config-driven (timed/gap) refresh writes capabilities and reasons to static_data."""
     agent = _make_agent()
-    agent.permissions.refresh_if_needed.return_value = True
     agent.permissions.get_all.return_value = {"nvidia_gpu": False, "cpu": True}
     agent.permissions.get_reasons.return_value = {
         "nvidia_gpu": "nvmlInit failed: driver removed"
     }
 
     agent_module.refresh_permissions_event.clear()
-    agent._handle_permission_refresh()
+    agent._apply_config_driven_refresh({"interval": 60})
 
+    agent.permissions.refresh_due.assert_called_once()
     assert (
         agent.static_data["capability_reasons"]["nvidia_gpu"]
         == "nvmlInit failed: driver removed"
     )
 
 
-def test_no_refresh_leaves_static_data_unchanged():
-    """When neither path triggers, static_data is not touched."""
+def test_no_sighup_leaves_static_data_unchanged():
+    """When the SIGHUP event is not set, the sighup handler does not touch static_data."""
     agent = _make_agent()
-    agent.permissions.refresh_if_needed.return_value = False
     snapshot_before = dict(agent.static_data)
 
     agent_module.refresh_permissions_event.clear()
-    agent._handle_permission_refresh()
+    agent._handle_sighup_refresh()
 
+    agent.permissions.force_refresh.assert_not_called()
     assert agent.static_data == snapshot_before

--- a/tests/test_agent_dry_run.py
+++ b/tests/test_agent_dry_run.py
@@ -25,7 +25,8 @@ def make_dry_run_agent():
     agent.synchronizer = None
     agent.permissions = MagicMock()
     agent.permissions.get_all.return_value = {}
-    agent.permissions.refresh_if_needed.return_value = False
+    agent.permissions.refresh_due.return_value = False
+    agent._last_recheck_token = agent_module._RECHECK_UNSET
     agent.queue = MagicMock()
     agent.static_data = {"version": "test"}
     agent._telemetry = {}

--- a/tests/test_agent_recheck.py
+++ b/tests/test_agent_recheck.py
@@ -1,0 +1,200 @@
+"""Tests for the backend-controlled recheck additions to Agent:
+recheck-token state machine, interval/throttle clamping, pending computation,
+and the config-driven refresh dispatch.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock libvirt before any fivenines_agent imports that transitively need it
+sys.modules.setdefault("libvirt", MagicMock())
+
+import fivenines_agent.agent as agent_module  # noqa: E402
+from fivenines_agent.agent import Agent  # noqa: E402
+
+
+def _agent(caps=None, reasons=None):
+    agent = Agent.__new__(Agent)
+    agent.permissions = MagicMock()
+    agent.permissions.get_all.return_value = caps if caps is not None else {}
+    agent.permissions.get_reasons.return_value = reasons or {}
+    agent.permissions.refresh_due.return_value = False
+    agent._last_recheck_token = agent_module._RECHECK_UNSET
+    agent.static_data = {}
+    return agent
+
+
+# --- _recheck_token_changed (nonce state machine) ---
+
+
+def test_token_first_observation_none_baselines():
+    agent = _agent()
+    assert agent._recheck_token_changed(None) is False
+    assert agent._last_recheck_token is None
+
+
+def test_token_first_observation_value_baselines_no_fire():
+    """A token already set when the agent (re)starts must not trigger a reprobe."""
+    agent = _agent()
+    assert agent._recheck_token_changed("abc") is False
+    assert agent._last_recheck_token == "abc"
+
+
+def test_token_change_after_baseline_fires():
+    agent = _agent()
+    agent._recheck_token_changed(None)  # baseline
+    assert agent._recheck_token_changed("abc") is True
+
+
+def test_token_unchanged_no_fire():
+    agent = _agent()
+    agent._recheck_token_changed("abc")  # baseline
+    assert agent._recheck_token_changed("abc") is False
+
+
+def test_token_changes_to_different_value_fires():
+    agent = _agent()
+    agent._recheck_token_changed("abc")  # baseline
+    assert agent._recheck_token_changed("def") is True
+
+
+def test_token_null_resets_then_same_value_fires():
+    """abc -> null -> abc fires, because null resets the baseline."""
+    agent = _agent()
+    agent._recheck_token_changed("abc")  # baseline
+    assert agent._recheck_token_changed(None) is False
+    assert agent._last_recheck_token is None
+    assert agent._recheck_token_changed("abc") is True
+
+
+# --- _collection_interval ---
+
+
+def test_collection_interval_default_when_absent():
+    assert _agent()._collection_interval({}) == 60
+
+
+def test_collection_interval_allows_low_warmup_value():
+    assert _agent()._collection_interval({"interval": 5}) == 5
+
+
+def test_collection_interval_blocks_zero_and_negative():
+    agent = _agent()
+    assert agent._collection_interval({"interval": 0}) == 60
+    assert agent._collection_interval({"interval": -3}) == 60
+
+
+def test_collection_interval_rejects_non_numeric_and_bool():
+    agent = _agent()
+    assert agent._collection_interval({"interval": "x"}) == 60
+    assert agent._collection_interval({"interval": True}) == 60
+
+
+def test_collection_interval_passes_normal_value():
+    assert _agent()._collection_interval({"interval": 60}) == 60
+
+
+# --- _gap_probe_interval ---
+
+
+def test_gap_interval_absent_means_every_tick():
+    assert _agent()._gap_probe_interval({}, 60) == 0
+
+
+def test_gap_interval_throttle_above_interval():
+    assert (
+        _agent()._gap_probe_interval({"permissions_recheck_interval": 120}, 60) == 120
+    )
+
+
+def test_gap_interval_floored_at_interval():
+    assert _agent()._gap_probe_interval({"permissions_recheck_interval": 30}, 60) == 60
+
+
+def test_gap_interval_capped_at_3600():
+    assert (
+        _agent()._gap_probe_interval({"permissions_recheck_interval": 99999}, 60)
+        == 3600
+    )
+
+
+def test_gap_interval_rejects_zero_negative_bool_and_nonint():
+    agent = _agent()
+    assert agent._gap_probe_interval({"permissions_recheck_interval": 0}, 60) == 0
+    assert agent._gap_probe_interval({"permissions_recheck_interval": -5}, 60) == 0
+    assert agent._gap_probe_interval({"permissions_recheck_interval": True}, 60) == 0
+    assert agent._gap_probe_interval({"permissions_recheck_interval": "x"}, 60) == 0
+
+
+# --- _pending_capabilities ---
+
+
+def test_pending_includes_enabled_missing_and_override():
+    agent = _agent({"qemu": False, "docker": True, "smart_storage": False})
+    config = {"qemu": True, "docker": True, "smart_storage_health": True}
+    pending = agent._pending_capabilities(config)
+    assert "qemu" in pending  # enabled + missing
+    assert "smart_storage" in pending  # override: smart_storage_health -> smart_storage
+    assert "docker" not in pending  # enabled but present
+
+
+def test_pending_excludes_disabled():
+    agent = _agent({"qemu": False})
+    assert agent._pending_capabilities({}) == []
+
+
+def test_pending_includes_snmp_targets():
+    agent = _agent({"snmp": False})
+    pending = agent._pending_capabilities({"snmp_targets": [{"host": "h"}]})
+    assert pending == ["snmp"]
+
+
+def test_pending_snmp_not_added_when_available():
+    agent = _agent({"snmp": True})
+    assert agent._pending_capabilities({"snmp_targets": [{"host": "h"}]}) == []
+
+
+# --- _apply_config_driven_refresh ---
+
+
+def test_apply_token_change_forces_full_reprobe():
+    agent = _agent({"qemu": True})
+    agent._last_recheck_token = "old"
+    agent._apply_config_driven_refresh({"permissions_recheck_token": "new"})
+    agent.permissions.force_refresh.assert_called_once()
+    agent.permissions.refresh_due.assert_not_called()
+    assert agent.static_data["capabilities"] == {"qemu": True}
+    assert agent.static_data["pending_capabilities"] == []
+
+
+def test_apply_no_token_runs_gap_refresh_and_publishes_state():
+    agent = _agent({"qemu": False}, reasons={"qemu": "libvirt probe timed out"})
+    agent._apply_config_driven_refresh({"interval": 60, "qemu": True})
+    agent.permissions.force_refresh.assert_not_called()
+    agent.permissions.refresh_due.assert_called_once_with(["qemu"], 0)
+    assert agent.static_data["capabilities"] == {"qemu": False}
+    assert agent.static_data["capability_reasons"] == {
+        "qemu": "libvirt probe timed out"
+    }
+    assert agent.static_data["pending_capabilities"] == ["qemu"]
+
+
+# --- _wait_interval (uses the clamped collection interval) ---
+
+
+def test_wait_interval_uses_clamped_interval():
+    agent = _agent()
+    agent.config = {"interval": 60}
+    with patch.object(agent_module, "exit_event") as fake_event:
+        agent._wait_interval(0.5)
+    fake_event.wait.assert_called_once()
+    assert abs(fake_event.wait.call_args[0][0] - 59.5) < 0.01
+
+
+def test_wait_interval_floors_sleep_at_minimum():
+    """A 5s warmup interval with longer running_time floors the sleep at 0.1s."""
+    agent = _agent()
+    agent.config = {"interval": 5}
+    with patch.object(agent_module, "exit_event") as fake_event:
+        agent._wait_interval(10.0)
+    assert fake_event.wait.call_args[0][0] == 0.1

--- a/tests/test_agent_watchdog.py
+++ b/tests/test_agent_watchdog.py
@@ -19,7 +19,8 @@ def make_agent():
     agent.synchronizer = MagicMock()
     agent.permissions = MagicMock()
     agent.permissions.get_all.return_value = {}
-    agent.permissions.refresh_if_needed.return_value = False
+    agent.permissions.refresh_due.return_value = False
+    agent._last_recheck_token = agent_module._RECHECK_UNSET
     agent.queue = MagicMock()
     agent.static_data = {"version": "test"}
     agent._telemetry = {}

--- a/tests/test_permissions_recheck.py
+++ b/tests/test_permissions_recheck.py
@@ -1,0 +1,202 @@
+"""Tests for the backend-controlled recheck additions to PermissionProbe:
+selective gap re-probe (refresh_due / _reprobe_capabilities) and the
+openReadOnly-based libvirt probe with hard timeout.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import fivenines_agent.permissions as perm
+from fivenines_agent.permissions import PermissionProbe
+
+
+@pytest.fixture(autouse=True)
+def _force_linux():
+    with patch("fivenines_agent.permissions.is_windows", return_value=False):
+        yield
+
+
+def _probe_obj(caps, last_probe_time=0, last_gap_probe_time=0):
+    probe = PermissionProbe.__new__(PermissionProbe)
+    probe.capabilities = dict(caps)
+    probe._capability_reasons = {}
+    probe._current_reason = None
+    probe._last_probe_time = last_probe_time
+    probe._last_gap_probe_time = last_gap_probe_time
+    return probe
+
+
+# --- _reprobe_capabilities (selective gap probe) ---
+
+
+def test_reprobe_flips_to_available_and_logs():
+    probe = _probe_obj({"qemu": False, "cpu": True})
+    with patch.object(PermissionProbe, "_can_access_libvirt", return_value=True), patch(
+        "fivenines_agent.permissions.log"
+    ) as mock_log:
+        flipped = probe._reprobe_capabilities({"qemu"})
+    assert flipped is True
+    assert probe.capabilities["qemu"] is True
+    info = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    assert any("qemu" in m and "now AVAILABLE" in m for m in info)
+
+
+def test_reprobe_flips_to_unavailable_with_hint():
+    probe = _probe_obj({"qemu": True})
+    with patch.object(
+        PermissionProbe, "_can_access_libvirt", return_value=False
+    ), patch("fivenines_agent.permissions.log") as mock_log:
+        flipped = probe._reprobe_capabilities({"qemu"})
+    assert flipped is True
+    assert probe.capabilities["qemu"] is False
+    info = [c.args[0] for c in mock_log.call_args_list if c.args[1] == "info"]
+    flip = next(m for m in info if "qemu" in m and "now UNAVAILABLE" in m)
+    assert "requires libvirt group" in flip
+
+
+def test_reprobe_no_flip_returns_false():
+    probe = _probe_obj({"qemu": True})
+    with patch.object(PermissionProbe, "_can_access_libvirt", return_value=True):
+        assert probe._reprobe_capabilities({"qemu"}) is False
+    assert probe.capabilities["qemu"] is True
+
+
+def test_reprobe_skips_unknown_capability():
+    probe = _probe_obj({"qemu": False})
+    assert probe._reprobe_capabilities({"not_a_capability"}) is False
+    assert "not_a_capability" not in probe.capabilities
+
+
+# --- refresh_due (cadence) ---
+
+
+def test_refresh_due_full_probe_when_interval_elapsed():
+    probe = _probe_obj({"qemu": False}, last_probe_time=0)
+
+    def fake_full():
+        probe.capabilities = {"qemu": True}
+
+    with patch.object(probe, "_probe_all", side_effect=fake_full):
+        changed = probe.refresh_due({"qemu"}, 0)
+    assert changed is True
+    assert probe.capabilities == {"qemu": True}
+
+
+def test_refresh_due_full_probe_no_change_returns_false():
+    probe = _probe_obj({"qemu": True}, last_probe_time=0)
+    with patch.object(probe, "_probe_all", side_effect=lambda: None):
+        assert probe.refresh_due((), 0) is False
+
+
+def test_refresh_due_gap_probe_when_not_due_for_full():
+    import time
+
+    probe = _probe_obj(
+        {"qemu": False}, last_probe_time=time.time(), last_gap_probe_time=0
+    )
+    with patch.object(PermissionProbe, "_can_access_libvirt", return_value=True):
+        changed = probe.refresh_due({"qemu"}, 0)
+    assert changed is True
+    assert probe.capabilities["qemu"] is True
+
+
+def test_refresh_due_empty_gap_is_noop():
+    import time
+
+    probe = _probe_obj(
+        {"qemu": False}, last_probe_time=time.time(), last_gap_probe_time=0
+    )
+    assert probe.refresh_due((), 0) is False
+    assert probe.capabilities["qemu"] is False
+
+
+def test_refresh_due_gap_throttled_not_due():
+    import time
+
+    now = time.time()
+    probe = _probe_obj({"qemu": False}, last_probe_time=now, last_gap_probe_time=now)
+    # gap_interval huge -> the gap probe is not due yet
+    assert probe.refresh_due({"qemu"}, 9999) is False
+    assert probe.capabilities["qemu"] is False
+
+
+# --- _can_access_libvirt (openReadOnly + hard timeout) ---
+
+
+def test_libvirt_probe_module_not_importable():
+    probe = _probe_obj({})
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "libvirt":
+            raise ImportError("no libvirt")
+        return real_import(name, *a, **k)
+
+    with patch.object(builtins, "__import__", fake_import):
+        assert probe._can_access_libvirt() is False
+    assert probe._current_reason == "libvirt module not available"
+
+
+def test_libvirt_probe_connects():
+    probe = _probe_obj({})
+    fake_libvirt = MagicMock()
+    conn = MagicMock()
+    fake_libvirt.openReadOnly.return_value = conn
+    with patch.dict("sys.modules", {"libvirt": fake_libvirt}):
+        assert probe._can_access_libvirt() is True
+    fake_libvirt.openReadOnly.assert_called_once_with("qemu:///system")
+    conn.close.assert_called_once()
+
+
+def test_libvirt_probe_returns_none():
+    probe = _probe_obj({})
+    fake_libvirt = MagicMock()
+    fake_libvirt.openReadOnly.return_value = None
+    with patch.dict("sys.modules", {"libvirt": fake_libvirt}):
+        assert probe._can_access_libvirt() is False
+    assert probe._current_reason == "openReadOnly returned None"
+
+
+def test_libvirt_probe_raises():
+    probe = _probe_obj({})
+    fake_libvirt = MagicMock()
+    fake_libvirt.openReadOnly.side_effect = RuntimeError("boom")
+    with patch.dict("sys.modules", {"libvirt": fake_libvirt}):
+        assert probe._can_access_libvirt() is False
+    assert probe._current_reason == "RuntimeError: boom"
+
+
+def test_libvirt_probe_swallows_close_error():
+    """A failing conn.close() must not break the probe: connection succeeded."""
+    probe = _probe_obj({})
+    fake_libvirt = MagicMock()
+    conn = MagicMock()
+    conn.close.side_effect = RuntimeError("close failed")
+    fake_libvirt.openReadOnly.return_value = conn
+    with patch.dict("sys.modules", {"libvirt": fake_libvirt}):
+        assert probe._can_access_libvirt() is True
+    conn.close.assert_called_once()
+
+
+def test_libvirt_probe_times_out():
+    probe = _probe_obj({})
+    release = threading.Event()
+    fake_libvirt = MagicMock()
+
+    def blocking_open(uri):
+        release.wait(2)  # block past the (patched, tiny) probe timeout
+        return MagicMock()
+
+    fake_libvirt.openReadOnly.side_effect = blocking_open
+    try:
+        with patch.dict("sys.modules", {"libvirt": fake_libvirt}), patch.object(
+            perm, "LIBVIRT_PROBE_TIMEOUT", 0.05
+        ):
+            assert probe._can_access_libvirt() is False
+        assert probe._current_reason == "libvirt probe timed out"
+    finally:
+        release.set()  # let the abandoned daemon worker finish


### PR DESCRIPTION
Makes the agent detect late-arriving capabilities (QEMU, Docker, SMART, ...) within ~one interval instead of up to 5 minutes, so new users stop seeing an empty dashboard and thinking the integration is broken, without ever coupling collection cadence to permission state.

- Selective gap re-probe of enabled-but-missing capabilities every tick (the 300s full probe is kept for regressions).
- QEMU is now probed via `libvirt.openReadOnly("qemu:///system")` behind a hard timeout (worker thread + join), mirroring the collector exactly so a wedged libvirt stack can no longer stall the whole loop; the probe spec is refactored into one shared `name -> (probe, args)` table.
- Backend-tunable recheck throttle (floored at the collection interval) and an on-demand re-detect token, with `pending_capabilities` reported in the payload for the dashboard "pending + reason" view, plus a collection-interval clamp.
- 39 new tests (`test_permissions_recheck.py`, `test_agent_recheck.py`); full suite green (583 passing).

Pre-merge gates (cannot run on the macOS dev box): verify `openReadOnly` on a real libvirt host (system + modular `virtqemud`/`virtproxyd`) and run `make test` on Linux, since CI does not run pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
