### PR TITLE
fix: stop probing nvme-cli on hosts with no NVMe device

### DIFF
--- a/fivenines_agent/smart_storage.py
+++ b/fivenines_agent/smart_storage.py
@@ -16,6 +16,14 @@ _identification_storage_cache = {
     "data": []
 }
 
+# Cap data-collection smartctl/nvme calls so a slow or hanging drive cannot
+# block the single-threaded collection loop indefinitely and starve the systemd
+# watchdog. (A drive truly wedged in uninterruptible D-state I/O can still delay
+# the post-timeout reap -- that is a kernel-level limit no userspace timeout
+# fully escapes.) 30s matches the heaviest data collector (packages.py) and is
+# generous for slow-but-healthy drives.
+_DATA_SUBPROCESS_TIMEOUT = 30
+
 # SMART attributes where normalized VALUE (0-100%) is more meaningful than RAW_VALUE
 # These typically represent wear/life percentages
 SMART_LIFE_ATTRIBUTES = {'177', '202', '231', '232', '233'}
@@ -248,47 +256,37 @@ NVME_ATTRIBUTE_NAMES = {
     'Critical Composite Temperature Time': 'critical_comp_time'
 }
 
-def smartctl_available():
-    """
-    Check if smartctl is available and we have permission to run it.
-    Uses sudo -n (non-interactive) to detect if sudoers is configured.
-    Returns False if:
-    - smartctl is not installed
-    - sudo is not configured for this user
-    - sudo would require a password
+def _sudo_probe(args, timeout=5):
+    """Run `sudo -n <args>` and return the CompletedProcess, or None.
+
+    Returns None when the command could not run, exited non-zero, timed out, or
+    raised -- i.e. the tool is not usable via passwordless sudo. Centralizes the
+    one `sudo -n` probe shape shared by the *_available() gates and the
+    get_*_version() fetchers, so the invocation, timeout, and env handling
+    cannot drift between them. Uses sudo -n (non-interactive) to detect whether
+    sudoers is configured without ever prompting for a password.
     """
     try:
         result = subprocess.run(
-            ["sudo", "-n", "smartctl", "--version"],
-            capture_output=True,
-            timeout=5,
+            ["sudo", "-n", *args],
+            capture_output=True, text=True, timeout=timeout,
             env=get_clean_env()
         )
-        return result.returncode == 0
+        return result if result.returncode == 0 else None
     except subprocess.TimeoutExpired:
-        log("smartctl availability check timed out", 'error')
-        return False
-    except Exception:
-        return False
+        log(f"sudo -n {args[0]} probe timed out", 'error')
+        return None
+    except Exception as e:
+        log(f"sudo -n {args[0]} probe failed: {e}", 'debug')
+        return None
+
+def smartctl_available():
+    """Whether smartctl is installed and runnable via passwordless sudo."""
+    return _sudo_probe(["smartctl", "--version"]) is not None
 
 def nvme_cli_available():
-    """
-    Check if nvme-cli is available and we have permission to run it.
-    Uses sudo -n (non-interactive) to detect if sudoers is configured.
-    """
-    try:
-        result = subprocess.run(
-            ["sudo", "-n", "nvme", "version"],
-            capture_output=True,
-            timeout=5,
-            env=get_clean_env()
-        )
-        return result.returncode == 0
-    except subprocess.TimeoutExpired:
-        log("nvme availability check timed out", 'error')
-        return False
-    except Exception:
-        return False
+    """Whether nvme-cli is installed and runnable via passwordless sudo."""
+    return _sudo_probe(["nvme", "version"]) is not None
 
 def is_partition(device):
     """Check if a device is a partition."""
@@ -306,7 +304,7 @@ def list_storage_devices():
     try:
         result = subprocess.run(
             ['sudo', 'smartctl', '--scan'],
-            capture_output=True,
+            capture_output=True, timeout=_DATA_SUBPROCESS_TIMEOUT,
             env=get_clean_env()
         )
         lines = result.stdout.decode().splitlines()
@@ -329,6 +327,7 @@ def get_nvme_enhanced_info(device):
         result = subprocess.run(
             ["sudo", "nvme", "smart-log", device, "-o", "json"],
             capture_output=True, text=True, check=True,
+            timeout=_DATA_SUBPROCESS_TIMEOUT,
             env=get_clean_env()
         )
         raw = json.loads(result.stdout)
@@ -349,8 +348,14 @@ def get_nvme_enhanced_info(device):
         log(f"Error fetching NVMe enhanced info for device: {device}: {e}", 'error')
         return {}
 
-def get_storage_info(device):
-    """Get storage device information using smartctl and optionally nvme-cli."""
+def get_storage_info(device, nvme_available=lambda: False):
+    """Get storage device information using smartctl and optionally nvme-cli.
+
+    nvme_available is a zero-arg callable, memoized once per collection tick by
+    the caller. It is consulted only for devices whose parsed SMART output is
+    NVMe, so a host with no NVMe device never shells out to `nvme version` and a
+    multi-NVMe host probes exactly once per tick.
+    """
     try:
         results = {
             "device": device.split('/')[-1]
@@ -358,6 +363,7 @@ def get_storage_info(device):
         proc_result = subprocess.run(
             ['sudo', 'smartctl', '-A', '-H', device],
             capture_output=True, text=True,
+            timeout=_DATA_SUBPROCESS_TIMEOUT,
             env=get_clean_env()
         )
         storage_stats = proc_result.stdout.splitlines()
@@ -410,8 +416,10 @@ def get_storage_info(device):
             elif key == "Critical Warning":
                 results["critical_warning"] = safe_int_conversion(value, 16)
 
-        # If it's an NVMe device and nvme-cli is available, get enhanced info
-        if current_section == "nvme" and nvme_cli_available():
+        # If it's an NVMe device and nvme-cli is available, get enhanced info.
+        # The probe is memoized by the caller, so this runs `nvme version` at
+        # most once per tick no matter how many NVMe devices are present.
+        if current_section == "nvme" and nvme_available():
             nvme_info = get_nvme_enhanced_info(device)
             results.update(nvme_info)
 
@@ -434,10 +442,32 @@ def safe_int_conversion(value, base=10):
     """Safely convert a string to integer, handling various formats."""
     if not value:
         return None
+    value = value.strip()
     try:
-        # Remove any non-numeric characters except for minus sign
-        cleaned = ''.join(c for c in value if c.isdigit() or c == '-')
-        return int(cleaned, base)
+        # Direct parse first. With base 16 this correctly reads hex like
+        # "0x0c" -> 12; the old digit-only strip dropped a-f, so an NVMe
+        # "Critical Warning: 0x0c" became 0 and a failing drive read as healthy.
+        return int(value, base)
+    except (ValueError, TypeError):
+        pass
+    try:
+        # Fall back for values with trailing text (e.g. "100 (raw)" or a
+        # hypothetical annotated "0x0c (A)"). Drop a base-matching radix prefix
+        # first, then take the LEADING run of valid characters and stop at the
+        # first invalid one. Filtering the whole string instead would let the
+        # annotation's letters bleed into the result (e.g. "0x0c (A)" -> 202).
+        v = value.lower()
+        for prefix, prefix_base in (("0x", 16), ("0o", 8), ("0b", 2)):
+            if base == prefix_base and v.startswith(prefix):
+                v = v[len(prefix):]
+                break
+        valid = set("0123456789abcdef"[:base] + "-")
+        leading = ""
+        for c in v:
+            if c not in valid:
+                break
+            leading += c
+        return int(leading, base)
     except (ValueError, TypeError):
         return None
 
@@ -453,34 +483,25 @@ def safe_temperature_conversion(value):
         return None
 
 def get_smartctl_version():
-    """Get smartctl version information."""
-    try:
-        result = subprocess.run(
-            ["sudo", "smartctl", "--version"],
-            capture_output=True, text=True, check=True,
-            env=get_clean_env()
-        )
-        # Extract version from first line
-        version_line = result.stdout.split('\n')[0]
-        return version_line.strip()
-    except Exception as e:
-        log(f"Error fetching smartctl version: {e}", 'error')
+    """Return the smartctl version string, or None if smartctl is unavailable.
+
+    Routes through _sudo_probe, so it doubles as the availability check: an
+    unusable smartctl (absent, no passwordless sudo) -- or empty version output
+    -- returns None quietly, letting the caller skip a separate probe.
+    """
+    proc = _sudo_probe(["smartctl", "--version"])
+    if proc is None:
         return None
+    # First line, or None if the tool printed nothing parseable.
+    return proc.stdout.split('\n')[0].strip() or None
 
 def get_nvme_cli_version():
-    """Get nvme-cli version information."""
-    try:
-        result = subprocess.run(
-            ["sudo", "nvme", "version"],
-            capture_output=True, text=True, check=True,
-            env=get_clean_env()
-        )
-        # Extract version from first line
-        version_line = result.stdout.split('\n')[0]
-        return version_line.strip()
-    except Exception as e:
-        log(f"Error fetching nvme-cli version: {e}", 'error')
+    """Return the nvme-cli version string, or None if nvme-cli is unavailable."""
+    proc = _sudo_probe(["nvme", "version"])
+    if proc is None:
         return None
+    # First line, or None if the tool printed nothing parseable.
+    return proc.stdout.split('\n')[0].strip() or None
 
 def get_storage_identification(device):
     """Get storage device identification using smartctl."""
@@ -488,6 +509,7 @@ def get_storage_identification(device):
         result = subprocess.run(
             ["sudo", "smartctl", "-i", device],
             capture_output=True, text=True, check=True,
+            timeout=_DATA_SUBPROCESS_TIMEOUT,
             env=get_clean_env()
         )
 
@@ -514,7 +536,7 @@ def get_storage_identification(device):
 def smart_storage_identification():
     """Collect storage identification for all storage devices.
     Uses smartctl for all devices.
