### PR TITLE
feat: connect to PostgreSQL via pg8000 driver instead of psql

### DIFF
--- a/fivenines_agent/postgresql.py
+++ b/fivenines_agent/postgresql.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import ssl
 
 import pg8000.dbapi
 from pg8000.exceptions import DatabaseError, InterfaceError
@@ -13,7 +14,8 @@ from fivenines_agent.debug import debug, log
 # driver). No `psql` binary is required on the host, so a PostgreSQL running
 # inside a Docker container is reachable over its published TCP port.
 #
-# Metrics collected (one connection per tick, six read-only queries):
+# Metrics collected (one connection per tick, six read-only queries; a replica
+# adds a seventh query for replication lag):
 #   - server version
 #   - connection counts by state (active, idle, idle in transaction, ...)
 #   - per-database statistics (transactions, cache hit ratio, tuples, ...)
@@ -41,18 +43,56 @@ from fivenines_agent.debug import debug, log
 # Password discovery mirrors the previous psql/libpq behavior so existing
 # installs keep working: explicit config password, then PGPASSWORD, then a
 # ~/.pgpass / PGPASSFILE lookup. (pg_service.conf / PGSERVICE is not handled.)
+# TLS follows PGSSLMODE / PGSSLROOTCERT (see _ssl_context).
 
-# Bounds connection establishment so a dead host cannot stall the loop.
-CONNECT_TIMEOUT = 5
-
-# Server-side per-query cap, sent as a startup parameter so it protects EVERY
-# query including the first, with no extra round-trip (vs a post-connect SET).
+# Server-side per-query cap (ms). Sent as a startup parameter so it protects
+# EVERY query including the first, with no extra round-trip. We keep it in the
+# StartupMessage rather than a post-connect `SET` because a `SET` in autocommit
+# mode does not persist across statements behind a transaction pooler, and
+# monitoring through a transaction pooler is atypical anyway (it breaks the
+# session-scoped pg_stat_* views this collector reads).
 STATEMENT_TIMEOUT_MS = 5000
+
+# The socket read timeout must EXCEED statement_timeout: a slow query should be
+# cancelled server-side (a clean, degradable DatabaseError) before the socket
+# read times out (an InterfaceError that would flip the whole tick to
+# unreachable). It also bounds connection establishment so a dead host cannot
+# stall the loop.
+SOCKET_TIMEOUT = 10
 
 
 def _is_socket_host(host):
     """True when host is a Unix socket directory path (psql-style)."""
     return isinstance(host, str) and host.startswith("/")
+
+
+def _ssl_context(host):
+    """Return the pg8000 ssl_context for the configured PGSSLMODE.
+
+    Restores the TLS posture the old psql/libpq path honored via env:
+      disable                -> False (no TLS)
+      require                -> TLS required, certificate NOT verified
+      verify-ca              -> TLS required, certificate verified (no hostname)
+      verify-full            -> TLS required, certificate + hostname verified
+      prefer/allow/unset     -> None (pg8000 default: opportunistic, unverified)
+    PGSSLROOTCERT selects the CA bundle for the verify-* modes. TLS is never
+    used over a local Unix socket (libpq behavior), regardless of PGSSLMODE.
+    """
+    if _is_socket_host(host):
+        return False
+    mode = os.environ.get("PGSSLMODE")
+    if mode == "disable":
+        return False
+    if mode == "require":
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    if mode in ("verify-ca", "verify-full"):
+        ctx = ssl.create_default_context(cafile=os.environ.get("PGSSLROOTCERT") or None)
+        ctx.check_hostname = mode == "verify-full"
+        return ctx
+    return None
 
 
 def _split_pgpass_line(line):
@@ -113,7 +153,10 @@ def _pgpass_lookup(host, port, database, user):
 
     target = [str(host), str(port), str(database), str(user)]
     for raw in lines:
-        line = raw.rstrip("\n")
+        # rstrip CR as well as LF: a Windows pgpass.conf (and the standard
+        # %APPDATA% location) is CRLF, and a trailing \r would corrupt the
+        # password field.
+        line = raw.rstrip("\r\n")
         if not line or line.lstrip().startswith("#"):
             continue
         entry = _split_pgpass_line(line)
@@ -147,19 +190,25 @@ def _resolve_password(host, port, database, user, password):
 
 def _connect(host, port, user, password, database):
     """Open a pg8000 connection, routing path-like hosts to a unix socket."""
+    try:
+        port_num = int(port)
+    except (TypeError, ValueError):
+        # A socket config may legitimately omit the port; fall back to default.
+        port_num = 5432
     params = {
         "user": user,
         "database": database,
-        "password": _resolve_password(host, port, database, user, password),
-        "timeout": CONNECT_TIMEOUT,
+        "password": _resolve_password(host, port_num, database, user, password),
+        "ssl_context": _ssl_context(host),
+        "timeout": SOCKET_TIMEOUT,
         "startup_params": {"statement_timeout": str(STATEMENT_TIMEOUT_MS)},
     }
     if _is_socket_host(host):
         # psql-style socket directory -> pg8000 socket file path.
-        params["unix_sock"] = "{}/.s.PGSQL.{}".format(host.rstrip("/"), int(port))
+        params["unix_sock"] = "{}/.s.PGSQL.{}".format(host.rstrip("/"), port_num)
     else:
         params["host"] = host
-        params["port"] = int(port)
+        params["port"] = port_num
     return pg8000.dbapi.connect(**params)
 
 
@@ -179,6 +228,11 @@ def _error_category(exc):
     if isinstance(cause, socket.gaierror):
         return "unreachable"
     if isinstance(exc, InterfaceError):
+        # pg8000 raises InterfaceError (not DatabaseError) when the server
+        # requires a password none was provided, or for an unsupported auth
+        # method -- every such message contains "authentication".
+        if "authentication" in str(exc).lower():
+            return "auth_failed"
         return "unreachable"
     return "error"
 
@@ -206,7 +260,9 @@ def _get_version(cursor):
     """Return the PostgreSQL server version string (e.g. '16.2')."""
     rows = _query(cursor, "SHOW server_version;")
     if rows:
-        return str(rows[0][0]).split()[0]
+        parts = str(rows[0][0]).split()
+        if parts:
+            return parts[0]
     return None
 
 
@@ -299,12 +355,23 @@ def _get_database_sizes(cursor):
     return sizes
 
 
-def _get_replication_lag(cursor):
-    """Return replication lag in seconds for a replica, else None."""
-    rows = _query(cursor, "SELECT pg_is_in_recovery();")
-    if not rows or not rows[0][0]:
-        return None
+def _get_replication(cursor):
+    """Return (is_replica, lag_seconds).
 
+    is_replica is derived from pg_is_in_recovery() ALONE, independent of the lag
+    value, so a replica whose lag is not yet available (NULL, e.g. just after
+    start) is still reported as a replica rather than misclassified as a
+    primary. is_replica is None when pg_is_in_recovery() could not be read
+    (query denied/failed) -- distinct from False (a confirmed primary).
+    lag_seconds is None on a primary or when a replica's lag is unavailable.
+    """
+    rows = _query(cursor, "SELECT pg_is_in_recovery();")
+    if not rows:
+        return None, None
+    if not rows[0][0]:
+        return False, None
+
+    lag = None
     lag_rows = _query(
         cursor,
         "SELECT CASE "
@@ -314,10 +381,10 @@ def _get_replication_lag(cursor):
     )
     if lag_rows and lag_rows[0][0] is not None:
         try:
-            return float(lag_rows[0][0])
+            lag = float(lag_rows[0][0])
         except (ValueError, TypeError):
-            return None
-    return None
+            lag = None
+    return True, lag
 
 
 def _get_locks_count(cursor):
@@ -333,9 +400,30 @@ def _get_locks_count(cursor):
     return locks
 
 