-    Cached for 60 seconds.
+    Cached for 10 minutes.
     """
     global _identification_storage_cache
     now = time.time()
@@ -525,13 +547,12 @@ def smart_storage_identification():
     if now - _identification_storage_cache["timestamp"] < 600:
         return _identification_storage_cache["data"]
 
-    # Get tool versions only if we have devices to process
-    tool_versions = {
-        "smartctl_version": get_smartctl_version() if smartctl_available() else None,
-        "nvme_cli_version": get_nvme_cli_version() if nvme_cli_available() else None
-    }
-
-    if tool_versions["smartctl_version"] is None:
+    # Preserve the prior failure contract: if smartctl's version is unreadable,
+    # emit nothing rather than a partial payload (the backend reads this shape).
+    # get_smartctl_version() self-checks via `sudo -n`, so it doubles as the
+    # availability gate -- no separate smartctl_available() shell-out.
+    smartctl_version = get_smartctl_version()
+    if smartctl_version is None:
         log("smartctl unavailable (not installed or no sudo permissions)", 'debug')
         data = []
     else:
@@ -540,6 +561,18 @@ def smart_storage_identification():
             log("No storage devices found", 'error')
             data = []
         else:
+            # Fetch the nvme-cli version only when an NVMe device is present, so
+            # ATA-only hosts never shell out to `nvme version`. Identification
+            # keys off the device path (its `smartctl -i` output has no SMART
+            # section to parse, unlike the health collector). get_nvme_cli_version()
+            # self-checks via `sudo -n` and returns None when nvme-cli is unusable,
+            # so it doubles as the availability gate. The key stays in the payload
+            # (null when absent) to keep the per-device shape stable.
+            has_nvme = any(is_nvme_device(dev) for dev in devices)
+            tool_versions = {
+                "smartctl_version": smartctl_version,
+                "nvme_cli_version": get_nvme_cli_version() if has_nvme else None,
+            }
             data = [get_storage_identification(dev) for dev in devices]
             data = [d for d in data if d is not None]
             for device_info in data:
@@ -549,6 +582,23 @@ def smart_storage_identification():
     _identification_storage_cache["data"] = data
 
     return data
+
+def _memoized_nvme_probe():
+    """Build a zero-arg callable that runs nvme_cli_available() at most once.
+
+    Passed to get_storage_info per tick so several NVMe drives share a single
+    `nvme version` probe, while a host with no NVMe device (no parsed nvme
+    section) never probes at all.
+    """
+    state = {}
+
+    def probe():
+        if "available" not in state:
+            state["available"] = nvme_cli_available()
+        return state["available"]
+
+    return probe
+
 
 @debug('smart_storage_health')
 def smart_storage_health():
@@ -572,8 +622,11 @@ def smart_storage_health():
             log("No storage devices found", 'error')
             data = []
         else:
-            data = [get_storage_info(dev) for dev in devices]
-            # Remove None values and add tool versions
+            # Probe nvme-cli at most once per tick (memoized) and only for
+            # devices whose parsed SMART output is NVMe, matching the per-device
+            # gate in get_storage_info. Hosts with no NVMe device never probe.
+            nvme_probe = _memoized_nvme_probe()
+            data = [get_storage_info(dev, nvme_probe) for dev in devices]
             data = [d for d in data if d is not None]
 
     _health_storage_cache["timestamp"] = now

--- a/tests/test_smart_storage.py
+++ b/tests/test_smart_storage.py
@@ -1,0 +1,522 @@
+import time
+from unittest import mock
+
+import pytest
+
+import fivenines_agent.smart_storage as smart_storage
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Reset both module caches before AND after each test.
+
+    Symmetric teardown (matching the autouse convention in test_packages.py)
+    stops a test that stamps a cache with the real clock from leaking a stale
+    entry into a later test that exercises the real collectors.
+    """
+    def _clear():
+        smart_storage._identification_storage_cache["timestamp"] = 0
+        smart_storage._identification_storage_cache["data"] = []
+        smart_storage._health_storage_cache["timestamp"] = 0
+        smart_storage._health_storage_cache["data"] = []
+
+    _clear()
+    yield
+    _clear()
+
+
+def _proc(returncode=0, stdout=""):
+    proc = mock.Mock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    return proc
+
+
+def _nvme_smartctl_proc():
+    return _proc(stdout=(
+        "=== START OF SMART DATA SECTION ===\n"
+        "SMART overall-health self-assessment test result: PASSED\n"
+        "Critical Warning: 0x0c\n"
+    ))
+
+
+def _ata_smartctl_proc():
+    return _proc(stdout=(
+        "=== START OF READ SMART DATA SECTION ===\n"
+        "  9 Power_On_Hours        0x0032   100   100   000    Old_age   1234\n"
+    ))
+
+
+# --- safe_int_conversion --------------------------------------------------
+
+
+def test_safe_int_conversion_parses_hex_and_decimal():
+    """Hex Critical Warning values with a-f must not be silently zeroed.
+
+    Regression for the bug where '0x0c' was stripped to '00' and read as a
+    healthy drive. int(value, 16) parses the 0x prefix directly.
+    """
+    assert smart_storage.safe_int_conversion("0x00", 16) == 0
+    assert smart_storage.safe_int_conversion("0x0c", 16) == 12
+    assert smart_storage.safe_int_conversion("0x0f", 16) == 15
+    assert smart_storage.safe_int_conversion("0x1a", 16) == 26
+    # Base-10 path is unchanged, including trailing-text and signed values.
+    assert smart_storage.safe_int_conversion("1234") == 1234
+    assert smart_storage.safe_int_conversion("100 (raw)") == 100
+    assert smart_storage.safe_int_conversion("-5") == -5
+    assert smart_storage.safe_int_conversion("") is None
+    assert smart_storage.safe_int_conversion("nonsense") is None
+    # Annotated values take only the LEADING valid run -- a trailing annotation
+    # must not inject digits into the result (the fallback path).
+    assert smart_storage.safe_int_conversion("12 (200)") == 12       # not 12200
+    assert smart_storage.safe_int_conversion("0c foo", 16) == 12     # not 0x0cf=207
+    # Radix-prefixed + annotated hex: strip the 0x, then leading run -- must NOT
+    # collapse to 0 (a dangerous "healthy" critical_warning).
+    assert smart_storage.safe_int_conversion("0x04 (foo)", 16) == 4
+    assert smart_storage.safe_int_conversion("0x0c (A)", 16) == 12
+
+
+# --- get_smartctl_version / get_nvme_cli_version (self-checking) ----------
+
+
+def test_get_smartctl_version_parses_first_line(monkeypatch):
+    monkeypatch.setattr(
+        smart_storage.subprocess,
+        "run",
+        lambda *_a, **_k: _proc(0, "smartctl 7.2 2020-12-30 r5155\nCopyright\n"),
+    )
+    assert smart_storage.get_smartctl_version() == "smartctl 7.2 2020-12-30 r5155"
+
+
+def test_get_smartctl_version_none_when_unavailable(monkeypatch):
+    """Non-zero exit (no smartctl / no passwordless sudo) -> None, quietly."""
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(1, "")
+    )
+    assert smart_storage.get_smartctl_version() is None
+
+
+def test_get_nvme_cli_version_parses_first_line(monkeypatch):
+    monkeypatch.setattr(
+        smart_storage.subprocess,
+        "run",
+        lambda *_a, **_k: _proc(0, "nvme version 2.1\n"),
+    )
+    assert smart_storage.get_nvme_cli_version() == "nvme version 2.1"
+
+
+def test_get_nvme_cli_version_none_when_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(1, "")
+    )
+    assert smart_storage.get_nvme_cli_version() is None
+
+
+def test_version_fetchers_none_on_empty_stdout(monkeypatch):
+    """rc=0 but empty stdout -> None (honors the 'unreadable -> emit nothing' contract)."""
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(0, "\n")
+    )
+    assert smart_storage.get_smartctl_version() is None
+    assert smart_storage.get_nvme_cli_version() is None
+
+
+def test_smartctl_available_reflects_probe(monkeypatch):
+    """smartctl_available is True only when the sudo -n probe exits 0."""
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(0, "smartctl 7.2\n")
+    )
+    assert smart_storage.smartctl_available() is True
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(1, "")
+    )
+    assert smart_storage.smartctl_available() is False
+
+
+def test_nvme_cli_available_reflects_probe(monkeypatch):
+    """nvme_cli_available is True only when the sudo -n probe exits 0."""
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(0, "nvme 2.1\n")
+    )
+    assert smart_storage.nvme_cli_available() is True
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _proc(1, "")
+    )
+    assert smart_storage.nvme_cli_available() is False
+
+
+def test_version_fetchers_none_on_timeout(monkeypatch):
+    """A stuck sudo (TimeoutExpired) returns None instead of stalling the loop."""
+    def boom(*_a, **_k):
+        raise smart_storage.subprocess.TimeoutExpired(cmd="x", timeout=5)
+
+    monkeypatch.setattr(smart_storage.subprocess, "run", boom)
+    assert smart_storage.get_smartctl_version() is None
+    assert smart_storage.get_nvme_cli_version() is None
+
+
+def test_version_fetchers_none_on_unexpected_error(monkeypatch):
+    """Any other subprocess failure returns None quietly."""
+    def boom(*_a, **_k):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(smart_storage.subprocess, "run", boom)
+    assert smart_storage.get_smartctl_version() is None
+    assert smart_storage.get_nvme_cli_version() is None
+
+
+# --- smart_storage_identification -----------------------------------------
+
+
+def test_identification_no_nvme_device_does_not_fetch_nvme_version(monkeypatch):
+    """REGRESSION: with only ATA devices, `nvme version` must never run.
+
+    get_nvme_cli_version IS the `sudo -n nvme version` call now, so asserting it
+    is never invoked pins 'no nvme shell-out on ATA-only hosts'.
+    """
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", lambda: "smartctl 7.2")
+    monkeypatch.setattr(
+        smart_storage, "list_storage_devices", lambda: ["/dev/sda", "/dev/sdb"]
+    )
+    monkeypatch.setattr(
+        smart_storage,
+        "get_storage_identification",
+        lambda dev: {"device": dev.split("/")[-1]},
+    )
+
+    nvme_version = mock.Mock(return_value="nvme 2.1")
+    monkeypatch.setattr(smart_storage, "get_nvme_cli_version", nvme_version)
+
+    data = smart_storage.smart_storage_identification()
+
+    nvme_version.assert_not_called()
+    assert len(data) == 2
+    for device_info in data:
+        assert device_info["smartctl_version"] == "smartctl 7.2"
+        # Key stays present (shape stable for the backend), value is null.
+        assert device_info["nvme_cli_version"] is None
+
+
+def test_identification_with_nvme_device_fetches_nvme_version_once(monkeypatch):
+    """An NVMe device present -> nvme version fetched once and reported."""
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", lambda: "smartctl 7.2")
+    monkeypatch.setattr(
+        smart_storage, "list_storage_devices", lambda: ["/dev/sda", "/dev/nvme0"]
+    )
+    monkeypatch.setattr(
+        smart_storage,
+        "get_storage_identification",
+        lambda dev: {"device": dev.split("/")[-1]},
+    )
+
+    nvme_version = mock.Mock(return_value="nvme 2.1")
+    monkeypatch.setattr(smart_storage, "get_nvme_cli_version", nvme_version)
+
+    data = smart_storage.smart_storage_identification()
+
+    nvme_version.assert_called_once()
+    assert len(data) == 2
+    for device_info in data:
+        assert device_info["nvme_cli_version"] == "nvme 2.1"
+
+
+def test_identification_nvme_present_but_cli_unavailable(monkeypatch):
+    """NVMe device present but nvme-cli unusable -> version fetch returns None."""
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", lambda: "smartctl 7.2")
+    monkeypatch.setattr(smart_storage, "list_storage_devices", lambda: ["/dev/nvme0"])
+    monkeypatch.setattr(
+        smart_storage,
+        "get_storage_identification",
+        lambda dev: {"device": dev.split("/")[-1]},
+    )
+
+    nvme_version = mock.Mock(return_value=None)
+    monkeypatch.setattr(smart_storage, "get_nvme_cli_version", nvme_version)
+
+    data = smart_storage.smart_storage_identification()
+
+    nvme_version.assert_called_once()
+    assert data[0]["nvme_cli_version"] is None
+
+
+def test_identification_smartctl_unavailable_returns_empty(monkeypatch):
+    """smartctl unusable (get_smartctl_version returns None) -> empty data.
+
+    Covers both 'smartctl not installed / no sudo' and 'version unreadable':
+    both now manifest as get_smartctl_version() returning None. Device
+    discovery and the nvme fetch must not run.
+    """
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", lambda: None)
+    list_devices = mock.Mock()
+    monkeypatch.setattr(smart_storage, "list_storage_devices", list_devices)
+    nvme_version = mock.Mock()
+    monkeypatch.setattr(smart_storage, "get_nvme_cli_version", nvme_version)
+
+    assert smart_storage.smart_storage_identification() == []
+    list_devices.assert_not_called()
+    nvme_version.assert_not_called()
+
+
+def test_identification_no_devices_returns_empty(monkeypatch):
+    """smartctl present but zero devices -> empty data, no nvme fetch."""
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", lambda: "smartctl 7.2")
+    monkeypatch.setattr(smart_storage, "list_storage_devices", lambda: [])
+    nvme_version = mock.Mock()
+    monkeypatch.setattr(smart_storage, "get_nvme_cli_version", nvme_version)
+
+    assert smart_storage.smart_storage_identification() == []
+    nvme_version.assert_not_called()
+
+
+def test_identification_cache_hit_skips_all_work(monkeypatch):
+    """Fresh cache (<600s) returns cached data without touching subprocess paths."""
+    smart_storage._identification_storage_cache["timestamp"] = time.time()
+    smart_storage._identification_storage_cache["data"] = [{"device": "cached"}]
+
+    smartctl_version = mock.Mock()
+    monkeypatch.setattr(smart_storage, "get_smartctl_version", smartctl_version)
+
+    assert smart_storage.smart_storage_identification() == [{"device": "cached"}]
+    smartctl_version.assert_not_called()
+
+
+# --- smart_storage_health / get_storage_info ------------------------------
+
+
+def test_health_probes_nvme_availability_once_for_multi_nvme(monkeypatch):
+    """End-to-end: several NVMe devices share a single memoized `nvme version`.
+
+    Devices are gated by PARSED output (current_section == nvme), and the probe
+    is consulted once even though every device enriches.
+    """
+    monkeypatch.setattr(smart_storage, "smartctl_available", lambda: True)
+    monkeypatch.setattr(
+        smart_storage,
+        "list_storage_devices",
+        lambda: ["/dev/nvme0", "/dev/nvme1", "/dev/nvme2"],
+    )
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _nvme_smartctl_proc()
+    )
+    monkeypatch.setattr(
+        smart_storage, "calculate_percentage_used", lambda *_a, **_k: None
+    )
+    nvme_available = mock.Mock(return_value=True)
+    monkeypatch.setattr(smart_storage, "nvme_cli_available", nvme_available)
+    enhanced = mock.Mock(return_value={"percent_used": 7})
+    monkeypatch.setattr(smart_storage, "get_nvme_enhanced_info", enhanced)
+
+    data = smart_storage.smart_storage_health()
+
+    nvme_available.assert_called_once()      # memoized across all 3 devices
+    assert enhanced.call_count == 3          # but each NVMe device still enriched
+    assert len(data) == 3
+    for device_info in data:
+        assert device_info["device_type"] == "nvme"
+        assert device_info["critical_warning"] == 12   # 0x0c parsed correctly
+        assert device_info["percent_used"] == 7         # enrichment merged in
+
+
+def test_health_no_nvme_section_never_probes(monkeypatch):
+    """REGRESSION: devices whose PARSED output is ATA never probe nvme-cli.
+
+    This is the exact-equivalence guard: gating is by parsed current_section,
+    not the device path, so an NVMe device under an exotic name would still be
+    enriched (and an ATA device never triggers a probe).
+    """
+    monkeypatch.setattr(smart_storage, "smartctl_available", lambda: True)
+    monkeypatch.setattr(
+        smart_storage, "list_storage_devices", lambda: ["/dev/sda", "/dev/sdb"]
+    )
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _ata_smartctl_proc()
+    )
+    monkeypatch.setattr(
+        smart_storage, "calculate_percentage_used", lambda *_a, **_k: None
+    )
+    nvme_available = mock.Mock(return_value=True)
+    monkeypatch.setattr(smart_storage, "nvme_cli_available", nvme_available)
+
+    data = smart_storage.smart_storage_health()
+
+    nvme_available.assert_not_called()
+    assert all(device_info["device_type"] == "ata" for device_info in data)
+
+
+def test_memoized_nvme_probe_runs_underlying_check_once(monkeypatch):
+    """The probe factory caches the first nvme_cli_available() result."""
+    underlying = mock.Mock(return_value=True)
+    monkeypatch.setattr(smart_storage, "nvme_cli_available", underlying)
+
+    probe = smart_storage._memoized_nvme_probe()
+    assert probe() is True
+    assert probe() is True
+    assert probe() is True
+
+    underlying.assert_called_once()
+
+
+def test_health_smartctl_unavailable_returns_empty(monkeypatch):
+    """No smartctl -> empty health data, device discovery never attempted."""
+    monkeypatch.setattr(smart_storage, "smartctl_available", lambda: False)
+    list_devices = mock.Mock()
+    monkeypatch.setattr(smart_storage, "list_storage_devices", list_devices)
+
+    assert smart_storage.smart_storage_health() == []
+    list_devices.assert_not_called()
+
+
+def test_health_no_devices_returns_empty(monkeypatch):
+    """smartctl present but zero devices -> empty health data, nvme never probed."""
+    monkeypatch.setattr(smart_storage, "smartctl_available", lambda: True)
+    monkeypatch.setattr(smart_storage, "list_storage_devices", lambda: [])
+    nvme_available = mock.Mock()
+    monkeypatch.setattr(smart_storage, "nvme_cli_available", nvme_available)
+
+    assert smart_storage.smart_storage_health() == []
+    nvme_available.assert_not_called()
+
+
+def test_health_cache_hit_skips_all_work(monkeypatch):
+    """Fresh health cache (<60s) returns cached data without re-collecting."""
+    smart_storage._health_storage_cache["timestamp"] = time.time()
+    smart_storage._health_storage_cache["data"] = [{"device": "cached"}]
+
+    smartctl = mock.Mock()
+    monkeypatch.setattr(smart_storage, "smartctl_available", smartctl)
+
+    assert smart_storage.smart_storage_health() == [{"device": "cached"}]
+    smartctl.assert_not_called()
+
+
+def test_get_storage_info_honors_nvme_available_flag(monkeypatch):
+    """get_storage_info enriches an NVMe device only when told nvme-cli is usable,
+    and the parsed/derived fields are actually written into the result."""
+    monkeypatch.setattr(
+        smart_storage.subprocess,
+        "run",
+        lambda *_a, **_k: _proc(stdout=(
+            "=== START OF SMART DATA SECTION ===\n"
+            "SMART overall-health self-assessment test result: PASSED\n"
+            "Critical Warning: 0x0c\n"
+        )),
+    )
+    monkeypatch.setattr(
+        smart_storage, "calculate_percentage_used", lambda *_a, **_k: 95
+    )
+
+    enhanced = mock.Mock(return_value={"percent_used": 5})
+    monkeypatch.setattr(smart_storage, "get_nvme_enhanced_info", enhanced)
+
+    # Probe says nvme-cli is usable -> enhanced info is fetched AND merged.
+    res = smart_storage.get_storage_info("/dev/nvme0", nvme_available=lambda: True)
+    enhanced.assert_called_once_with("/dev/nvme0")
+    assert res["device"] == "nvme0"
+    assert res["device_type"] == "nvme"
+    assert res["critical_warning"] == 12        # 0x0c, not silently zeroed
+    assert res["percent_used"] == 5             # results.update(nvme_info) ran
+    assert res["percentage_used"] == 95         # percentage_used write path ran
+
+    # Probe says nvme-cli is not usable -> enhanced info is skipped, but the
+    # smartctl-parsed fields are still present.
+    enhanced.reset_mock()
+    res2 = smart_storage.get_storage_info("/dev/nvme0", nvme_available=lambda: False)
+    enhanced.assert_not_called()
+    assert "percent_used" not in res2
+    assert res2["critical_warning"] == 12
+
+
+# --- data-path timeouts (a wedged drive must not stall the loop) ----------
+
+
+def test_data_path_subprocess_calls_set_timeout(monkeypatch):
+    """Every data-collection smartctl/nvme call passes a timeout, so a wedged
+    drive cannot block the single-threaded collection loop forever."""
+    seen = []
+
+    def spy(cmd, *_a, **kwargs):
+        seen.append(kwargs.get("timeout"))
+        proc = mock.Mock()
+        proc.returncode = 0
+        if "--scan" in cmd:
+            proc.stdout = b""           # list_storage_devices does .decode()
+        elif "smart-log" in cmd:
+            proc.stdout = "{}"          # get_nvme_enhanced_info does json.loads
+        else:
+            proc.stdout = ""            # -A -H / -i do .splitlines()
+        return proc
+
+    monkeypatch.setattr(smart_storage.subprocess, "run", spy)
+    monkeypatch.setattr(
+        smart_storage, "calculate_percentage_used", lambda *_a, **_k: None
+    )
+
+    smart_storage.list_storage_devices()
+    smart_storage.get_storage_info("/dev/sda")
+    smart_storage.get_storage_identification("/dev/sda")
+    smart_storage.get_nvme_enhanced_info("/dev/nvme0")
+
+    assert seen, "no subprocess calls were made"
+    # Pin the value with a literal (NOT the constant -- that would move with a
+    # mutation): a regression shrinking the cap below the slow-but-healthy-drive
+    # budget must fail here. And confirm every call uses the shared constant.
+    assert smart_storage._DATA_SUBPROCESS_TIMEOUT == 30
+    assert all(
+        t == smart_storage._DATA_SUBPROCESS_TIMEOUT for t in seen
+    ), f"a data-path call did not use the shared timeout: {seen}"
+
+
+def test_data_path_degrades_on_timeout(monkeypatch):
+    """A timed-out data call degrades to a safe value instead of propagating."""
+    def boom(*_a, **_k):
+        raise smart_storage.subprocess.TimeoutExpired(cmd="smartctl", timeout=30)
+
+    monkeypatch.setattr(smart_storage.subprocess, "run", boom)
+
+    assert smart_storage.list_storage_devices() == []
+    assert smart_storage.get_storage_info("/dev/sda") is None
+    assert smart_storage.get_storage_identification("/dev/sda") is None
+    assert smart_storage.get_nvme_enhanced_info("/dev/nvme0") == {}
+
+
+def test_get_storage_info_gates_on_parsed_section_not_device_path(monkeypatch):
+    """Enrichment is gated on PARSED output (current_section), NOT the device path.
+
+    A device whose path is not /dev/nvme* but whose smartctl output parses as
+    NVMe must still be enriched. This pins the exact-equivalence choice: the
+    health path deliberately does NOT use the is_nvme_device path heuristic here
+    (only identification does, because `smartctl -i` has no SMART section).
+    """
+    monkeypatch.setattr(
+        smart_storage.subprocess, "run", lambda *_a, **_k: _nvme_smartctl_proc()
+    )
+    monkeypatch.setattr(
+        smart_storage, "calculate_percentage_used", lambda *_a, **_k: None
+    )
+    enhanced = mock.Mock(return_value={"percent_used": 9})
+    monkeypatch.setattr(smart_storage, "get_nvme_enhanced_info", enhanced)
+
+    # Non-/dev/nvme path, but the parsed SMART section is NVMe.
+    res = smart_storage.get_storage_info("/dev/sda", nvme_available=lambda: True)
+
+    enhanced.assert_called_once_with("/dev/sda")   # gated on section, not path
+    assert res["device_type"] == "nvme"
+    assert res["percent_used"] == 9
+
+
+def test_sudo_probe_passes_timeout(monkeypatch):
+    """The availability/version probe must also pass a timeout, so a wedged tool
+    at probe time cannot hang the loop either."""
+    seen = []
+
+    def spy(cmd, *_a, **kwargs):
+        seen.append(kwargs.get("timeout"))
+        return _proc(0, "smartctl 7.2\n")
+
+    monkeypatch.setattr(smart_storage.subprocess, "run", spy)
+
+    smart_storage.get_smartctl_version()
+    smart_storage.smartctl_available()
+
+    assert seen, "no probe calls were made"
+    assert all(t is not None for t in seen), f"a probe call had no timeout: {seen}"


### PR DESCRIPTION
`smart_storage_identification` and `smart_storage_health` no longer shell out to `nvme` unless an NVMe device is actually present, and the health path memoizes the nvme-cli probe to one call per tick instead of one per device. While in here it also fixes `safe_int_conversion` mangling hex `Critical Warning` values (`0x0c` parsed to `0`, masking a failing drive), unifies the four `sudo -n` probes behind a single `_sudo_probe` helper, and caps every data-collection smartctl/nvme subprocess call with a timeout so a wedged drive can't stall the single-threaded collection loop. Adds `tests/test_smart_storage.py` (27 tests; the module previously had none). Reviewed via `/plan-eng-review`, `/code-review` (max effort), and `/codex review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)