+def _failure(exc):
+    """Build the unreachable payload for an exception.
+
+    The category comes from _error_category; for the generic "error" catch-all
+    a short human-readable error_detail is attached (the contract's optional
+    field) since the category alone is not descriptive there.
+    """
+    category = _error_category(exc)
+    result = {"reachable": False, "error": category}
+    if category == "error":
+        detail = str(exc).strip()
+        if detail:
+            result["error_detail"] = detail[:200]
+    return result
+
+
 @debug("postgresql_metrics")
 def postgresql_metrics(
-    host="localhost", port=5432, user="postgres", password=None, database="postgres"
+    host="localhost",
+    port=5432,
+    user="postgres",
+    password=None,
+    database="postgres",
+    **_kwargs,
 ):
     """Collect metrics from PostgreSQL over a direct socket connection.
 
@@ -345,6 +433,8 @@ def postgresql_metrics(
         user: PostgreSQL user (default: postgres).
         password: password, or None for peer/trust auth.
         database: database to connect to (default: postgres).
+        **_kwargs: extra config keys are ignored (forward-compatible with the
+            backend adding connection options the agent does not yet know).
 
     Returns:
         dict: {"reachable": True, <metrics...>} when connected (metric sections
@@ -354,9 +444,8 @@ def postgresql_metrics(
     try:
         conn = _connect(host, port, user, password, database)
     except Exception as e:
-        category = _error_category(e)
-        log(f"Cannot connect to PostgreSQL ({category}): {e}", "debug")
-        return {"reachable": False, "error": category}
+        log(f"Cannot connect to PostgreSQL: {e}", "debug")
+        return _failure(e)
 
     try:
         # Read-only collection: autocommit isolates each query so a denied
@@ -396,12 +485,11 @@ def postgresql_metrics(
             metrics["database_sizes"] = sizes
             metrics["total_size"] = sum(sizes.values())
 
-        replication_lag = _get_replication_lag(cursor)
+        is_replica, replication_lag = _get_replication(cursor)
+        if is_replica is not None:
+            metrics["is_replica"] = is_replica
         if replication_lag is not None:
             metrics["replication_lag_seconds"] = replication_lag
-            metrics["is_replica"] = True
-        else:
-            metrics["is_replica"] = False
 
         locks = _get_locks_count(cursor)
         if locks:
@@ -409,9 +497,11 @@ def postgresql_metrics(
 
         return metrics
     except Exception as e:
-        # Connected but the session could not be queried at all -- not healthy.
+        # A transport/session error reached here (a degradable per-view error
+        # would have been swallowed in _query). The session is not usable;
+        # report unreachable with the specific category, not a flat "error".
         log(f"Error collecting PostgreSQL metrics: {e}", "error")
-        return {"reachable": False, "error": "error"}
+        return _failure(e)
     finally:
         try:
             conn.close()

--- a/fivenines_agent/postgresql.py
+++ b/fivenines_agent/postgresql.py
@@ -1,298 +1,307 @@
-import subprocess
-import json
+import socket
+
+import pg8000.dbapi
+from pg8000.exceptions import DatabaseError, InterfaceError
 
 from fivenines_agent.debug import debug, log
-from fivenines_agent.subprocess_utils import get_clean_env
 
 
 # PostgreSQL metrics collector
-# Collects statistics from PostgreSQL using psql command
 #
-# Metrics collected:
-# - Connection counts by state (active, idle, idle in transaction)
-# - Database statistics (transactions, cache hit ratio)
-# - Database sizes
-# - Replication lag (if applicable)
+# Connects directly to PostgreSQL over a socket using pg8000 (a pure-Python
+# driver). No `psql` binary is required on the host, so a PostgreSQL running
+# inside a Docker container is reachable over its published TCP port.
+#
+# Metrics collected (one connection per tick, six read-only queries):
+#   - server version
+#   - connection counts by state (active, idle, idle in transaction, ...)
+#   - per-database statistics (transactions, cache hit ratio, tuples, ...)
+#   - per-database sizes (bytes)
+#   - replication lag (replicas only)
+#   - lock counts by mode
+#
+# Connection routing (backward compatible with the previous psql collector):
+#
+#   config.host -- starts with "/" --> unix domain socket
+#   (psql passed a socket DIRECTORY to `-h`; pg8000 wants the socket FILE,
+#    so we append the standard ".s.PGSQL.<port>" name). password=None keeps
+#    peer/trust auth working.
+#               -- otherwise       --> TCP to host:port (the Docker path)
+#
+# Failure contract:
+#   connect / auth / timeout fails --> {"reachable": False, "error": <category>}
+#   connected                      --> {"reachable": True, <metrics...>}
+#   Once connected, a single query that fails (e.g. the monitoring role lacks
+#   privilege on one view) only drops THAT section; reachable stays True and
+#   the rest of the payload is still returned (autocommit isolates queries).
 
-def _run_psql_query(query, host='localhost', port=5432, user='postgres', password=None, database='postgres'):
-    """Run a psql query and return JSON results."""
-    env = {}
-    if password:
-        env['PGPASSWORD'] = password
+# Bounds connection establishment so a dead host cannot stall the loop.
+CONNECT_TIMEOUT = 5
 
-    cmd = [
-        'psql',
-        '-h', str(host),
-        '-p', str(port),
-        '-U', str(user),
-        '-d', str(database),
-        '-t',  # Tuples only (no headers)
-        '-A',  # Unaligned output
-        '-c', query
-    ]
+# Server-side per-query cap, sent as a startup parameter so it protects EVERY
+# query including the first, with no extra round-trip (vs a post-connect SET).
+STATEMENT_TIMEOUT_MS = 5000
 
+
+def _connect(host, port, user, password, database):
+    """Open a pg8000 connection, routing path-like hosts to a unix socket."""
+    params = {
+        "user": user,
+        "database": database,
+        "password": password,
+        "timeout": CONNECT_TIMEOUT,
+        "startup_params": {"statement_timeout": str(STATEMENT_TIMEOUT_MS)},
+    }
+    if isinstance(host, str) and host.startswith("/"):
+        # psql-style socket directory -> pg8000 socket file path.
+        params["unix_sock"] = "{}/.s.PGSQL.{}".format(host.rstrip("/"), int(port))
+    else:
+        params["host"] = host
+        params["port"] = int(port)
+    return pg8000.dbapi.connect(**params)
+
+
+def _error_category(exc):
+    """Map a connection exception to a stable, backend-facing category."""
+    if isinstance(exc, DatabaseError):
+        detail = exc.args[0] if exc.args else None
+        code = detail.get("C") if isinstance(detail, dict) else None
+        if code and str(code).startswith("28"):  # SQLSTATE 28xxx = invalid auth
+            return "auth_failed"
+        return "error"
+    cause = getattr(exc, "__cause__", None)
+    if isinstance(cause, ConnectionRefusedError):
+        return "connection_refused"
+    if isinstance(cause, (socket.timeout, TimeoutError)):
+        return "timeout"
+    if isinstance(cause, socket.gaierror):
+        return "unreachable"
+    if isinstance(exc, InterfaceError):
+        return "unreachable"
+    return "error"
+
+
+def _query(cursor, sql):
+    """Run a read-only query on the shared cursor; degrade to None on failure.
+
+    A per-query failure (most often a per-view privilege denial) is logged and
+    surfaced as None so the caller drops only that one section. autocommit is
+    enabled on the connection, so the failure does not poison later queries.
+    """
     try:
-        # Use clean env to avoid PyInstaller library conflicts, merge in PGPASSWORD if set
-        clean_env = get_clean_env()
-        if env:
-            clean_env.update(env)
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env=clean_env
-        )
-        if result.returncode != 0:
-            log(f"psql error: {result.stderr}", 'debug')
-            return None
-        return result.stdout.strip()
-    except subprocess.TimeoutExpired:
-        log("psql query timed out", 'debug')
-        return None
-    except FileNotFoundError:
-        log("psql command not found", 'debug')
-        return None
+        cursor.execute(sql)
+        return cursor.fetchall()
     except Exception as e:
-        log(f"Error running psql: {e}", 'debug')
+        log(f"PostgreSQL query failed: {e}", "error")
         return None
 
 
-def _get_version(host, port, user, password, database):
-    """Get PostgreSQL version."""
-    result = _run_psql_query("SHOW server_version;", host, port, user, password, database)
-    if result:
-        return result.split()[0]  # Get just the version number
+def _get_version(cursor):
+    """Return the PostgreSQL server version string (e.g. '16.2')."""
+    rows = _query(cursor, "SHOW server_version;")
+    if rows:
+        return str(rows[0][0]).split()[0]
     return None
 
 
-def _get_connection_stats(host, port, user, password, database):
-    """Get connection statistics by state."""
-    query = """
-    SELECT state, count(*)
-    FROM pg_stat_activity
-    WHERE state IS NOT NULL
-    GROUP BY state;
-    """
-    result = _run_psql_query(query, host, port, user, password, database)
-    if not result:
+def _get_connection_stats(cursor):
+    """Return connection counts by backend state."""
+    rows = _query(
+        cursor,
+        "SELECT state, count(*) FROM pg_stat_activity "
+        "WHERE state IS NOT NULL GROUP BY state;",
+    )
+    if not rows:
         return {}
 
     stats = {
-        'active': 0,
-        'idle': 0,
-        'idle_in_transaction': 0,
-        'idle_in_transaction_aborted': 0,
-        'fastpath_function_call': 0,
-        'disabled': 0
+        "active": 0,
+        "idle": 0,
+        "idle_in_transaction": 0,
+        "idle_in_transaction_aborted": 0,
+        "fastpath_function_call": 0,
+        "disabled": 0,
     }
-
-    for line in result.split('\n'):
-        if '|' in line:
-            parts = line.split('|')
-            if len(parts) >= 2:
-                state = parts[0].strip().replace(' ', '_')
-                count = int(parts[1].strip())
-                if state in stats:
-                    stats[state] = count
-
-    # Calculate total
-    stats['total'] = sum(stats.values())
+    for state, count in rows:
+        key = str(state).replace(" ", "_")
+        if key in stats:
+            stats[key] = int(count)
+    stats["total"] = sum(stats.values())
     return stats
 
 
-def _get_database_stats(host, port, user, password, database):
-    """Get database-level statistics."""
-    query = """
-    SELECT
-        datname,
-        numbackends,
-        xact_commit,
-        xact_rollback,
-        blks_read,
-        blks_hit,
-        tup_returned,
-        tup_fetched,
-        tup_inserted,
-        tup_updated,
-        tup_deleted,
-        conflicts,
-        deadlocks
-    FROM pg_stat_database
-    WHERE datname NOT LIKE 'template%'
-    ORDER BY datname;
-    """
-    result = _run_psql_query(query, host, port, user, password, database)
-    if not result:
+def _get_database_stats(cursor):
+    """Return per-database statistics (excluding template databases)."""
+    rows = _query(
+        cursor,
+        "SELECT datname, numbackends, xact_commit, xact_rollback, blks_read, "
+        "blks_hit, tup_returned, tup_fetched, tup_inserted, tup_updated, "
+        "tup_deleted, conflicts, deadlocks FROM pg_stat_database "
+        "WHERE datname NOT LIKE 'template%' ORDER BY datname;",
+    )
+    if not rows:
         return []
 
+    def num(value):
+        return int(value) if value is not None else 0
+
     databases = []
-    for line in result.split('\n'):
-        if '|' in line:
-            parts = [p.strip() for p in line.split('|')]
-            if len(parts) >= 13 and parts[0]:
-                blks_read = int(parts[4]) if parts[4] else 0
-                blks_hit = int(parts[5]) if parts[5] else 0
-                total_blks = blks_read + blks_hit
-
-                databases.append({
-                    'name': parts[0],
-                    'connections': int(parts[1]) if parts[1] else 0,
-                    'xact_commit': int(parts[2]) if parts[2] else 0,
-                    'xact_rollback': int(parts[3]) if parts[3] else 0,
-                    'blks_read': blks_read,
-                    'blks_hit': blks_hit,
-                    'cache_hit_ratio': round((blks_hit / total_blks * 100), 2) if total_blks > 0 else 100.0,
-                    'tup_returned': int(parts[6]) if parts[6] else 0,
-                    'tup_fetched': int(parts[7]) if parts[7] else 0,
-                    'tup_inserted': int(parts[8]) if parts[8] else 0,
-                    'tup_updated': int(parts[9]) if parts[9] else 0,
-                    'tup_deleted': int(parts[10]) if parts[10] else 0,
-                    'conflicts': int(parts[11]) if parts[11] else 0,
-                    'deadlocks': int(parts[12]) if parts[12] else 0
-                })
-
+    for r in rows:
+        name = r[0]
+        if not name:
+            continue
+        blks_read = num(r[4])
+        blks_hit = num(r[5])
+        total_blks = blks_read + blks_hit
+        databases.append(
+            {
+                "name": name,
+                "connections": num(r[1]),
+                "xact_commit": num(r[2]),
+                "xact_rollback": num(r[3]),
+                "blks_read": blks_read,
+                "blks_hit": blks_hit,
+                "cache_hit_ratio": (
+                    round((blks_hit / total_blks * 100), 2) if total_blks > 0 else 100.0
+                ),
+                "tup_returned": num(r[6]),
+                "tup_fetched": num(r[7]),
+                "tup_inserted": num(r[8]),
+                "tup_updated": num(r[9]),
+                "tup_deleted": num(r[10]),
+                "conflicts": num(r[11]),
+                "deadlocks": num(r[12]),
+            }
+        )
     return databases
 
 
-def _get_database_sizes(host, port, user, password, database):
-    """Get database sizes in bytes."""
-    query = """
-    SELECT datname, pg_database_size(datname) as size
-    FROM pg_database
-    WHERE datname NOT LIKE 'template%'
-    ORDER BY datname;
-    """
-    result = _run_psql_query(query, host, port, user, password, database)
-    if not result:
+def _get_database_sizes(cursor):
+    """Return a mapping of database name to size in bytes."""
+    rows = _query(
+        cursor,
+        "SELECT datname, pg_database_size(datname) FROM pg_database "
+        "WHERE datname NOT LIKE 'template%' ORDER BY datname;",
+    )
+    if not rows:
         return {}
 
     sizes = {}
-    for line in result.split('\n'):
-        if '|' in line:
-            parts = line.split('|')
-            if len(parts) >= 2 and parts[0].strip():
-                sizes[parts[0].strip()] = int(parts[1].strip())
-
+    for name, size in rows:
+        if name:
+            sizes[name] = int(size)
     return sizes
 
 
-def _get_replication_lag(host, port, user, password, database):
-    """Get replication lag in bytes (for replicas)."""
-    # Check if this is a replica
-    query = "SELECT pg_is_in_recovery();"
-    result = _run_psql_query(query, host, port, user, password, database)
+def _get_replication_lag(cursor):
+    """Return replication lag in seconds for a replica, else None."""
+    rows = _query(cursor, "SELECT pg_is_in_recovery();")
+    if not rows or not rows[0][0]:
+        return None
 
-    if result and result.strip() == 't':
-        # This is a replica, get lag
-        lag_query = """
-        SELECT
-            CASE
-                WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-                ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())
-            END AS lag_seconds;
-        """
-        lag_result = _run_psql_query(lag_query, host, port, user, password, database)
-        if lag_result and lag_result.strip():
-            try:
-                return float(lag_result.strip())
-            except ValueError:
-                return None
+    lag_rows = _query(
+        cursor,
+        "SELECT CASE "
+        "WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 "
+        "ELSE EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp()) "
+        "END;",
+    )
+    if lag_rows and lag_rows[0][0] is not None:
+        try:
+            return float(lag_rows[0][0])
+        except (ValueError, TypeError):
+            return None
     return None
 
 
-def _get_locks_count(host, port, user, password, database):
-    """Get count of locks by mode."""
-    query = """
-    SELECT mode, count(*)
-    FROM pg_locks
-    GROUP BY mode;
-    """
-    result = _run_psql_query(query, host, port, user, password, database)
-    if not result:
+def _get_locks_count(cursor):
+    """Return lock counts by mode, plus a total."""
+    rows = _query(cursor, "SELECT mode, count(*) FROM pg_locks GROUP BY mode;")
+    if not rows:
         return {}
 
     locks = {}
-    for line in result.split('\n'):
-        if '|' in line:
-            parts = line.split('|')
-            if len(parts) >= 2:
-                mode = parts[0].strip()
-                count = int(parts[1].strip())
-                locks[mode] = count
-
-    locks['total'] = sum(locks.values())
+    for mode, count in rows:
+        locks[mode] = int(count)
+    locks["total"] = sum(locks.values())
     return locks
 
 
-@debug('postgresql_metrics')
-def postgresql_metrics(host='localhost', port=5432, user='postgres', password=None, database='postgres'):
-    """
-    Collect metrics from PostgreSQL.
+@debug("postgresql_metrics")
+def postgresql_metrics(
+    host="localhost", port=5432, user="postgres", password=None, database="postgres"
+):
+    """Collect metrics from PostgreSQL over a direct socket connection.
 
     Args:
-        host: PostgreSQL host (default: localhost)
-        port: PostgreSQL port (default: 5432)
-        user: PostgreSQL user (default: postgres)
-        password: PostgreSQL password (default: None, uses peer auth)
-        database: Database to connect to (default: postgres)
+        host: TCP host, or a unix socket DIRECTORY path (starts with '/').
+        port: PostgreSQL port (default: 5432).
+        user: PostgreSQL user (default: postgres).
+        password: password, or None for peer/trust auth.
+        database: database to connect to (default: postgres).
 
     Returns:
-        dict: Metrics dictionary or None on error
+        dict: {"reachable": True, <metrics...>} when connected (metric sections
+        may be partial if a query is denied); {"reachable": False, "error":
+        <category>} when the connection or authentication fails.
     """
     try:
-        metrics = {}
+        conn = _connect(host, port, user, password, database)
+    except Exception as e:
+        category = _error_category(e)
+        log(f"Cannot connect to PostgreSQL ({category}): {e}", "debug")
+        return {"reachable": False, "error": category}
 
-        # Get version
-        version = _get_version(host, port, user, password, database)
-        if version is None:
-            log("Cannot connect to PostgreSQL", 'debug')
-            return None
+    try:
+        # Read-only collection: autocommit isolates each query so a denied
+        # view drops only its own section instead of aborting the rest.
+        conn.autocommit = True
+        cursor = conn.cursor()
+        metrics: dict = {"reachable": True}
 
-        metrics['version'] = version
+        version = _get_version(cursor)
+        if version is not None:
+            metrics["version"] = version
 
-        # Get connection stats
-        conn_stats = _get_connection_stats(host, port, user, password, database)
+        conn_stats = _get_connection_stats(cursor)
         if conn_stats:
-            metrics['connections'] = conn_stats
+            metrics["connections"] = conn_stats
 
-        # Get database stats
-        db_stats = _get_database_stats(host, port, user, password, database)
+        db_stats = _get_database_stats(cursor)
         if db_stats:
-            metrics['databases'] = db_stats
-
-            # Calculate totals across all databases
-            metrics['total_xact_commit'] = sum(d['xact_commit'] for d in db_stats)
-            metrics['total_xact_rollback'] = sum(d['xact_rollback'] for d in db_stats)
-            metrics['total_deadlocks'] = sum(d['deadlocks'] for d in db_stats)
-
-            # Calculate overall cache hit ratio
-            total_hit = sum(d['blks_hit'] for d in db_stats)
-            total_read = sum(d['blks_read'] for d in db_stats)
+            metrics["databases"] = db_stats
+            metrics["total_xact_commit"] = sum(d["xact_commit"] for d in db_stats)
+            metrics["total_xact_rollback"] = sum(d["xact_rollback"] for d in db_stats)
+            metrics["total_deadlocks"] = sum(d["deadlocks"] for d in db_stats)
+            total_hit = sum(d["blks_hit"] for d in db_stats)
+            total_read = sum(d["blks_read"] for d in db_stats)
             total_blks = total_hit + total_read
-            metrics['cache_hit_ratio'] = round((total_hit / total_blks * 100), 2) if total_blks > 0 else 100.0
+            metrics["cache_hit_ratio"] = (
+                round((total_hit / total_blks * 100), 2) if total_blks > 0 else 100.0
+            )
 
-        # Get database sizes
-        sizes = _get_database_sizes(host, port, user, password, database)
+        sizes = _get_database_sizes(cursor)
         if sizes:
-            metrics['database_sizes'] = sizes
-            metrics['total_size'] = sum(sizes.values())
+            metrics["database_sizes"] = sizes
+            metrics["total_size"] = sum(sizes.values())
 
-        # Get replication lag (if replica)
-        replication_lag = _get_replication_lag(host, port, user, password, database)
+        replication_lag = _get_replication_lag(cursor)
         if replication_lag is not None:
-            metrics['replication_lag_seconds'] = replication_lag
-            metrics['is_replica'] = True
+            metrics["replication_lag_seconds"] = replication_lag
+            metrics["is_replica"] = True
         else:
-            metrics['is_replica'] = False
+            metrics["is_replica"] = False
 
-        # Get locks
-        locks = _get_locks_count(host, port, user, password, database)
+        locks = _get_locks_count(cursor)
         if locks:
-            metrics['locks'] = locks
+            metrics["locks"] = locks
 
         return metrics
-
     except Exception as e:
-        log(f"Error collecting PostgreSQL metrics: {e}", 'error')
-        return None
+        log(f"Error collecting PostgreSQL metrics: {e}", "error")
+        return {"reachable": True, "error": "error"}
+    finally:
+        try:
+            conn.close()
+        except Exception as e:
+            log(f"Error closing PostgreSQL connection: {e}", "debug")

--- a/fivenines_agent/postgresql.py
+++ b/fivenines_agent/postgresql.py
@@ -50,6 +50,11 @@ CONNECT_TIMEOUT = 5
 STATEMENT_TIMEOUT_MS = 5000
 
 
+def _is_socket_host(host):
+    """True when host is a Unix socket directory path (psql-style)."""
+    return isinstance(host, str) and host.startswith("/")
+
+
 def _split_pgpass_line(line):
     """Split a .pgpass line into its 5 fields, honoring backslash escapes.
 
@@ -123,7 +128,11 @@ def _resolve_password(host, port, database, user, password):
     env_password = os.environ.get("PGPASSWORD")
     if env_password:
         return env_password
-    return _pgpass_lookup(host, port, database, user)
+    # libpq matches .pgpass on "localhost" for local Unix-socket connections,
+    # not the socket directory path. Mirror that so an existing local-socket
+    # setup with a "localhost:5432:..." .pgpass entry keeps authenticating.
+    lookup_host = "localhost" if _is_socket_host(host) else host
+    return _pgpass_lookup(lookup_host, port, database, user)
 
 
 def _connect(host, port, user, password, database):
@@ -135,7 +144,7 @@ def _connect(host, port, user, password, database):
         "timeout": CONNECT_TIMEOUT,
         "startup_params": {"statement_timeout": str(STATEMENT_TIMEOUT_MS)},
     }
-    if isinstance(host, str) and host.startswith("/"):
+    if _is_socket_host(host):
         # psql-style socket directory -> pg8000 socket file path.
         params["unix_sock"] = "{}/.s.PGSQL.{}".format(host.rstrip("/"), int(port))
     else:
@@ -165,17 +174,21 @@ def _error_category(exc):
 
 
 def _query(cursor, sql):
-    """Run a read-only query on the shared cursor; degrade to None on failure.
+    """Run a read-only query on the shared cursor.
 
-    A per-query failure (most often a per-view privilege denial) is logged and
-    surfaced as None so the caller drops only that one section. autocommit is
-    enabled on the connection, so the failure does not poison later queries.
+    A server-side error (the monitoring role lacks privilege on this view, or
+    the query hit statement_timeout) degrades only this section to None and is
+    logged at debug -- the session is alive, so the rest of the payload is
+    still collected and reachable stays True. Transport/session errors (the
+    connection dropped, a protocol failure) are NOT swallowed here: they
+    propagate to postgresql_metrics()'s outer handler, which reports
+    reachable: False instead of false-healthy partial data.
     """
     try:
         cursor.execute(sql)
         return cursor.fetchall()
-    except Exception as e:
-        log(f"PostgreSQL query failed: {e}", "error")
+    except DatabaseError as e:
+        log(f"PostgreSQL query degraded (server error): {e}", "debug")
         return None
 
 

--- a/fivenines_agent/postgresql.py
+++ b/fivenines_agent/postgresql.py
@@ -81,15 +81,23 @@ def _split_pgpass_line(line):
     return fields if len(fields) == 5 else None
 
 
+def _default_pgpass_path():
+    """The platform default password file when PGPASSFILE is unset (libpq).
+
+    Windows uses %APPDATA%\\postgresql\\pgpass.conf; elsewhere it is ~/.pgpass.
+    """
+    if os.name == "nt":
+        return os.path.join(os.environ.get("APPDATA", ""), "postgresql", "pgpass.conf")
+    return os.path.join(os.path.expanduser("~"), ".pgpass")
+
+
 def _pgpass_lookup(host, port, database, user):
-    """Return the password from ~/.pgpass (or PGPASSFILE) matching the target.
+    """Return the password from the pgpass file matching the target.
 
     Mirrors libpq: each field supports a '*' wildcard, the file is ignored when
     it is group/world accessible (non-Windows), and the first match wins.
     """
-    path = os.environ.get("PGPASSFILE") or os.path.join(
-        os.path.expanduser("~"), ".pgpass"
-    )
+    path = os.environ.get("PGPASSFILE") or _default_pgpass_path()
     try:
         mode = os.stat(path).st_mode
     except OSError:
@@ -120,10 +128,12 @@ def _pgpass_lookup(host, port, database, user):
 def _resolve_password(host, port, database, user, password):
     """Resolve the password the way the previous psql/libpq path did.
 
-    Order: explicit config password, then PGPASSWORD, then ~/.pgpass. Returns
+    Order: explicit config password, then PGPASSWORD, then the pgpass file.
+    A blank (falsy) configured password is treated as "unset" and falls back to
+    ambient credentials, matching the old `if password:` psql behavior. Returns
     None for peer/trust auth (no password anywhere).
     """
-    if password is not None:
+    if password:
         return password
     env_password = os.environ.get("PGPASSWORD")
     if env_password:

--- a/fivenines_agent/postgresql.py
+++ b/fivenines_agent/postgresql.py
@@ -1,3 +1,4 @@
+import os
 import socket
 
 import pg8000.dbapi
@@ -30,10 +31,16 @@ from fivenines_agent.debug import debug, log
 #
 # Failure contract:
 #   connect / auth / timeout fails --> {"reachable": False, "error": <category>}
-#   connected                      --> {"reachable": True, <metrics...>}
-#   Once connected, a single query that fails (e.g. the monitoring role lacks
-#   privilege on one view) only drops THAT section; reachable stays True and
-#   the rest of the payload is still returned (autocommit isolates queries).
+#   connected + version probe OK   --> {"reachable": True, <metrics...>}
+#   The no-privilege `SHOW server_version` probe is the liveness gate: if it
+#   fails after connect (session dropped or unusable), report reachable: False
+#   instead of a false-healthy empty payload. Once it succeeds, a privileged
+#   view that fails (e.g. the monitoring role lacks rights) only drops THAT
+#   section; reachable stays True (autocommit isolates queries).
+#
+# Password discovery mirrors the previous psql/libpq behavior so existing
+# installs keep working: explicit config password, then PGPASSWORD, then a
+# ~/.pgpass / PGPASSFILE lookup. (pg_service.conf / PGSERVICE is not handled.)
 
 # Bounds connection establishment so a dead host cannot stall the loop.
 CONNECT_TIMEOUT = 5
@@ -43,12 +50,88 @@ CONNECT_TIMEOUT = 5
 STATEMENT_TIMEOUT_MS = 5000
 
 
+def _split_pgpass_line(line):
+    """Split a .pgpass line into its 5 fields, honoring backslash escapes.
+
+    Returns [host, port, database, user, password], or None when the line does
+    not have exactly five colon-separated fields.
+    """
+    fields = []
+    current = []
+    i = 0
+    while i < len(line):
+        char = line[i]
+        if char == "\\" and i + 1 < len(line):
+            current.append(line[i + 1])
+            i += 2
+            continue
+        if char == ":":
+            fields.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(char)
+        i += 1
+    fields.append("".join(current))
+    return fields if len(fields) == 5 else None
+
+
+def _pgpass_lookup(host, port, database, user):
+    """Return the password from ~/.pgpass (or PGPASSFILE) matching the target.
+
+    Mirrors libpq: each field supports a '*' wildcard, the file is ignored when
+    it is group/world accessible (non-Windows), and the first match wins.
+    """
+    path = os.environ.get("PGPASSFILE") or os.path.join(
+        os.path.expanduser("~"), ".pgpass"
+    )
+    try:
+        mode = os.stat(path).st_mode
+    except OSError:
+        return None
+    if os.name != "nt" and (mode & 0o077):
+        # libpq refuses a .pgpass that group or others can access.
+        return None
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return None
+
+    target = [str(host), str(port), str(database), str(user)]
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if not line or line.lstrip().startswith("#"):
+            continue
+        entry = _split_pgpass_line(line)
+        if entry is None:
+            continue
+        patterns = entry[:4]
+        if all(p == "*" or p == t for p, t in zip(patterns, target)):
+            return entry[4]
+    return None
+
+
+def _resolve_password(host, port, database, user, password):
+    """Resolve the password the way the previous psql/libpq path did.
+
+    Order: explicit config password, then PGPASSWORD, then ~/.pgpass. Returns
+    None for peer/trust auth (no password anywhere).
+    """
+    if password is not None:
+        return password
+    env_password = os.environ.get("PGPASSWORD")
+    if env_password:
+        return env_password
+    return _pgpass_lookup(host, port, database, user)
+
+
 def _connect(host, port, user, password, database):
     """Open a pg8000 connection, routing path-like hosts to a unix socket."""
     params = {
         "user": user,
         "database": database,
-        "password": password,
+        "password": _resolve_password(host, port, database, user, password),
         "timeout": CONNECT_TIMEOUT,
         "startup_params": {"statement_timeout": str(STATEMENT_TIMEOUT_MS)},
     }
@@ -257,11 +340,16 @@ def postgresql_metrics(
         # view drops only its own section instead of aborting the rest.
         conn.autocommit = True
         cursor = conn.cursor()
-        metrics: dict = {"reachable": True}
 
+        # Liveness gate: SHOW server_version needs no privilege, so if it fails
+        # the session is not usable (dropped after connect, broken setup) -- not
+        # a per-view privilege denial. Report unreachable instead of a
+        # false-healthy empty payload.
         version = _get_version(cursor)
-        if version is not None:
-            metrics["version"] = version
+        if version is None:
+            return {"reachable": False, "error": "error"}
+
+        metrics: dict = {"reachable": True, "version": version}
 
         conn_stats = _get_connection_stats(cursor)
         if conn_stats:
@@ -298,8 +386,9 @@ def postgresql_metrics(
 
         return metrics
     except Exception as e:
+        # Connected but the session could not be queried at all -- not healthy.
         log(f"Error collecting PostgreSQL metrics: {e}", "error")
-        return {"reachable": True, "error": "error"}
+        return {"reachable": False, "error": "error"}
     finally:
         try:
             conn.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -33,6 +33,18 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67"},
+    {file = "asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"},
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 description = "Backport of CPython tarfile module"
@@ -1141,6 +1153,22 @@ files = [
 ]
 
 [[package]]
+name = "pg8000"
+version = "1.31.5"
+description = "PostgreSQL interface library"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pg8000-1.31.5-py3-none-any.whl", hash = "sha256:0af2c1926b153307639868d2ee5cef6cd3a7d07448e12736989b10e1d491e201"},
+    {file = "pg8000-1.31.5.tar.gz", hash = "sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.8.2"
+scramp = ">=1.4.5"
+
+[[package]]
 name = "pkginfo"
 version = "1.12.1.2"
 description = "Query metadata from sdists / bdists / installed packages."
@@ -1453,6 +1481,21 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1645,6 +1688,21 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
+name = "scramp"
+version = "1.4.8"
+description = "An implementation of the SCRAM protocol."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "scramp-1.4.8-py3-none-any.whl", hash = "sha256:87c2f15976845a2872fe5490a06097f0d01813cceb53774ea168c911f2ad025c"},
+    {file = "scramp-1.4.8.tar.gz", hash = "sha256:bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71"},
+]
+
+[package.dependencies]
+asn1crypto = ">=1.5.1"
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -1692,6 +1750,18 @@ groups = ["dev"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -2062,4 +2132,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "6261d332590c09bfd040096d70ead268bb783d0368877e5d8af36a32542697e2"
+content-hash = "c6c40c87813420bfa0190c3f30f346168f25c5b7255797bc24d89c7fd93daf25"

--- a/py2exe.sh
+++ b/py2exe.sh
@@ -283,6 +283,7 @@ PYI_BASE=(
     --exclude-module doctest --exclude-module test --exclude-module distutils
     --noconfirm --onedir --name "$BINARY_NAME"
     --workpath ./build/tmp --distpath ./build --clean
+    --hidden-import=scramp --hidden-import=dateutil.parser
     --add-binary "$PYTHON_LIB:."
     --add-binary "/usr/local/lib/libcrypt.so.2:." --add-binary "/usr/local/lib/libcrypt.so.1:."
     --add-binary "/usr/lib64/libz.so.1:."

--- a/py2exe.sh
+++ b/py2exe.sh
@@ -284,6 +284,7 @@ PYI_BASE=(
     --noconfirm --onedir --name "$BINARY_NAME"
     --workpath ./build/tmp --distpath ./build --clean
     --hidden-import=scramp --hidden-import=dateutil.parser
+    --copy-metadata pg8000 --copy-metadata scramp
     --add-binary "$PYTHON_LIB:."
     --add-binary "/usr/local/lib/libcrypt.so.2:." --add-binary "/usr/local/lib/libcrypt.so.1:."
     --add-binary "/usr/lib64/libz.so.1:."
@@ -309,9 +310,14 @@ echo "Total directory size: $(du -sh ./build/$BINARY_NAME | awk '{print $1}')"
 echo "Binary dependencies:"
 ldd ./build/$BINARY_NAME/$BINARY_NAME | head -10 || echo "ldd check failed (might be expected)"
 
-# Quick test of the binary
+# Quick test of the binary. --version must succeed: it imports the full
+# collector graph (incl. pg8000, which reads its package metadata at import),
+# so this catches missing hidden imports or un-copied metadata before shipping.
 echo "=== Testing Built Binary ==="
-./build/$BINARY_NAME/$BINARY_NAME --version || echo "Version check failed, but binary was built"
+if ! ./build/$BINARY_NAME/$BINARY_NAME --version; then
+    echo "Smoke check FAILED: built binary cannot run --version (missing hidden import or bundled metadata). Aborting."
+    exit 1
+fi
 
 # Move to final location
 if [ -n "${SYNOLOGY:-}" ]; then

--- a/py2exe_alpine.sh
+++ b/py2exe_alpine.sh
@@ -105,7 +105,9 @@ PYINSTALLER_ARGS="--strip \
     --hidden-import=proxmoxer.backends \
     --hidden-import=proxmoxer.backends.https \
     --hidden-import=scramp \
-    --hidden-import=dateutil.parser"
+    --hidden-import=dateutil.parser \
+    --copy-metadata pg8000 \
+    --copy-metadata scramp"
 
 if [ -n "$PYTHON_LIB" ] && [ -f "$PYTHON_LIB" ]; then
     echo "Adding Python shared library: $PYTHON_LIB"
@@ -129,9 +131,14 @@ echo "Total directory size: $(du -sh ./build/$BINARY_NAME | awk '{print $1}')"
 echo "Binary dependencies:"
 ldd ./build/$BINARY_NAME/$BINARY_NAME | head -10 || echo "ldd check failed"
 
-# Quick test
+# Quick test. --version imports the full collector graph (incl. pg8000, which
+# reads its package metadata at import), so a failure here means a missing
+# hidden import or un-copied metadata -- fail the build rather than ship it.
 echo "=== Testing Built Binary ==="
-./build/$BINARY_NAME/$BINARY_NAME --version || echo "Version check failed, but binary was built"
+if ! ./build/$BINARY_NAME/$BINARY_NAME --version; then
+    echo "Smoke check FAILED: built binary cannot run --version. Aborting."
+    exit 1
+fi
 
 # Move to final location
 mv ./build/$BINARY_NAME ./dist/linux/

--- a/py2exe_alpine.sh
+++ b/py2exe_alpine.sh
@@ -103,7 +103,9 @@ PYINSTALLER_ARGS="--strip \
     --hidden-import=libvirt \
     --hidden-import=libvirtmod \
     --hidden-import=proxmoxer.backends \
-    --hidden-import=proxmoxer.backends.https"
+    --hidden-import=proxmoxer.backends.https \
+    --hidden-import=scramp \
+    --hidden-import=dateutil.parser"
 
 if [ -n "$PYTHON_LIB" ] && [ -f "$PYTHON_LIB" ]; then
     echo "Adding Python shared library: $PYTHON_LIB"

--- a/py2exe_windows.ps1
+++ b/py2exe_windows.ps1
@@ -90,6 +90,8 @@ $pyInstallerArgs = @(
     "--hidden-import", "wmi",
     "--hidden-import", "scramp",
     "--hidden-import", "dateutil.parser",
+    "--copy-metadata", "pg8000",
+    "--copy-metadata", "scramp",
     "--noconfirm",
     "--onedir",
     "--name", $BINARY_NAME,

--- a/py2exe_windows.ps1
+++ b/py2exe_windows.ps1
@@ -88,6 +88,8 @@ $pyInstallerArgs = @(
     "--exclude-module", "proxmoxer",
     "--hidden-import", "win32timezone",
     "--hidden-import", "wmi",
+    "--hidden-import", "scramp",
+    "--hidden-import", "dateutil.parser",
     "--noconfirm",
     "--onedir",
     "--name", $BINARY_NAME,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ certifi = "^2024.12.14"
 docker = "^7.1.0"
 dnspython = "^2.7"
 requests = "^2.33.0"
+# Pure-Python PostgreSQL driver for the postgresql collector. Chosen over
+# psycopg (C extension + libpq) because it bundles into the PyInstaller binary
+# on both glibc and musl with no shared-library handling. Pulls scramp +
+# python-dateutil transitively (locked in poetry.lock, no security floor).
+pg8000 = "^1.31.5"
 # Security floor: GHSA-pq67-6m6q-mj2v (decompression bomb), GHSA-48p4-8xcf-vxj5 (header leak across origins). Brought in transitively by requests/docker; pinned here so future lock regenerations cannot drop below the patched line.
 urllib3 = "^2.7.0"
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,532 @@
+"""Tests for fivenines_agent.postgresql module.
+
+The collector connects to PostgreSQL with pg8000 (pure-Python driver). These
+tests mock at two seams:
+  - pg8000.dbapi.connect    -> for _connect routing (TCP vs unix socket)
+  - fivenines_agent.postgresql._connect / the helpers -> for orchestration
+
+No real PostgreSQL is needed. The opt-in integration test that exercises a real
+socket lives in test_postgresql_integration.py.
+"""
+
+import socket
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from pg8000.exceptions import DatabaseError, InterfaceError
+
+from fivenines_agent.postgresql import (
+    _connect,
+    _error_category,
+    _get_connection_stats,
+    _get_database_sizes,
+    _get_database_stats,
+    _get_locks_count,
+    _get_replication_lag,
+    _get_version,
+    _query,
+    postgresql_metrics,
+)
+
+
+PG = "fivenines_agent.postgresql"
+
+
+def cursor_returning(*fetch_results):
+    """Fake cursor whose successive fetchall() calls return the given results."""
+    cur = MagicMock()
+    cur.fetchall.side_effect = list(fetch_results)
+    return cur
+
+
+def with_cause(exc, cause):
+    """Attach a __cause__ to an exception, as `raise ... from ...` would."""
+    exc.__cause__ = cause
+    return exc
+
+
+# ---------------------------------------------------------------------------
+# _connect: TCP vs unix-socket routing (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_connect_tcp_passes_host_and_port():
+    """Normal host routes to a TCP connection (host/port)."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("db.example.com", 5432, "postgres", "secret", "appdb")
+        kwargs = conn.call_args.kwargs
+        assert kwargs["host"] == "db.example.com"
+        assert kwargs["port"] == 5432
+        assert "unix_sock" not in kwargs
+        assert kwargs["user"] == "postgres"
+        assert kwargs["password"] == "secret"
+        assert kwargs["database"] == "appdb"
+
+
+def test_connect_sets_connect_and_statement_timeout():
+    """connect_timeout + statement_timeout (startup param) are always set."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("localhost", 5432, "postgres", None, "postgres")
+        kwargs = conn.call_args.kwargs
+        assert kwargs["timeout"] == 5
+        assert kwargs["startup_params"] == {"statement_timeout": "5000"}
+
+
+def test_connect_path_like_host_routes_to_unix_socket():
+    """A path-like host (psql socket directory) routes to pg8000 unix_sock."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("/var/run/postgresql", 5432, "postgres", None, "postgres")
+        kwargs = conn.call_args.kwargs
+        assert kwargs["unix_sock"] == "/var/run/postgresql/.s.PGSQL.5432"
+        assert "host" not in kwargs
+        assert "port" not in kwargs
+
+
+def test_connect_unix_socket_strips_trailing_slash():
+    """Trailing slash on the socket directory is normalized."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("/tmp/", 5433, "postgres", None, "postgres")
+        assert conn.call_args.kwargs["unix_sock"] == "/tmp/.s.PGSQL.5433"
+
+
+def test_connect_non_string_host_uses_tcp():
+    """A non-string host (defensive) falls through to the TCP branch."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect(None, 5432, "postgres", None, "postgres")
+        assert "unix_sock" not in conn.call_args.kwargs
+        assert conn.call_args.kwargs["host"] is None
+
+
+# ---------------------------------------------------------------------------
+# _error_category: stable failure categories
+# ---------------------------------------------------------------------------
+
+
+def test_error_category_auth_failed():
+    """SQLSTATE 28xxx maps to auth_failed."""
+    assert (
+        _error_category(DatabaseError({"C": "28P01", "M": "bad pw"})) == "auth_failed"
+    )
+
+
+def test_error_category_other_database_error():
+    """A non-28 DatabaseError maps to the generic 'error'."""
+    assert _error_category(DatabaseError({"C": "42501", "M": "denied"})) == "error"
+
+
+def test_error_category_database_error_non_dict_arg():
+    """DatabaseError whose arg is not a dict still classifies as 'error'."""
+    assert _error_category(DatabaseError("oops")) == "error"
+
+
+def test_error_category_database_error_no_args():
+    """DatabaseError with no args classifies as 'error' (no detail)."""
+    err = DatabaseError()
+    err.args = ()
+    assert _error_category(err) == "error"
+
+
+def test_error_category_connection_refused():
+    """A refused TCP connection maps to connection_refused."""
+    exc = with_cause(InterfaceError("x"), ConnectionRefusedError())
+    assert _error_category(exc) == "connection_refused"
+
+
+def test_error_category_timeout():
+    """A socket timeout maps to timeout."""
+    assert (
+        _error_category(with_cause(InterfaceError("x"), socket.timeout())) == "timeout"
+    )
+
+
+def test_error_category_timeout_builtin():
+    """A builtin TimeoutError also maps to timeout."""
+    assert _error_category(with_cause(InterfaceError("x"), TimeoutError())) == "timeout"
+
+
+def test_error_category_dns_unreachable():
+    """A DNS resolution failure maps to unreachable."""
+    exc = with_cause(InterfaceError("x"), socket.gaierror())
+    assert _error_category(exc) == "unreachable"
+
+
+def test_error_category_interface_error_unknown_cause():
+    """An InterfaceError with no recognized cause maps to unreachable."""
+    assert _error_category(InterfaceError("x")) == "unreachable"
+
+
+def test_error_category_unknown_exception():
+    """Any other exception type maps to the generic 'error'."""
+    assert _error_category(ValueError("boom")) == "error"
+
+
+# ---------------------------------------------------------------------------
+# _query: shared execute/fetch with per-query degradation
+# ---------------------------------------------------------------------------
+
+
+def test_query_returns_rows_on_success():
+    cur = cursor_returning([("a", 1)])
+    assert _query(cur, "SELECT 1") == [("a", 1)]
+    cur.execute.assert_called_once_with("SELECT 1")
+
+
+def test_query_returns_none_on_failure():
+    cur = MagicMock()
+    cur.execute.side_effect = RuntimeError("permission denied")
+    assert _query(cur, "SELECT 1") is None
+
+
+# ---------------------------------------------------------------------------
+# _get_version
+# ---------------------------------------------------------------------------
+
+
+def test_get_version_parses_number():
+    assert _get_version(cursor_returning([("16.2",)])) == "16.2"
+
+
+def test_get_version_strips_suffix():
+    assert _get_version(cursor_returning([("16.2 (Debian 16.2-1)",)])) == "16.2"
+
+
+def test_get_version_none_when_empty():
+    assert _get_version(cursor_returning([])) is None
+
+
+def test_get_version_none_when_query_fails():
+    cur = MagicMock()
+    cur.execute.side_effect = RuntimeError("boom")
+    assert _get_version(cur) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_connection_stats
+# ---------------------------------------------------------------------------
+
+
+def test_connection_stats_empty_when_no_rows():
+    assert _get_connection_stats(cursor_returning([])) == {}
+
+
+def test_connection_stats_maps_known_states_and_totals():
+    rows = [("active", 2), ("idle", 5), ("idle in transaction", 1)]
+    stats = _get_connection_stats(cursor_returning(rows))
+    assert stats["active"] == 2
+    assert stats["idle"] == 5
+    assert stats["idle_in_transaction"] == 1
+    assert stats["total"] == 8
+
+
+def test_connection_stats_ignores_unknown_state():
+    rows = [("active", 2), ("weird_state", 99)]
+    stats = _get_connection_stats(cursor_returning(rows))
+    assert stats["active"] == 2
+    assert "weird_state" not in stats
+    assert stats["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _get_database_stats
+# ---------------------------------------------------------------------------
+
+
+def _db_row(name="app", **over):
+    base = [name, 3, 100, 7, 10, 990, 1, 1, 1, 1, 0, 0, 0]
+    fields = [
+        "name",
+        "numbackends",
+        "xact_commit",
+        "xact_rollback",
+        "blks_read",
+        "blks_hit",
+        "tup_returned",
+        "tup_fetched",
+        "tup_inserted",
+        "tup_updated",
+        "tup_deleted",
+        "conflicts",
+        "deadlocks",
+    ]
+    for k, v in over.items():
+        base[fields.index(k)] = v
+    return tuple(base)
+
+
+def test_database_stats_empty_when_no_rows():
+    assert _get_database_stats(cursor_returning([])) == []
+
+
+def test_database_stats_happy_path():
+    dbs = _get_database_stats(cursor_returning([_db_row()]))
+    assert dbs[0]["name"] == "app"
+    assert dbs[0]["connections"] == 3
+    assert dbs[0]["cache_hit_ratio"] == 99.0  # 990 / (10 + 990) * 100
+
+
+def test_database_stats_cache_ratio_zero_blocks_is_100():
+    """No reads and no hits -> 100.0 (div-by-zero guard)."""
+    row = _db_row(blks_read=0, blks_hit=0)
+    assert _get_database_stats(cursor_returning([row]))[0]["cache_hit_ratio"] == 100.0
+
+
+def test_database_stats_skips_null_datname():
+    null_name_row = (None,) + _db_row()[1:]
+    rows = [null_name_row, _db_row(name="real")]
+    dbs = _get_database_stats(cursor_returning(rows))
+    assert [d["name"] for d in dbs] == ["real"]
+
+
+def test_database_stats_null_numeric_fields_coerce_to_zero():
+    row = _db_row(xact_commit=None, blks_read=None, blks_hit=None, deadlocks=None)
+    db = _get_database_stats(cursor_returning([row]))[0]
+    assert db["xact_commit"] == 0
+    assert db["blks_read"] == 0
+    assert db["blks_hit"] == 0
+    assert db["deadlocks"] == 0
+    assert db["cache_hit_ratio"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# _get_database_sizes
+# ---------------------------------------------------------------------------
+
+
+def test_database_sizes_empty_when_no_rows():
+    assert _get_database_sizes(cursor_returning([])) == {}
+
+
+def test_database_sizes_maps_name_to_bytes():
+    sizes = _get_database_sizes(cursor_returning([("app", 1024), ("other", 2048)]))
+    assert sizes == {"app": 1024, "other": 2048}
+
+
+def test_database_sizes_skips_null_name():
+    sizes = _get_database_sizes(cursor_returning([(None, 1), ("app", 99)]))
+    assert sizes == {"app": 99}
+
+
+# ---------------------------------------------------------------------------
+# _get_replication_lag
+# ---------------------------------------------------------------------------
+
+
+def test_replication_lag_none_when_query_fails():
+    cur = MagicMock()
+    cur.execute.side_effect = RuntimeError("boom")
+    assert _get_replication_lag(cur) is None
+
+
+def test_replication_lag_primary_returns_none():
+    """pg_is_in_recovery() False -> primary -> None."""
+    assert _get_replication_lag(cursor_returning([(False,)])) is None
+
+
+def test_replication_lag_replica_returns_seconds():
+    cur = cursor_returning([(True,)], [(1.5,)])
+    assert _get_replication_lag(cur) == 1.5
+
+
+def test_replication_lag_replica_caught_up_is_zero():
+    cur = cursor_returning([(True,)], [(0,)])
+    assert _get_replication_lag(cur) == 0.0
+
+
+def test_replication_lag_null_replay_returns_none():
+    """Replica whose lag expression is NULL -> None."""
+    cur = cursor_returning([(True,)], [(None,)])
+    assert _get_replication_lag(cur) is None
+
+
+def test_replication_lag_empty_lag_rows_returns_none():
+    cur = cursor_returning([(True,)], [])
+    assert _get_replication_lag(cur) is None
+
+
+def test_replication_lag_unparseable_value_returns_none():
+    """A non-numeric lag value is swallowed to None."""
+    cur = cursor_returning([(True,)], [("not-a-number",)])
+    assert _get_replication_lag(cur) is None
+
+
+# ---------------------------------------------------------------------------
+# _get_locks_count
+# ---------------------------------------------------------------------------
+
+
+def test_locks_empty_when_no_rows():
+    assert _get_locks_count(cursor_returning([])) == {}
+
+
+def test_locks_maps_modes_with_total():
+    locks = _get_locks_count(
+        cursor_returning([("AccessShareLock", 3), ("RowExclusiveLock", 1)])
+    )
+    assert locks["AccessShareLock"] == 3
+    assert locks["RowExclusiveLock"] == 1
+    assert locks["total"] == 4
+
+
+# ---------------------------------------------------------------------------
+# postgresql_metrics: orchestration
+# ---------------------------------------------------------------------------
+
+
+def fake_conn(cursor=None, cursor_raises=False, close_raises=False):
+    conn = MagicMock()
+    if cursor_raises:
+        conn.cursor.side_effect = RuntimeError("cursor boom")
+    else:
+        conn.cursor.return_value = cursor if cursor is not None else MagicMock()
+    if close_raises:
+        conn.close.side_effect = RuntimeError("close boom")
+    return conn
+
+
+@contextmanager
+def helpers_patched(**values):
+    """Patch all six _get_* helpers with fixed return values for a block."""
+    defaults = {
+        "_get_version": None,
+        "_get_connection_stats": {},
+        "_get_database_stats": [],
+        "_get_database_sizes": {},
+        "_get_replication_lag": None,
+        "_get_locks_count": {},
+    }
+    defaults.update(values)
+    patches = [
+        patch(f"{PG}.{name}", return_value=val) for name, val in defaults.items()
+    ]
+    for p in patches:
+        p.start()
+    try:
+        yield
+    finally:
+        for p in reversed(patches):
+            p.stop()
+
+
+def run_metrics(conn, **helper_values):
+    with patch(f"{PG}._connect", return_value=conn), helpers_patched(**helper_values):
+        return postgresql_metrics()
+
+
+def test_metrics_connect_failure_returns_unreachable():
+    exc = with_cause(InterfaceError("x"), ConnectionRefusedError())
+    with patch(f"{PG}._connect", side_effect=exc):
+        assert postgresql_metrics() == {
+            "reachable": False,
+            "error": "connection_refused",
+        }
+
+
+def test_metrics_happy_path_full_payload():
+    db = {
+        "name": "app",
+        "xact_commit": 100,
+        "xact_rollback": 7,
+        "deadlocks": 2,
+        "blks_hit": 990,
+        "blks_read": 10,
+    }
+    result = run_metrics(
+        fake_conn(),
+        _get_version="16.2",
+        _get_connection_stats={"active": 1, "total": 1},
+        _get_database_stats=[db],
+        _get_database_sizes={"app": 2048},
+        _get_replication_lag=None,
+        _get_locks_count={"AccessShareLock": 1, "total": 1},
+    )
+    assert result["reachable"] is True
+    assert result["version"] == "16.2"
+    assert result["connections"] == {"active": 1, "total": 1}
+    assert result["databases"] == [db]
+    assert result["total_xact_commit"] == 100
+    assert result["total_xact_rollback"] == 7
+    assert result["total_deadlocks"] == 2
+    assert result["cache_hit_ratio"] == 99.0
+    assert result["database_sizes"] == {"app": 2048}
+    assert result["total_size"] == 2048
+    assert result["is_replica"] is False
+    assert result["locks"] == {"AccessShareLock": 1, "total": 1}
+
+
+def test_metrics_replica_sets_lag_and_flag():
+    result = run_metrics(fake_conn(), _get_version="16.2", _get_replication_lag=2.5)
+    assert result["replication_lag_seconds"] == 2.5
+    assert result["is_replica"] is True
+
+
+def test_metrics_all_sections_empty_omits_keys():
+    """Empty/None helper returns -> only reachable + is_replica present."""
+    result = run_metrics(fake_conn())
+    assert result == {"reachable": True, "is_replica": False}
+
+
+def test_metrics_cache_ratio_zero_blocks_is_100():
+    db = {
+        "name": "app",
+        "xact_commit": 0,
+        "xact_rollback": 0,
+        "deadlocks": 0,
+        "blks_hit": 0,
+        "blks_read": 0,
+    }
+    result = run_metrics(fake_conn(), _get_database_stats=[db])
+    assert result["cache_hit_ratio"] == 100.0
+
+
+def test_metrics_inner_exception_returns_reachable_with_error():
+    """Connected but a catastrophic processing error -> reachable True + error."""
+    result = run_metrics(fake_conn(cursor_raises=True))
+    assert result == {"reachable": True, "error": "error"}
+
+
+def test_metrics_closes_connection_on_success():
+    conn = fake_conn()
+    run_metrics(conn, _get_version="16.2")
+    conn.close.assert_called_once()
+
+
+def test_metrics_swallows_close_error():
+    """A failing conn.close() in the finally block does not escape."""
+    conn = fake_conn(close_raises=True)
+    result = run_metrics(conn, _get_version="16.2")
+    assert result["reachable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility regression (T9)
+#
+# Existing users monitor PostgreSQL with the previous (psql-based) agent using
+# host/port/user/password/database. The driver swap must not break them.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_previous_version_tcp_config_still_connects():
+    """Default/previous-version config (TCP host) reaches the driver unchanged."""
+    with patch(
+        f"{PG}.pg8000.dbapi.connect", return_value=fake_conn()
+    ) as conn, helpers_patched(_get_version="16.2"):
+        result = postgresql_metrics(
+            host="localhost",
+            port=5432,
+            user="postgres",
+            password=None,
+            database="postgres",
+        )
+    assert result["reachable"] is True
+    assert conn.call_args.kwargs["host"] == "localhost"
+
+
+def test_regression_previous_version_socket_dir_config_still_connects():
+    """A previous-version socket-directory host keeps working via unix_sock."""
+    with patch(
+        f"{PG}.pg8000.dbapi.connect", return_value=fake_conn()
+    ) as conn, helpers_patched(_get_version="16.2"):
+        result = postgresql_metrics(host="/var/run/postgresql", password=None)
+    assert result["reachable"] is True
+    assert conn.call_args.kwargs["unix_sock"] == "/var/run/postgresql/.s.PGSQL.5432"
+    assert conn.call_args.kwargs["password"] is None

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -19,6 +19,7 @@ from pg8000.exceptions import DatabaseError, InterfaceError
 
 from fivenines_agent.postgresql import (
     _connect,
+    _default_pgpass_path,
     _error_category,
     _get_connection_stats,
     _get_database_sizes,
@@ -637,6 +638,26 @@ def test_resolve_password_socket_host_matches_localhost_entry(monkeypatch, tmp_p
     pgpass = _write_pgpass(tmp_path, "localhost:5432:db:u:sockpw\n")
     monkeypatch.setenv("PGPASSFILE", pgpass)
     assert _resolve_password("/var/run/postgresql", 5432, "db", "u", None) == "sockpw"
+
+
+def test_resolve_password_blank_config_falls_back_to_env(monkeypatch):
+    """A blank configured password is treated as unset (old `if password:`)."""
+    monkeypatch.setenv("PGPASSWORD", "env-secret")
+    assert _resolve_password("h", 5432, "db", "u", "") == "env-secret"
+
+
+def test_default_pgpass_path_posix(monkeypatch):
+    monkeypatch.setattr(os, "name", "posix")
+    assert _default_pgpass_path().endswith(".pgpass")
+
+
+def test_default_pgpass_path_windows(monkeypatch):
+    """Windows defaults to %APPDATA%\\postgresql\\pgpass.conf, like libpq."""
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setenv("APPDATA", "APPDATA_DIR")
+    assert _default_pgpass_path() == os.path.join(
+        "APPDATA_DIR", "postgresql", "pgpass.conf"
+    )
 
 
 def test_pgpass_lookup_wildcards_match(monkeypatch, tmp_path):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -9,10 +9,12 @@ No real PostgreSQL is needed. The opt-in integration test that exercises a real
 socket lives in test_postgresql_integration.py.
 """
 
+import os
 import socket
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pg8000.exceptions import DatabaseError, InterfaceError
 
 from fivenines_agent.postgresql import (
@@ -24,12 +26,26 @@ from fivenines_agent.postgresql import (
     _get_locks_count,
     _get_replication_lag,
     _get_version,
+    _pgpass_lookup,
     _query,
+    _resolve_password,
+    _split_pgpass_line,
     postgresql_metrics,
 )
 
 
 PG = "fivenines_agent.postgresql"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pg_credentials(monkeypatch, tmp_path):
+    """Keep _resolve_password deterministic: no PGPASSWORD, no readable .pgpass.
+
+    Credential-discovery tests opt back in by setting PGPASSWORD / PGPASSFILE
+    themselves; everything else sees "no password available".
+    """
+    monkeypatch.delenv("PGPASSWORD", raising=False)
+    monkeypatch.setenv("PGPASSFILE", str(tmp_path / "does-not-exist.pgpass"))
 
 
 def cursor_returning(*fetch_results):
@@ -459,10 +475,20 @@ def test_metrics_replica_sets_lag_and_flag():
     assert result["is_replica"] is True
 
 
-def test_metrics_all_sections_empty_omits_keys():
-    """Empty/None helper returns -> only reachable + is_replica present."""
-    result = run_metrics(fake_conn())
-    assert result == {"reachable": True, "is_replica": False}
+def test_metrics_version_probe_failure_is_unreachable():
+    """P1: connect ok but the no-privilege version probe fails -> unreachable.
+
+    Guards against a false-healthy {"reachable": True} with no metrics when the
+    session drops or breaks immediately after connect.
+    """
+    result = run_metrics(fake_conn())  # _get_version defaults to None
+    assert result == {"reachable": False, "error": "error"}
+
+
+def test_metrics_connected_version_only_omits_empty_sections():
+    """Version ok but every privileged view empty -> reachable, partial payload."""
+    result = run_metrics(fake_conn(), _get_version="16.2")
+    assert result == {"reachable": True, "version": "16.2", "is_replica": False}
 
 
 def test_metrics_cache_ratio_zero_blocks_is_100():
@@ -474,14 +500,14 @@ def test_metrics_cache_ratio_zero_blocks_is_100():
         "blks_hit": 0,
         "blks_read": 0,
     }
-    result = run_metrics(fake_conn(), _get_database_stats=[db])
+    result = run_metrics(fake_conn(), _get_version="16.2", _get_database_stats=[db])
     assert result["cache_hit_ratio"] == 100.0
 
 
-def test_metrics_inner_exception_returns_reachable_with_error():
-    """Connected but a catastrophic processing error -> reachable True + error."""
+def test_metrics_inner_exception_is_unreachable():
+    """P1: connected but the session cannot be queried at all -> unreachable."""
     result = run_metrics(fake_conn(cursor_raises=True))
-    assert result == {"reachable": True, "error": "error"}
+    assert result == {"reachable": False, "error": "error"}
 
 
 def test_metrics_closes_connection_on_success():
@@ -530,3 +556,106 @@ def test_regression_previous_version_socket_dir_config_still_connects():
     assert result["reachable"] is True
     assert conn.call_args.kwargs["unix_sock"] == "/var/run/postgresql/.s.PGSQL.5432"
     assert conn.call_args.kwargs["password"] is None
+
+
+# ---------------------------------------------------------------------------
+# Password discovery (P2): config -> PGPASSWORD -> ~/.pgpass / PGPASSFILE.
+# Restores the libpq behavior the previous psql collector relied on, so an
+# install with credentials in .pgpass keeps working after the upgrade.
+# ---------------------------------------------------------------------------
+
+
+def _write_pgpass(tmp_path, content, mode=0o600):
+    path = tmp_path / "pgpass"
+    path.write_text(content)
+    os.chmod(path, mode)
+    return str(path)
+
+
+def test_split_pgpass_line_basic():
+    assert _split_pgpass_line("h:5432:db:user:pw") == ["h", "5432", "db", "user", "pw"]
+
+
+def test_split_pgpass_line_unescapes_colon_and_backslash():
+    # password "p:a\\ss" written as p\:a\\ss
+    assert _split_pgpass_line("h:5432:db:user:p\\:a\\\\ss") == [
+        "h",
+        "5432",
+        "db",
+        "user",
+        "p:a\\ss",
+    ]
+
+
+def test_split_pgpass_line_wrong_field_count_returns_none():
+    assert _split_pgpass_line("only:three:fields") is None
+
+
+def test_resolve_password_explicit_config_wins(monkeypatch):
+    monkeypatch.setenv("PGPASSWORD", "from-env")
+    assert _resolve_password("h", 5432, "db", "u", "from-config") == "from-config"
+
+
+def test_resolve_password_uses_pgpassword_env(monkeypatch):
+    monkeypatch.setenv("PGPASSWORD", "env-secret")
+    assert _resolve_password("h", 5432, "db", "u", None) == "env-secret"
+
+
+def test_resolve_password_none_when_nothing_available():
+    # autouse fixture cleared PGPASSWORD and pointed PGPASSFILE at a missing file
+    assert _resolve_password("h", 5432, "db", "u", None) is None
+
+
+def test_resolve_password_falls_back_to_pgpass(monkeypatch, tmp_path):
+    pgpass = _write_pgpass(tmp_path, "h:5432:db:u:pgpass-secret\n")
+    monkeypatch.setenv("PGPASSFILE", pgpass)
+    assert _resolve_password("h", 5432, "db", "u", None) == "pgpass-secret"
+
+
+def test_pgpass_lookup_wildcards_match(monkeypatch, tmp_path):
+    monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, "*:*:*:*:wild\n"))
+    assert _pgpass_lookup("anyhost", 5432, "anydb", "anyuser") == "wild"
+
+
+def test_pgpass_lookup_first_match_wins_and_skips_noise(monkeypatch, tmp_path):
+    content = (
+        "# a comment\n"
+        "\n"
+        "malformed:line\n"
+        "other:5432:db:u:nope\n"
+        "h:5432:db:u:right\n"
+        "h:5432:db:u:later\n"
+    )
+    monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, content))
+    assert _pgpass_lookup("h", 5432, "db", "u") == "right"
+
+
+def test_pgpass_lookup_no_match_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, "other:1:x:y:pw\n"))
+    assert _pgpass_lookup("h", 5432, "db", "u") is None
+
+
+def test_pgpass_lookup_empty_password_field(monkeypatch, tmp_path):
+    monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, "*:*:*:*:\n"))
+    assert _pgpass_lookup("h", 5432, "db", "u") == ""
+
+
+def test_pgpass_lookup_missing_file_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("PGPASSFILE", str(tmp_path / "nope.pgpass"))
+    assert _pgpass_lookup("h", 5432, "db", "u") is None
+
+
+def test_pgpass_lookup_ignored_when_group_or_world_accessible(monkeypatch, tmp_path):
+    # libpq refuses a .pgpass that is not private (0600).
+    pgpass = _write_pgpass(tmp_path, "*:*:*:*:secret\n", mode=0o640)
+    monkeypatch.setenv("PGPASSFILE", pgpass)
+    assert _pgpass_lookup("h", 5432, "db", "u") is None
+
+
+def test_pgpass_lookup_unreadable_path_returns_none(monkeypatch, tmp_path):
+    # A directory at the .pgpass path: stat succeeds, open raises -> None.
+    d = tmp_path / "pgpass_dir"
+    d.mkdir()
+    os.chmod(d, 0o700)
+    monkeypatch.setenv("PGPASSFILE", str(d))
+    assert _pgpass_lookup("h", 5432, "db", "u") is None

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -187,10 +187,19 @@ def test_query_returns_rows_on_success():
     cur.execute.assert_called_once_with("SELECT 1")
 
 
-def test_query_returns_none_on_failure():
+def test_query_degrades_server_error_to_none():
+    """A server-side error (e.g. privilege denial) degrades that section."""
     cur = MagicMock()
-    cur.execute.side_effect = RuntimeError("permission denied")
+    cur.execute.side_effect = DatabaseError({"C": "42501", "M": "permission denied"})
     assert _query(cur, "SELECT 1") is None
+
+
+def test_query_propagates_transport_error():
+    """A transport/session error is NOT swallowed -> it bubbles to the caller."""
+    cur = MagicMock()
+    cur.execute.side_effect = InterfaceError("connection dropped")
+    with pytest.raises(InterfaceError):
+        _query(cur, "SELECT 1")
 
 
 # ---------------------------------------------------------------------------
@@ -210,9 +219,9 @@ def test_get_version_none_when_empty():
     assert _get_version(cursor_returning([])) is None
 
 
-def test_get_version_none_when_query_fails():
+def test_get_version_none_when_server_error():
     cur = MagicMock()
-    cur.execute.side_effect = RuntimeError("boom")
+    cur.execute.side_effect = DatabaseError({"C": "57014", "M": "canceling statement"})
     assert _get_version(cur) is None
 
 
@@ -327,9 +336,9 @@ def test_database_sizes_skips_null_name():
 # ---------------------------------------------------------------------------
 
 
-def test_replication_lag_none_when_query_fails():
+def test_replication_lag_none_when_server_error():
     cur = MagicMock()
-    cur.execute.side_effect = RuntimeError("boom")
+    cur.execute.side_effect = DatabaseError({"C": "42501", "M": "denied"})
     assert _get_replication_lag(cur) is None
 
 
@@ -510,6 +519,16 @@ def test_metrics_inner_exception_is_unreachable():
     assert result == {"reachable": False, "error": "error"}
 
 
+def test_metrics_transport_error_after_version_is_unreachable():
+    """A transport error mid-collection bubbles to reachable: False, not a
+    false-healthy partial payload (version probe already succeeded)."""
+    with patch(f"{PG}._connect", return_value=fake_conn()), patch(
+        f"{PG}._get_version", return_value="16.2"
+    ), patch(f"{PG}._get_connection_stats", side_effect=InterfaceError("dropped")):
+        result = postgresql_metrics()
+    assert result == {"reachable": False, "error": "error"}
+
+
 def test_metrics_closes_connection_on_success():
     conn = fake_conn()
     run_metrics(conn, _get_version="16.2")
@@ -610,6 +629,14 @@ def test_resolve_password_falls_back_to_pgpass(monkeypatch, tmp_path):
     pgpass = _write_pgpass(tmp_path, "h:5432:db:u:pgpass-secret\n")
     monkeypatch.setenv("PGPASSFILE", pgpass)
     assert _resolve_password("h", 5432, "db", "u", None) == "pgpass-secret"
+
+
+def test_resolve_password_socket_host_matches_localhost_entry(monkeypatch, tmp_path):
+    """A Unix-socket host resolves .pgpass via 'localhost' (libpq behavior),
+    not the literal socket directory path."""
+    pgpass = _write_pgpass(tmp_path, "localhost:5432:db:u:sockpw\n")
+    monkeypatch.setenv("PGPASSFILE", pgpass)
+    assert _resolve_password("/var/run/postgresql", 5432, "db", "u", None) == "sockpw"
 
 
 def test_pgpass_lookup_wildcards_match(monkeypatch, tmp_path):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -818,7 +818,10 @@ def test_pgpass_lookup_missing_file_returns_none(monkeypatch, tmp_path):
 
 
 def test_pgpass_lookup_ignored_when_group_or_world_accessible(monkeypatch, tmp_path):
-    # libpq refuses a .pgpass that is not private (0600).
+    # libpq refuses a .pgpass that is not private (0600) -- but only on POSIX.
+    # Force os.name so the check is exercised regardless of the CI platform
+    # (on Windows the code intentionally skips it, like libpq).
+    monkeypatch.setattr(os, "name", "posix")
     pgpass = _write_pgpass(tmp_path, "*:*:*:*:secret\n", mode=0o640)
     monkeypatch.setenv("PGPASSFILE", pgpass)
     assert _pgpass_lookup("h", 5432, "db", "u") is None

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -11,6 +11,7 @@ socket lives in test_postgresql_integration.py.
 
 import os
 import socket
+import ssl
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -25,12 +26,13 @@ from fivenines_agent.postgresql import (
     _get_database_sizes,
     _get_database_stats,
     _get_locks_count,
-    _get_replication_lag,
+    _get_replication,
     _get_version,
     _pgpass_lookup,
     _query,
     _resolve_password,
     _split_pgpass_line,
+    _ssl_context,
     postgresql_metrics,
 )
 
@@ -40,12 +42,14 @@ PG = "fivenines_agent.postgresql"
 
 @pytest.fixture(autouse=True)
 def _isolate_pg_credentials(monkeypatch, tmp_path):
-    """Keep _resolve_password deterministic: no PGPASSWORD, no readable .pgpass.
+    """Keep credential/TLS resolution deterministic across tests.
 
-    Credential-discovery tests opt back in by setting PGPASSWORD / PGPASSFILE
-    themselves; everything else sees "no password available".
+    No PGPASSWORD, no readable .pgpass, no PGSSLMODE/PGSSLROOTCERT. Tests that
+    exercise those paths opt back in by setting the env themselves.
     """
     monkeypatch.delenv("PGPASSWORD", raising=False)
+    monkeypatch.delenv("PGSSLMODE", raising=False)
+    monkeypatch.delenv("PGSSLROOTCERT", raising=False)
     monkeypatch.setenv("PGPASSFILE", str(tmp_path / "does-not-exist.pgpass"))
 
 
@@ -80,13 +84,27 @@ def test_connect_tcp_passes_host_and_port():
         assert kwargs["database"] == "appdb"
 
 
-def test_connect_sets_connect_and_statement_timeout():
-    """connect_timeout + statement_timeout (startup param) are always set."""
+def test_connect_socket_timeout_exceeds_statement_timeout():
+    """The socket timeout (10s) must exceed statement_timeout (5000ms) so the
+    server cancels a slow query before the socket read times out."""
     with patch(f"{PG}.pg8000.dbapi.connect") as conn:
         _connect("localhost", 5432, "postgres", None, "postgres")
         kwargs = conn.call_args.kwargs
-        assert kwargs["timeout"] == 5
-        assert kwargs["startup_params"] == {"statement_timeout": "5000"}
+        assert kwargs["timeout"] == 10
+        assert (
+            int(kwargs["startup_params"]["statement_timeout"])
+            < kwargs["timeout"] * 1000
+        )
+
+
+def test_connect_safe_port_defaults_when_unparseable():
+    """A null/empty port (valid for a socket config) falls back to 5432."""
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("localhost", None, "postgres", None, "postgres")
+        assert conn.call_args.kwargs["port"] == 5432
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("/var/run/postgresql", "", "postgres", None, "postgres")
+        assert conn.call_args.kwargs["unix_sock"] == "/var/run/postgresql/.s.PGSQL.5432"
 
 
 def test_connect_path_like_host_routes_to_unix_socket():
@@ -112,6 +130,58 @@ def test_connect_non_string_host_uses_tcp():
         _connect(None, 5432, "postgres", None, "postgres")
         assert "unix_sock" not in conn.call_args.kwargs
         assert conn.call_args.kwargs["host"] is None
+
+
+def test_connect_forwards_ssl_context(monkeypatch):
+    """PGSSLMODE drives the ssl_context passed to pg8000."""
+    monkeypatch.setenv("PGSSLMODE", "require")
+    with patch(f"{PG}.pg8000.dbapi.connect") as conn:
+        _connect("db.example.com", 5432, "postgres", None, "postgres")
+        assert isinstance(conn.call_args.kwargs["ssl_context"], ssl.SSLContext)
+
+
+# ---------------------------------------------------------------------------
+# _ssl_context: PGSSLMODE / PGSSLROOTCERT parity (#2)
+# ---------------------------------------------------------------------------
+
+
+def test_ssl_context_default_is_none():
+    """No PGSSLMODE -> None (pg8000 default: opportunistic, unverified)."""
+    assert _ssl_context("db.example.com") is None
+
+
+def test_ssl_context_socket_host_disables_tls():
+    """TLS is never used on a local Unix socket."""
+    assert _ssl_context("/var/run/postgresql") is False
+
+
+def test_ssl_context_disable(monkeypatch):
+    monkeypatch.setenv("PGSSLMODE", "disable")
+    assert _ssl_context("h") is False
+
+
+def test_ssl_context_require_does_not_verify(monkeypatch):
+    monkeypatch.setenv("PGSSLMODE", "require")
+    ctx = _ssl_context("h")
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False
+
+
+def test_ssl_context_verify_ca_checks_cert_not_hostname(monkeypatch):
+    monkeypatch.setenv("PGSSLMODE", "verify-ca")
+    ctx = _ssl_context("h")
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is False
+
+
+def test_ssl_context_verify_full_checks_cert_and_hostname(monkeypatch):
+    monkeypatch.setenv("PGSSLMODE", "verify-full")
+    ctx = _ssl_context("h")
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +242,15 @@ def test_error_category_interface_error_unknown_cause():
     assert _error_category(InterfaceError("x")) == "unreachable"
 
 
+def test_error_category_interface_error_auth_message_is_auth_failed():
+    """pg8000 raises InterfaceError (not DatabaseError) when a password is
+    required but none was provided -- classify it as auth_failed."""
+    exc = InterfaceError(
+        "server requesting password authentication, but no password was provided"
+    )
+    assert _error_category(exc) == "auth_failed"
+
+
 def test_error_category_unknown_exception():
     """Any other exception type maps to the generic 'error'."""
     assert _error_category(ValueError("boom")) == "error"
@@ -218,6 +297,11 @@ def test_get_version_strips_suffix():
 
 def test_get_version_none_when_empty():
     assert _get_version(cursor_returning([])) is None
+
+
+def test_get_version_none_when_blank_value():
+    """A blank server_version value does not raise IndexError -> None."""
+    assert _get_version(cursor_returning([("   ",)])) is None
 
 
 def test_get_version_none_when_server_error():
@@ -333,46 +417,47 @@ def test_database_sizes_skips_null_name():
 
 
 # ---------------------------------------------------------------------------
-# _get_replication_lag
+# _get_replication -> (is_replica, lag_seconds)
 # ---------------------------------------------------------------------------
 
 
-def test_replication_lag_none_when_server_error():
+def test_replication_undetermined_when_recovery_query_denied():
+    """pg_is_in_recovery() denied/failed -> (None, None), NOT (False, ...)."""
     cur = MagicMock()
     cur.execute.side_effect = DatabaseError({"C": "42501", "M": "denied"})
-    assert _get_replication_lag(cur) is None
+    assert _get_replication(cur) == (None, None)
 
 
-def test_replication_lag_primary_returns_none():
-    """pg_is_in_recovery() False -> primary -> None."""
-    assert _get_replication_lag(cursor_returning([(False,)])) is None
+def test_replication_primary():
+    """pg_is_in_recovery() False -> (False, None)."""
+    assert _get_replication(cursor_returning([(False,)])) == (False, None)
 
 
-def test_replication_lag_replica_returns_seconds():
+def test_replication_replica_with_lag():
     cur = cursor_returning([(True,)], [(1.5,)])
-    assert _get_replication_lag(cur) == 1.5
+    assert _get_replication(cur) == (True, 1.5)
 
 
-def test_replication_lag_replica_caught_up_is_zero():
+def test_replication_replica_caught_up_lag_zero():
     cur = cursor_returning([(True,)], [(0,)])
-    assert _get_replication_lag(cur) == 0.0
+    assert _get_replication(cur) == (True, 0.0)
 
 
-def test_replication_lag_null_replay_returns_none():
-    """Replica whose lag expression is NULL -> None."""
+def test_replication_replica_null_lag_still_marks_replica():
+    """A replica whose lag is NULL (e.g. just started) is still is_replica=True
+    -- the bug was reporting it as a primary."""
     cur = cursor_returning([(True,)], [(None,)])
-    assert _get_replication_lag(cur) is None
+    assert _get_replication(cur) == (True, None)
 
 
-def test_replication_lag_empty_lag_rows_returns_none():
+def test_replication_replica_empty_lag_rows():
     cur = cursor_returning([(True,)], [])
-    assert _get_replication_lag(cur) is None
+    assert _get_replication(cur) == (True, None)
 
 
-def test_replication_lag_unparseable_value_returns_none():
-    """A non-numeric lag value is swallowed to None."""
+def test_replication_replica_unparseable_lag():
     cur = cursor_returning([(True,)], [("not-a-number",)])
-    assert _get_replication_lag(cur) is None
+    assert _get_replication(cur) == (True, None)
 
 
 # ---------------------------------------------------------------------------
@@ -417,7 +502,7 @@ def helpers_patched(**values):
         "_get_connection_stats": {},
         "_get_database_stats": [],
         "_get_database_sizes": {},
-        "_get_replication_lag": None,
+        "_get_replication": (False, None),
         "_get_locks_count": {},
     }
     defaults.update(values)
@@ -462,7 +547,7 @@ def test_metrics_happy_path_full_payload():
         _get_connection_stats={"active": 1, "total": 1},
         _get_database_stats=[db],
         _get_database_sizes={"app": 2048},
-        _get_replication_lag=None,
+        _get_replication=(False, None),
         _get_locks_count={"AccessShareLock": 1, "total": 1},
     )
     assert result["reachable"] is True
@@ -480,9 +565,29 @@ def test_metrics_happy_path_full_payload():
 
 
 def test_metrics_replica_sets_lag_and_flag():
-    result = run_metrics(fake_conn(), _get_version="16.2", _get_replication_lag=2.5)
+    result = run_metrics(fake_conn(), _get_version="16.2", _get_replication=(True, 2.5))
     assert result["replication_lag_seconds"] == 2.5
     assert result["is_replica"] is True
+
+
+def test_metrics_replica_null_lag_marks_replica_without_lag():
+    """#6: a replica with no lag yet is is_replica=True, lag key omitted (not a
+    primary)."""
+    result = run_metrics(
+        fake_conn(), _get_version="16.2", _get_replication=(True, None)
+    )
+    assert result["is_replica"] is True
+    assert "replication_lag_seconds" not in result
+
+
+def test_metrics_replication_undetermined_omits_is_replica():
+    """#6: when pg_is_in_recovery() is denied, is_replica is omitted entirely
+    rather than defaulted to False."""
+    result = run_metrics(
+        fake_conn(), _get_version="16.2", _get_replication=(None, None)
+    )
+    assert "is_replica" not in result
+    assert "replication_lag_seconds" not in result
 
 
 def test_metrics_version_probe_failure_is_unreachable():
@@ -514,20 +619,33 @@ def test_metrics_cache_ratio_zero_blocks_is_100():
     assert result["cache_hit_ratio"] == 100.0
 
 
-def test_metrics_inner_exception_is_unreachable():
-    """P1: connected but the session cannot be queried at all -> unreachable."""
+def test_metrics_inner_exception_is_unreachable_with_detail():
+    """P1+#13: a generic error after connect -> unreachable, with error_detail."""
     result = run_metrics(fake_conn(cursor_raises=True))
-    assert result == {"reachable": False, "error": "error"}
+    assert result == {
+        "reachable": False,
+        "error": "error",
+        "error_detail": "cursor boom",
+    }
 
 
 def test_metrics_transport_error_after_version_is_unreachable():
-    """A transport error mid-collection bubbles to reachable: False, not a
-    false-healthy partial payload (version probe already succeeded)."""
+    """#9: a transport error mid-collection bubbles to reachable: False with the
+    specific category (not a flat 'error'), and no false-healthy partial."""
     with patch(f"{PG}._connect", return_value=fake_conn()), patch(
         f"{PG}._get_version", return_value="16.2"
     ), patch(f"{PG}._get_connection_stats", side_effect=InterfaceError("dropped")):
         result = postgresql_metrics()
-    assert result == {"reachable": False, "error": "error"}
+    assert result == {"reachable": False, "error": "unreachable"}
+
+
+def test_metrics_tolerates_unknown_config_keys():
+    """#14: an unexpected backend config key is ignored, not a TypeError->None."""
+    with patch(f"{PG}._connect", return_value=fake_conn()), helpers_patched(
+        _get_version="16.2"
+    ):
+        result = postgresql_metrics(host="localhost", future_option="x")
+    assert result["reachable"] is True
 
 
 def test_metrics_closes_connection_on_success():
@@ -663,6 +781,12 @@ def test_default_pgpass_path_windows(monkeypatch):
 def test_pgpass_lookup_wildcards_match(monkeypatch, tmp_path):
     monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, "*:*:*:*:wild\n"))
     assert _pgpass_lookup("anyhost", 5432, "anydb", "anyuser") == "wild"
+
+
+def test_pgpass_lookup_strips_crlf(monkeypatch, tmp_path):
+    """#3: a CRLF pgpass (Windows default) must not leave \\r on the password."""
+    monkeypatch.setenv("PGPASSFILE", _write_pgpass(tmp_path, "h:5432:db:u:secret\r\n"))
+    assert _pgpass_lookup("h", 5432, "db", "u") == "secret"
 
 
 def test_pgpass_lookup_first_match_wins_and_skips_noise(monkeypatch, tmp_path):

--- a/tests/test_postgresql_integration.py
+++ b/tests/test_postgresql_integration.py
@@ -1,0 +1,54 @@
+"""Opt-in integration test for the PostgreSQL collector against a REAL server.
+
+Skipped unless RUN_PG_INTEGRATION is set. This is the only test that exercises
+the real pg8000 socket connection, SCRAM authentication, and live pg_stat_*
+queries -- the path the mocked unit tests cannot cover. Pointed at the built
+binary's environment, it also proves the frozen bundle ships pg8000 + scramp
+(per the build-script hidden-imports).
+
+Run against a local or containerized PostgreSQL, e.g.:
+
+    docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+    RUN_PG_INTEGRATION=1 PG_PASSWORD=postgres \\
+        poetry run pytest tests/test_postgresql_integration.py -v
+"""
+
+import os
+
+import pytest
+
+from fivenines_agent.postgresql import postgresql_metrics
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("RUN_PG_INTEGRATION"),
+    reason="set RUN_PG_INTEGRATION=1 to run against a real PostgreSQL",
+)
+
+
+def _conn_kwargs():
+    return {
+        "host": os.environ.get("PG_HOST", "localhost"),
+        "port": int(os.environ.get("PG_PORT", "5432")),
+        "user": os.environ.get("PG_USER", "postgres"),
+        "password": os.environ.get("PG_PASSWORD"),
+        "database": os.environ.get("PG_DATABASE", "postgres"),
+    }
+
+
+def test_real_postgres_is_reachable_with_metrics():
+    """Connect for real (SCRAM when a password is set) and collect metrics."""
+    result = postgresql_metrics(**_conn_kwargs())
+    assert result is not None
+    assert result["reachable"] is True, result
+    assert "version" in result
+    assert "connections" in result
+    assert "is_replica" in result
+    assert isinstance(result.get("databases", []), list)
+
+
+def test_real_postgres_unreachable_on_closed_port():
+    """A definitely-closed port yields a structured unreachable status."""
+    result = postgresql_metrics(host="127.0.0.1", port=1)
+    assert result["reachable"] is False
+    assert result["error"] in {"connection_refused", "timeout", "unreachable"}


### PR DESCRIPTION
Replaces the PostgreSQL collector's `psql` shell-out with a direct pg8000 (pure-Python) socket connection, so Postgres running inside a Docker container is monitored with no `psql` binary on the host. The collector now returns a reachability-aware payload (`reachable`/`error` categories, with per-query partial success preserved once connected) and bounds each query with a connect + statement timeout so a slow query can't stall the collection loop; a path-like `host` is routed to a unix socket so existing socket-directory configs keep working. pg8000 (plus scramp + python-dateutil) is added to the deps and wired into the PyInstaller builds (glibc/musl/Windows) via hidden-imports. Includes a new 100%-coverage unit suite and an opt-in integration test (`RUN_PG_INTEGRATION`) that exercises a real socket and SCRAM auth.

Note: the new `reachable`/`error` payload is a `/collect` contract change; the backend should accept it before the agent's emit is relied on (backward-compatible spec handed off separately). Multi-instance Postgres support is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
