### PR TITLE
v1.11.1 feat: log monitoring V1 (agent-side): journald capture + signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ poetry run fivenines_agent --version
 **Permission Probing (`permissions.py`)**
 - Detects available monitoring capabilities at startup based on file permissions, sudo access, and group memberships
 - Re-probes automatically every 5 minutes or on SIGHUP signal to detect permission changes
-- Capabilities include: core metrics (always available), hardware sensors, storage (SMART/RAID), services (Docker/QEMU/Proxmox/systemd), kernel surfaces (cgroup, tri-state "v1"/"v2"/None), security (fail2ban), etc.
+- Capabilities include: core metrics (always available), hardware sensors, storage (SMART/RAID), services (Docker/QEMU/Proxmox/systemd), kernel surfaces (cgroup, tri-state "v1"/"v2"/None), security (fail2ban), logs (`journald` read access, probed via `journalctl -n 0`), etc.
 - Prints a capabilities banner showing what features are available/unavailable with hints
 
 **Synchronizer (`synchronizer.py`)**
@@ -76,6 +76,11 @@ poetry run fivenines_agent --version
 **SynchronizationQueue (`synchronization_queue.py`)**
 - Thread-safe queue with maxsize limit for buffering collected metrics
 - Prevents memory exhaustion if API is unreachable
+
+**Log Uploader (`log_uploader.py`, `log_capture.py`)**
+- Dedicated `LogUploader` worker thread + bounded queue that upload incident log-capture bundles to `/logs` via `Synchronizer.send_logs`, kept off the metric-collection loop so a slow/large upload never stalls collection, `/collect`, or the systemd watchdog
+- `CaptureCoordinator` applies the backend `capture_logs` command with a capture_id nonce + on-disk `last_capture_id` persistence: each command fires exactly once and never replays after a `Restart=always` restart; `last_served` advances only after a confirmed upload, so a failed capture retries
+- Part of log-monitoring V1; inert until the backend implements the `/collect` `capture_logs` command and the `/logs` endpoint
 
 **Subprocess Utilities (`subprocess_utils.py`)**
 - Critical for PyInstaller compatibility: removes LD_LIBRARY_PATH and other environment variables that can interfere with system commands
@@ -98,11 +103,12 @@ Each metric collector is a separate module that exports functions to collect spe
 
 - **Core metrics** (always enabled): `cpu.py`, `memory.py`, `load_average.py`, `io.py`, `network.py`, `partitions.py`, `files.py`, `ports.py`, `processes.py`, `temperatures.py`, `fans.py`
 - **Storage**: `smart_storage.py` (requires sudo smartctl), `raid_storage.py` (requires sudo mdadm), `zfs.py`
-- **Services**: `docker.py`, `qemu.py`, `proxmox.py`, `caddy.py`, `nginx.py`, `postgresql.py`, `redis.py`, `systemd.py` (per-unit health + inventory delta-sync, requires systemctl; journalctl only for failure journal tails)
+- **Services**: `docker.py`, `qemu.py`, `proxmox.py`, `caddy.py`, `nginx.py`, `postgresql.py`, `redis.py`, `systemd.py` (per-unit health + inventory delta-sync, requires systemctl; journalctl only for failure journal tails, redacted before send)
 - **Security**: `fail2ban.py` (requires sudo fail2ban-client)
 - **Network/connectivity**: `ip.py` (public IPv4/IPv6 via ip.fivenines.io with 60s cache), `ping.py` (TCP latency), `snmp.py` (SNMP device polling via net-snmp CLI tools)
 - **Security scanning**: `packages.py` (installed packages via dpkg/rpm/apk/pacman with hash-based delta sync)
 - **Kernel surfaces**: `cgroup.py` (v1/v2 hierarchy detection + safe per-unit metric reads, used by `systemd.py`)
+- **Log monitoring** (V1): `logs.py` (continuous per-unit error/warn signals + top fingerprints via `collect_log_signals`, wired as the `logs` collector; incident capture via `build_capture_bundle`: bounded retroactive `journalctl` slice -> redacted enriched digest; shared best-effort `redact()` for secrets/PII, also used by `systemd.py`). Gated on the `journald` capability (journal read access); transport/coordination live in `log_capture.py` + `log_uploader.py` (see Core Components).
 
 Collectors use the `@debug` decorator from `debug.py` to log execution time and results.
 
@@ -117,6 +123,8 @@ Collectors use the `@debug` decorator from `debug.py` to log execution time and 
   - `request_options`: timeout, retry count, retry interval
   - `packages.scan`: triggers package inventory sync with hash-based deduplication
   - `systemd`: unit collection config (`unit_types` as comma-separated string or list; `scan` triggers inventory delta-sync to `/systemd_inventory`)
+  - `logs`: continuous log-signal collection (`units` allowlist, `signal_interval_s` window); gated on the `journald` capability
+  - `capture_logs`: backend-pull incident capture command (`capture_id`, `unit`, `since`, `lines`, `expiry`); fired exactly once via the capture_id nonce + on-disk persistence, uploaded to `/logs` off the collection loop
 
 ### Installation Types
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The agent works without sudo, but these features will be unavailable (this is al
 | SNMP device polling | `net-snmp` tools (`snmpget`, `snmpbulkwalk`) |
 | systemd unit metrics | `systemd` init system (`systemctl`; `journalctl` only for failure journal tails) |
 | systemd failure journal tails | journal read access: the bundled service unit grants `SupplementaryGroups=systemd-journal`; for user installs add your user to the `systemd-journal` group (tails degrade to empty without it) |
+| Log monitoring (journald capture + signals) | journal read access (`systemd-journal` group) |
 | Per-unit cgroup metrics | cgroup v1 or v2 mounted at `/sys/fs/cgroup` |
 | Ceph cluster status | `ceph` CLI + read-only cephx keyring (no sudo) |
 
@@ -233,6 +234,9 @@ When the agent starts, it displays a banner showing which features are available
 
   Networking:
     [+] Snmp
+
+  Logs:
+    [+] Journald
 
   [!] Some features unavailable. See: https://docs.fivenines.io/agent/permissions
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,46 @@
 # TODOS
 
+## P2: Log monitoring - flat-file (non-journald) source (E2)
+
+Deferred from `ceo-plans/2026-06-30-log-file-monitoring.md` at the Codex
+cut-scope. V1 reads journald only, so services that log to their own files
+(`/var/log/nginx/*.log`, apps writing files, non-systemd hosts) are uncovered.
+Add a log2journal-style parser + a ring-buffer for rotation (no retroactive
+read on rotating files). This is the "second subsystem" the review flagged.
+
+- **Effort:** L (human) / M (CC)
+- **Depends on:** log monitoring V1 shipped
+- **Files:** `fivenines_agent/logs.py` (file source alongside journald), tests
+
+## P3: Log monitoring - remaining V1 fast-follows
+
+Consolidated deferrals from the same CEO plan, each a complete follow-up:
+- **E1 ML edge trigger** (k-means anomaly detection on the agent) - gated behind
+  a PyInstaller/BLAS feasibility spike; deterministic triggers suffice for now.
+- **Local instant capture trigger** (sub-second, agent-side) - V1 uses
+  backend-pull + incident-mode interval drop; the local detector is deferred.
+- **Windows Event Log source** - V1 is Linux/journald only.
+- **Raw posture opt-in** - V1 hardcodes `posture: "digest"`; wire the per-account
+  raw flag through and enforce `max_bytes` (only meaningful for raw). E4
+  log-based alerting is backend-side.
+
+- **Effort:** varies (see plan) / mostly M (CC)
+- **Depends on:** log monitoring V1 in production + demand signal
+- **Files:** `fivenines_agent/logs.py`, `fivenines_agent/log_capture.py`
+
+## P3: Log monitoring - DRY debt from pre-landing review
+
+Two duplications flagged (confidence 4-5, deferred rather than refactor at ship):
+`logs._signals_for_unit` and `logs.build_digest` share a fingerprint-grouping
+loop with subtly different outputs (info counted or not, `sample` vs `excerpt`
+key, top-N cap); and journald `-o json` MESSAGE parsing is duplicated between
+`logs._capture_entries` and `systemd._parse_journalctl_failed`. Extract shared
+helpers once the shapes stabilize.
+
+- **Effort:** S (human) / S (CC)
+- **Depends on:** nothing
+- **Files:** `fivenines_agent/logs.py`, `fivenines_agent/systemd.py`, tests
+
 ## P1: Hourly re-send TTL for stuck-failed unit drilldowns
 
 Deferred from plan `2026-05-04-systemd-services.md` (ship gate decision). The

--- a/fivenines-agent.service
+++ b/fivenines-agent.service
@@ -4,6 +4,9 @@ Description=Five Nines monitoring agent
 [Service]
 Type=notify
 User=fivenines
+# Grants read access to the systemd journal so the log-monitoring collector can
+# run as the unprivileged fivenines user (journald capability).
+SupplementaryGroups=systemd-journal
 ExecStart=/opt/fivenines/fivenines_agent
 RestartSec=5
 Restart=always

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -150,7 +150,11 @@ class Agent:
             self.log_uploader = None
         else:
             self.log_uploader = LogUploader(
-                self.log_queue, build_capture_bundle, self.synchronizer.send_logs
+                self.log_queue,
+                build_capture_bundle,
+                self.synchronizer.send_logs,
+                on_success=self.capture_coordinator.mark_uploaded,
+                on_failure=self.capture_coordinator.mark_failed,
             )
             self.log_uploader.start()
 

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -66,6 +66,7 @@ _DRY_RUN_CONFIG = {
     "network": True,
     "partitions": True,
     "io": True,
+    "logs": {"units": ["nginx.service", "ssh.service"]},
     "processes": True,
     "ports": True,
     "temperatures": True,

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -28,6 +28,9 @@ from fivenines_agent.env import config_dir, dry_run, env_file, get_user_context,
 from fivenines_agent.files import file_handles_limit, file_handles_used, handle_count
 from fivenines_agent.ip import get_ip
 from fivenines_agent.load_average import load_average
+from fivenines_agent.log_capture import CaptureCoordinator, evaluate_and_enqueue
+from fivenines_agent.log_uploader import LogUploader
+from fivenines_agent.logs import build_capture_bundle
 from fivenines_agent.machine_id import get_machine_id
 from fivenines_agent.packages import packages_sync
 from fivenines_agent.permissions import get_permissions, print_capabilities_banner
@@ -134,6 +137,22 @@ class Agent:
             self.synchronizer = Synchronizer(self.token, self.queue, self.static_data)
             self.synchronizer.start()
 
+        # Dedicated channel for incident log-capture bundles (Brique A), kept off
+        # the metric path so a slow/large /logs upload never blocks collection or
+        # /collect. The coordinator applies the capture_id nonce + disk persistence
+        # so a backend command fires exactly once and never replays after a restart.
+        self.log_queue = SynchronizationQueue(maxsize=20)
+        self.capture_coordinator = CaptureCoordinator(
+            os.path.join(CONFIG_DIR, "last_capture_id")
+        )
+        if self.synchronizer is None:
+            self.log_uploader = None
+        else:
+            self.log_uploader = LogUploader(
+                self.log_queue, build_capture_bundle, self.synchronizer.send_logs
+            )
+            self.log_uploader.start()
+
     def _load_file(self, filename):
         try:
             path = os.path.join(CONFIG_DIR, filename)
@@ -173,6 +192,8 @@ class Agent:
                         self.queue.put({"get_config": True, **self.static_data})
                         exit_event.wait(25)
                         continue
+
+                self._handle_capture_request(self.config)
 
                 data = self.static_data.copy()
                 data["ts"] = time.time()
@@ -257,6 +278,15 @@ class Agent:
         self._collect(
             "packages_sync", packages_sync, self.config, self.synchronizer.send_packages
         )
+
+    def _handle_capture_request(self, config):
+        """Enqueue an incident log-capture job when the backend issues a new
+        capture_logs command. The coordinator owns the nonce + allowlist + expiry;
+        the LogUploader thread runs the actual journalctl capture off the loop.
+        No-op when log uploading is disabled (dry-run / no synchronizer)."""
+        if self.log_uploader is None:
+            return
+        evaluate_and_enqueue(self.capture_coordinator, self.log_queue, config)
 
     def _handle_sighup_refresh(self):
         """SIGHUP-triggered full reprobe. Kept at the top of the loop (needs no
@@ -378,4 +408,8 @@ class Agent:
             self.synchronizer.stop()
             self.queue.put(None)
             self.synchronizer.join()
+        if self.log_uploader is not None:
+            self.log_uploader.stop()
+            self.log_queue.put(None)
+            self.log_uploader.join()
         sys.exit(0)

--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.10.0'
+VERSION = '1.10.1'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -102,8 +102,9 @@ COLLECTORS = [
 CAPABILITY_KEY_OVERRIDES = {
     "smart_storage_health": "smart_storage",
     "raid_storage_health": "raid_storage",
-    # Log signals are gated by journald read access (capability added with the
-    # journald permission probe); until that lands, the cap is absent -> not gated.
+    # Log signals are gated by journald read access, probed via `journalctl -n 0`
+    # in permissions.py (_can_read_journal). Hosts where the cap is absent (non
+    # systemd, or no group) are simply not gated on it.
     "logs": "journald",
 }
 

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -11,6 +11,7 @@ from fivenines_agent.fail2ban import fail2ban_metrics
 from fivenines_agent.fans import fans
 from fivenines_agent.gpu import gpu_metrics
 from fivenines_agent.io import io
+from fivenines_agent.logs import collect_log_signals
 from fivenines_agent.memory import memory, swap
 from fivenines_agent.network import network
 from fivenines_agent.nginx import nginx_metrics
@@ -60,6 +61,9 @@ COLLECTORS = [
         ],
     ),
     ("io", [("io", io, False)]),
+    # Brique C log signals: per-unit error/warn rate + fingerprints. pass_kwargs
+    # unpacks the logs config (units allowlist, signal_interval_s) as **kwargs.
+    ("logs", [("logs", collect_log_signals, True)]),
     (
         "smart_storage_health",
         [
@@ -93,6 +97,9 @@ COLLECTORS = [
 CAPABILITY_KEY_OVERRIDES = {
     "smart_storage_health": "smart_storage",
     "raid_storage_health": "raid_storage",
+    # Log signals are gated by journald read access (capability added with the
+    # journald permission probe); until that lands, the cap is absent -> not gated.
+    "logs": "journald",
 }
 
 # Tracks (config_key, capability_value) pairs that have already been logged

--- a/fivenines_agent/log_capture.py
+++ b/fivenines_agent/log_capture.py
@@ -19,6 +19,7 @@ capture; the backend re-issues a NEW capture_id once `expiry` passes without an 
 This keeps replay prevention simple and avoids an in-flight retry loop.
 """
 
+import threading
 import time
 
 from fivenines_agent.debug import log
@@ -28,7 +29,12 @@ class CaptureCoordinator:
     def __init__(self, state_path, now_fn=time.time):
         self.state_path = state_path
         self._now = now_fn
+        self._lock = threading.Lock()
         self._last_served = self._load()
+        # capture_ids enqueued but not yet confirmed uploaded. Guards against
+        # re-enqueuing a duplicate while an upload is in flight, while letting a
+        # failed upload retry (last_served advances only after a real upload).
+        self._in_flight = set()
         self._last_warned_id = None
 
     def _load(self):
@@ -51,35 +57,39 @@ class CaptureCoordinator:
             log(f"CaptureCoordinator: cannot persist {self.state_path}: {e}", "error")
 
     def evaluate(self, capture_logs, allowed_units):
-        """Return a capture job dict if this command should fire now, else None."""
+        """Return a capture job dict if this command should fire now, else None.
+
+        On fire the capture_id is marked in-flight, NOT served: last_served (the
+        no-replay-across-restart guard) advances only once mark_uploaded confirms
+        a successful /logs POST, so a failed upload is retried on a later tick.
+        mark_failed releases the in-flight slot. The lock guards state touched
+        from both the collection loop (evaluate) and the uploader thread
+        (mark_uploaded / mark_failed).
+        """
         if not isinstance(capture_logs, dict):
             return None
         capture_id = capture_logs.get("capture_id")
         if not capture_id:
             return None
-        if capture_id == self._last_served:
-            return None  # already served - replay guard, survives restart
-
         unit = capture_logs.get("unit")
-        if unit not in allowed_units:
-            # Default-deny. Warn once per capture_id to avoid per-tick log spam.
-            if self._last_warned_id != capture_id:
-                log(
-                    f"CaptureCoordinator: unit {unit!r} not in allowlist, "
-                    "refusing capture",
-                    "error",
-                )
-                self._last_warned_id = capture_id
-            return None
-
         expiry = capture_logs.get("expiry")
-        if isinstance(expiry, (int, float)) and not isinstance(expiry, bool):
-            if self._now() > expiry:
-                return None  # stale command
-
-        # Fire: mark served (optimistic) + persist so a restart never replays.
-        self._last_served = capture_id
-        self._persist(capture_id)
+        with self._lock:
+            if capture_id == self._last_served or capture_id in self._in_flight:
+                return None  # already uploaded, or already in flight
+            if unit not in allowed_units:
+                # Default-deny. Warn once per capture_id to avoid per-tick spam.
+                if self._last_warned_id != capture_id:
+                    log(
+                        f"CaptureCoordinator: unit {unit!r} not in allowlist, "
+                        "refusing capture",
+                        "error",
+                    )
+                    self._last_warned_id = capture_id
+                return None
+            if isinstance(expiry, (int, float)) and not isinstance(expiry, bool):
+                if self._now() > expiry:
+                    return None  # stale command
+            self._in_flight.add(capture_id)
         return {
             "capture_id": capture_id,
             "unit": unit,
@@ -87,6 +97,25 @@ class CaptureCoordinator:
             "lines": capture_logs.get("lines"),
             "max_bytes": capture_logs.get("max_bytes"),
         }
+
+    def mark_uploaded(self, capture_id):
+        """Uploader callback on a successful /logs POST: persist the capture_id as
+        served (no replay, survives restart) and free the in-flight slot."""
+        if not capture_id:
+            return
+        with self._lock:
+            self._last_served = capture_id
+            self._in_flight.discard(capture_id)
+            self._persist(capture_id)
+
+    def mark_failed(self, capture_id):
+        """Uploader callback when the capture/upload failed: free the in-flight
+        slot so the command retries on a later tick (bounded by the backend's
+        expiry). last_served is NOT advanced."""
+        if not capture_id:
+            return
+        with self._lock:
+            self._in_flight.discard(capture_id)
 
 
 def evaluate_and_enqueue(coordinator, log_queue, config):

--- a/fivenines_agent/log_capture.py
+++ b/fivenines_agent/log_capture.py
@@ -130,6 +130,16 @@ def evaluate_and_enqueue(coordinator, log_queue, config):
     logs_cfg = config.get("logs")
     allowed = logs_cfg.get("units", []) if isinstance(logs_cfg, dict) else []
     job = coordinator.evaluate(config.get("capture_logs"), allowed)
-    if job is not None:
-        log_queue.put(job)
+    if job is None:
+        return None
+    # evaluate() already marked this capture in-flight. The bounded log_queue
+    # drops the OLDEST job silently on overflow, and a dropped job never reaches
+    # the uploader -> its in-flight slot would leak forever. So when the queue is
+    # full, shed THIS capture and release its slot instead; the backend re-mints a
+    # fresh capture_id after expiry.
+    if log_queue.full():
+        log("evaluate_and_enqueue: log queue full, shedding capture", "error")
+        coordinator.mark_failed(job.get("capture_id"))
+        return None
+    log_queue.put(job)
     return job

--- a/fivenines_agent/log_capture.py
+++ b/fivenines_agent/log_capture.py
@@ -1,0 +1,103 @@
+"""Backend-pull capture coordinator: fire each capture_logs command exactly once.
+
+The /collect response config is REPLACED every tick (Synchronizer.send_metrics),
+so a capture_logs command left in config would re-fire every tick. This applies a
+nonce (mirrors the permissions_recheck_token state machine in agent.py) PLUS disk
+persistence, so a Restart=always agent never replays a capture it already served.
+
+    config.capture_logs = {capture_id, unit, since, lines, max_bytes, expiry}
+          |
+          v  evaluate()
+    capture_id == last_served (persisted) ?  -> None   (replay guard, survives restart)
+    unit not in allowlist ?                  -> None   (default-deny)
+    expiry set and now > expiry ?            -> None   (stale command)
+    otherwise -> persist last_served = capture_id, return the JOB (enqueue once)
+
+last_served is updated optimistically when the job is enqueued, not after the
+upload acks. Tradeoff: a crash between enqueue and a successful POST drops that one
+capture; the backend re-issues a NEW capture_id once `expiry` passes without an ack.
+This keeps replay prevention simple and avoids an in-flight retry loop.
+"""
+
+import time
+
+from fivenines_agent.debug import log
+
+
+class CaptureCoordinator:
+    def __init__(self, state_path, now_fn=time.time):
+        self.state_path = state_path
+        self._now = now_fn
+        self._last_served = self._load()
+        self._last_warned_id = None
+
+    def _load(self):
+        try:
+            with open(self.state_path, "r") as f:
+                return f.read().strip() or None
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            log(f"CaptureCoordinator: cannot read {self.state_path}: {e}", "error")
+            return None
+
+    def _persist(self, capture_id):
+        try:
+            with open(self.state_path, "w") as f:
+                f.write(str(capture_id))
+        except Exception as e:
+            # Best-effort: a write failure must not break capture. The in-memory
+            # _last_served still prevents replay within this process.
+            log(f"CaptureCoordinator: cannot persist {self.state_path}: {e}", "error")
+
+    def evaluate(self, capture_logs, allowed_units):
+        """Return a capture job dict if this command should fire now, else None."""
+        if not isinstance(capture_logs, dict):
+            return None
+        capture_id = capture_logs.get("capture_id")
+        if not capture_id:
+            return None
+        if capture_id == self._last_served:
+            return None  # already served - replay guard, survives restart
+
+        unit = capture_logs.get("unit")
+        if unit not in allowed_units:
+            # Default-deny. Warn once per capture_id to avoid per-tick log spam.
+            if self._last_warned_id != capture_id:
+                log(
+                    f"CaptureCoordinator: unit {unit!r} not in allowlist, "
+                    "refusing capture",
+                    "error",
+                )
+                self._last_warned_id = capture_id
+            return None
+
+        expiry = capture_logs.get("expiry")
+        if isinstance(expiry, (int, float)) and not isinstance(expiry, bool):
+            if self._now() > expiry:
+                return None  # stale command
+
+        # Fire: mark served (optimistic) + persist so a restart never replays.
+        self._last_served = capture_id
+        self._persist(capture_id)
+        return {
+            "capture_id": capture_id,
+            "unit": unit,
+            "since": capture_logs.get("since"),
+            "lines": capture_logs.get("lines"),
+            "max_bytes": capture_logs.get("max_bytes"),
+        }
+
+
+def evaluate_and_enqueue(coordinator, log_queue, config):
+    """Glue: read capture_logs + allowlist from config; enqueue a job if it fires.
+
+    Returns the job (also enqueued) or None. A free function so it is testable
+    without constructing an Agent.
+    """
+    logs_cfg = config.get("logs")
+    allowed = logs_cfg.get("units", []) if isinstance(logs_cfg, dict) else []
+    job = coordinator.evaluate(config.get("capture_logs"), allowed)
+    if job is not None:
+        log_queue.put(job)
+    return job

--- a/fivenines_agent/log_capture.py
+++ b/fivenines_agent/log_capture.py
@@ -8,15 +8,18 @@ persistence, so a Restart=always agent never replays a capture it already served
     config.capture_logs = {capture_id, unit, since, lines, max_bytes, expiry}
           |
           v  evaluate()
-    capture_id == last_served (persisted) ?  -> None   (replay guard, survives restart)
+    capture_id already served or in flight ? -> None   (replay guard + no dup)
     unit not in allowlist ?                  -> None   (default-deny)
     expiry set and now > expiry ?            -> None   (stale command)
-    otherwise -> persist last_served = capture_id, return the JOB (enqueue once)
+    otherwise -> mark in-flight, return the JOB (enqueue once)
 
-last_served is updated optimistically when the job is enqueued, not after the
-upload acks. Tradeoff: a crash between enqueue and a successful POST drops that one
-capture; the backend re-issues a NEW capture_id once `expiry` passes without an ack.
-This keeps replay prevention simple and avoids an in-flight retry loop.
+last_served advances only AFTER a confirmed upload (mark_uploaded), not at enqueue
+time, so a failed capture or upload is retried on a later tick instead of being
+lost; mark_failed releases the in-flight slot. last_served is persisted to disk so
+a Restart=always agent never replays a capture it already uploaded (a crash mid-
+capture re-fires, which the idempotent backend dedupes on capture_id). max_bytes is
+forward-plumbed into the job for the raw posture; V1 ships digest only, whose size
+is already bounded by the fingerprint/excerpt caps in logs.py.
 """
 
 import threading

--- a/fivenines_agent/log_uploader.py
+++ b/fivenines_agent/log_uploader.py
@@ -27,12 +27,16 @@ from fivenines_agent.debug import log
 
 
 class LogUploader(Thread):
-    def __init__(self, queue, build_fn, send_fn):
+    def __init__(self, queue, build_fn, send_fn, on_success=None, on_failure=None):
         Thread.__init__(self)
         self._stop_event = Event()
         self.queue = queue
         self.build_fn = build_fn
         self.send_fn = send_fn
+        # Called with the job's capture_id on terminal outcome, so the capture
+        # coordinator can mark it uploaded (no replay) or release it for retry.
+        self._on_success = on_success or (lambda capture_id: None)
+        self._on_failure = on_failure or (lambda capture_id: None)
 
     def run(self):
         while not self._stop_event.is_set():
@@ -49,22 +53,30 @@ class LogUploader(Thread):
     def _process(self, job):
         # Per-job isolation: one bad capture must not kill the uploader thread
         # (registry-collector-needs-per-item-isolation learning, applied to the
-        # async path).
+        # async path). Every terminal outcome signals the coordinator.
+        capture_id = job.get("capture_id") if isinstance(job, dict) else None
         try:
             bundle = self.build_fn(job)
         except Exception as e:
             log(f"LogUploader: capture build failed for {job!r}: {e}", "error")
+            self._on_failure(capture_id)
             return
         if bundle is None:
             log("LogUploader: capture produced no bundle, skipping", "debug")
+            self._on_failure(capture_id)
             return
         try:
-            if self.send_fn(bundle):
-                log("LogUploader: bundle uploaded", "info")
-            else:
-                log("LogUploader: bundle upload failed, dropping", "error")
+            ok = self.send_fn(bundle)
         except Exception as e:
             log(f"LogUploader: send failed: {e}", "error")
+            self._on_failure(capture_id)
+            return
+        if ok:
+            log("LogUploader: bundle uploaded", "info")
+            self._on_success(capture_id)
+        else:
+            log("LogUploader: bundle upload failed, dropping", "error")
+            self._on_failure(capture_id)
 
     def stop(self):
         self._stop_event.set()

--- a/fivenines_agent/log_uploader.py
+++ b/fivenines_agent/log_uploader.py
@@ -1,0 +1,70 @@
+"""Dedicated worker thread that uploads log-capture bundles off the collection loop.
+
+The agent has two pre-existing transport paths that both block something:
+  - /collect runs on the Synchronizer thread (drains the metric queue),
+  - /packages POSTs synchronously on the MAIN collection loop (blocks the tick).
+
+A log bundle is larger and triggered during incidents, exactly when the host is
+already unhappy. Posting it on either path would stall metric collection (and the
+systemd watchdog) or the /collect+config sync. So log uploads get their OWN thread
+and their OWN bounded queue:
+
+    main thread            log_queue (bounded)        LogUploader thread
+    capture_id nonce  -->  [job, job, ...]      -->   build_fn(job) -> send_fn(bundle)
+    enqueues a JOB         drop-oldest, logged        journalctl + redact + digest, POST /logs
+
+build_fn(job) runs the capture (Brique A: bounded retroactive journalctl, redaction,
+enriched digest) and returns a bundle dict, or None to skip (capture failed / nothing
+to send). send_fn(bundle) POSTs to /logs and returns truthy on success.
+
+Each job is fully isolated: a build or send failure logs and moves on, never killing
+the thread or starving later jobs.
+"""
+
+from threading import Event, Thread
+
+from fivenines_agent.debug import log
+
+
+class LogUploader(Thread):
+    def __init__(self, queue, build_fn, send_fn):
+        Thread.__init__(self)
+        self._stop_event = Event()
+        self.queue = queue
+        self.build_fn = build_fn
+        self.send_fn = send_fn
+
+    def run(self):
+        while not self._stop_event.is_set():
+            job = self.queue.get()
+            try:
+                # None is the shutdown sentinel pushed by Agent._cleanup, mirroring
+                # the Synchronizer drain. Break before doing any work.
+                if job is None:
+                    break
+                self._process(job)
+            finally:
+                self.queue.task_done()
+
+    def _process(self, job):
+        # Per-job isolation: one bad capture must not kill the uploader thread
+        # (registry-collector-needs-per-item-isolation learning, applied to the
+        # async path).
+        try:
+            bundle = self.build_fn(job)
+        except Exception as e:
+            log(f"LogUploader: capture build failed for {job!r}: {e}", "error")
+            return
+        if bundle is None:
+            log("LogUploader: capture produced no bundle, skipping", "debug")
+            return
+        try:
+            if self.send_fn(bundle):
+                log("LogUploader: bundle uploaded", "info")
+            else:
+                log("LogUploader: bundle upload failed, dropping", "error")
+        except Exception as e:
+            log(f"LogUploader: send failed: {e}", "error")
+
+    def stop(self):
+        self._stop_event.set()

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -1,0 +1,21 @@
+"""Log signal collection (Brique C) and incident capture (Brique A).
+
+The Brique A capture (retroactive `journalctl` slice WITH a timeout, secret/PII
+redaction, enriched digest) is implemented in a follow-up chunk. `build_capture_bundle`
+is the seam the LogUploader thread calls per capture job; it returns the bundle dict
+(echoing job["capture_id"] for the /logs ack) or None to skip.
+
+For now it returns None so the transport + nonce plumbing ships and is tested
+independently of journald.
+"""
+
+from fivenines_agent.debug import log
+
+
+def build_capture_bundle(job):
+    # TODO(brique-a): journalctl -u <job['unit']> --since <job['since']> with a
+    # subprocess timeout (timeout-the-data-path learning), redact secrets/PII,
+    # build the enriched digest (counts + redacted excerpts), cap at
+    # job['max_bytes'], and return the bundle echoing job['capture_id'].
+    log(f"build_capture_bundle: not yet implemented for {job!r}", "debug")
+    return None

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -297,6 +297,7 @@ def build_capture_bundle(job, _entries_fn=_capture_entries):
 _SIGNAL_LINES = 5000  # upper bound of journal entries scanned per unit per tick
 _SIGNAL_TIMEOUT = 5  # signals scan a small window; short timeout avoids the
 # watchdog risk of N units x 30s on the collection loop at a low incident interval.
+_DEFAULT_WINDOW_S = 60  # signal window fallback when the backend sends no/invalid value
 _TOP_FINGERPRINTS = 20
 
 
@@ -353,7 +354,7 @@ def collect_log_signals(
     """
     window = signal_interval_s
     if isinstance(window, bool) or not isinstance(window, (int, float)) or window <= 0:
-        window = 60
+        window = _DEFAULT_WINDOW_S
     if not enabled:
         return {"window_s": window, "units": {}}
     since = int(_now()) - int(window)

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -159,6 +159,63 @@ def _since_arg(since):
     return None
 
 
+# Multiline assembly (E3): stdout-captured services log stack traces one line
+# per journal entry, so without assembly one crash fans out into N fingerprints
+# (inflated counts, diluted top-N, false "new errors"). Group continuation
+# lines with the entry that started them BEFORE fingerprinting. Conservative,
+# promtail-style heuristics: indented lines and known chain markers continue a
+# group; a Python traceback header additionally absorbs its final unindented
+# exception line. Native journal-protocol apps (multiline in one MESSAGE) are
+# unaffected.
+_MAX_ASSEMBLED_LINES = 50  # cap text growth per group; grouping continues past it
+_TRACEBACK_HEADER = "Traceback (most recent call last):"
+_CONTINUATION_PREFIXES = (
+    "Caused by:",  # Java chained exceptions
+    "Suppressed:",  # Java try-with-resources
+    "During handling of the above exception",  # Python chained exceptions
+)
+
+
+def _is_continuation(message):
+    return message.startswith((" ", "\t")) or message.startswith(_CONTINUATION_PREFIXES)
+
+
+def assemble_multiline(entries):
+    """Group line-per-entry stack traces into single logical entries.
+
+    Returns entries in the same {priority, message} shape; a group keeps the
+    worst severity seen across its lines and joins messages with newlines
+    (text capped at _MAX_ASSEMBLED_LINES; grouping itself never stops, so an
+    oversized trace still yields ONE entry with a deterministic fingerprint).
+    """
+    assembled = []
+    line_counts = []
+    open_traceback = False  # awaiting the final unindented exception line
+    for e in entries:
+        message = e.get("message") or ""
+        if assembled:
+            cont = _is_continuation(message)
+            terminator = open_traceback and not cont
+            if cont or terminator:
+                group = assembled[-1]
+                if line_counts[-1] < _MAX_ASSEMBLED_LINES:
+                    group["message"] = group["message"] + "\n" + message
+                line_counts[-1] += 1
+                new_sev = severity_from_priority(e.get("priority"))
+                if (
+                    _SEVERITY_RANK[new_sev]
+                    > _SEVERITY_RANK[severity_from_priority(group.get("priority"))]
+                ):
+                    group["priority"] = e.get("priority")
+                if terminator:
+                    open_traceback = False
+                continue
+        assembled.append({"priority": e.get("priority"), "message": message})
+        line_counts.append(1)
+        open_traceback = message.startswith(_TRACEBACK_HEADER)
+    return assembled
+
+
 def _capture_entries(unit, since, lines, timeout=_CAPTURE_TIMEOUT):
     """Run a bounded journalctl slice. Returns a list of entries on success
     (possibly empty), or None on failure (timeout / non-zero exit / error)."""
@@ -201,7 +258,9 @@ def _capture_entries(unit, since, lines, timeout=_CAPTURE_TIMEOUT):
         if not isinstance(message, str) or not message:
             continue
         entries.append({"priority": obj.get("PRIORITY"), "message": message})
-    return entries
+    # Single-source multiline assembly BEFORE any fingerprinting: both consumers
+    # (Brique C signals and Brique A capture digests) read this seam.
+    return assemble_multiline(entries)
 
 
 def build_capture_bundle(job, _entries_fn=_capture_entries):

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -1,21 +1,217 @@
-"""Log signal collection (Brique C) and incident capture (Brique A).
+"""Incident log capture (Brique A): retroactive journald slice -> enriched digest.
 
-The Brique A capture (retroactive `journalctl` slice WITH a timeout, secret/PII
-redaction, enriched digest) is implemented in a follow-up chunk. `build_capture_bundle`
-is the seam the LogUploader thread calls per capture job; it returns the bundle dict
-(echoing job["capture_id"] for the /logs ack) or None to skip.
+The LogUploader thread calls build_capture_bundle(job) per capture command. It
+runs a bounded `journalctl` slice (WITH a subprocess timeout - a wedged journalctl
+would otherwise hang the worker - and get_clean_env() to avoid the PyInstaller
+LD_LIBRARY_PATH conflicts), then turns it into an LLM-oriented enriched digest:
+per-severity counts plus, per error fingerprint, a redacted representative excerpt.
 
-For now it returns None so the transport + nonce plumbing ships and is tested
-independently of journald.
+V1 posture is "digest": raw lines never leave the box, only redacted excerpts.
+Raw opt-in is a follow-up. Redaction is best-effort (it will miss novel secret
+formats); the digest default is the mitigation.
+
+    journalctl -u <unit> --since @<epoch> -o json   (timeout, clean env)
+          |  entries [{priority, message}]
+          v
+    build_digest: counts by severity + group by fingerprint(masked) + redact excerpt
+          |
+          v
+    bundle {capture_id (ack), unit, posture, truncated, redaction, digest, raw=None}
 """
 
+import hashlib
+import json
+import re
+import subprocess
+
 from fivenines_agent.debug import log
+from fivenines_agent.subprocess_utils import get_clean_env
+
+_CAPTURE_TIMEOUT = 30  # seconds; matches packages.py (timeout-the-data-path)
+_DEFAULT_LINES = 1000
+_MAX_FINGERPRINTS = 50
+_MAX_EXCERPT = 500
+REDACTION_VERSION = 1
+
+_SEVERITY_RANK = {"info": 0, "warn": 1, "error": 2}
+
+# Best-effort secret/PII redaction. Order matters: structured secrets before the
+# generic key=value rule. Documented as best-effort - it WILL miss novel formats.
+_REDACTIONS = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "[REDACTED_PRIVATE_KEY]"),
+    (
+        re.compile(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        "[REDACTED_JWT]",
+    ),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED_AWS_KEY]"),
+    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+"), "Bearer [REDACTED]"),
+    # password inside a connection string user:pass@host
+    (re.compile(r"(\w+://[^:@\s/]+:)[^@\s/]+(@)"), r"\1[REDACTED]\2"),
+    # generic secret assignment: key=value / key: value
+    (
+        re.compile(
+            r"(?i)\b(password|passwd|pwd|secret|token|api[_-]?key|apikey|"
+            r"access[_-]?key|authorization)\b\s*[=:]\s*\"?'?[^\s\"']+"
+        ),
+        r"\1=[REDACTED]",
+    ),
+    (
+        re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"),
+        "[REDACTED_EMAIL]",
+    ),
+]
+
+# Fingerprint masking: collapse volatile tokens so the same error template hashes
+# to one fingerprint regardless of ids/numbers. Order: structured before numbers.
+_MASKS = [
+    (
+        re.compile(
+            r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+        ),
+        "<UUID>",
+    ),
+    (re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b"), "<IP>"),
+    (re.compile(r"0x[0-9a-fA-F]+"), "<HEX>"),
+    (re.compile(r"\b[0-9a-fA-F]{16,}\b"), "<HEX>"),
+    # Any digit run, even when glued to a unit (30s, 5ms), so the same error
+    # template collapses to one fingerprint regardless of the number.
+    (re.compile(r"\d+"), "<N>"),
+]
 
 
-def build_capture_bundle(job):
-    # TODO(brique-a): journalctl -u <job['unit']> --since <job['since']> with a
-    # subprocess timeout (timeout-the-data-path learning), redact secrets/PII,
-    # build the enriched digest (counts + redacted excerpts), cap at
-    # job['max_bytes'], and return the bundle echoing job['capture_id'].
-    log(f"build_capture_bundle: not yet implemented for {job!r}", "debug")
+def redact(text):
+    """Best-effort secret/PII redaction on a single log line."""
+    for pattern, repl in _REDACTIONS:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def fingerprint(message):
+    """Stable fingerprint of an error template (volatile tokens masked, then hashed)."""
+    masked = message
+    for pattern, repl in _MASKS:
+        masked = pattern.sub(repl, masked)
+    return hashlib.sha256(masked.encode("utf-8")).hexdigest()[:12]
+
+
+def severity_from_priority(priority):
+    """Map a journald PRIORITY (0-7, may be a string) to error/warn/info."""
+    try:
+        p = int(priority)
+    except (TypeError, ValueError):
+        return "info"
+    if p <= 3:
+        return "error"
+    if p == 4:
+        return "warn"
+    return "info"
+
+
+def build_digest(entries):
+    """Turn journal entries into the enriched digest. Returns (digest, truncated)."""
+    counts = {"error": 0, "warn": 0, "info": 0}
+    groups = {}
+    order = []
+    for e in entries:
+        sev = severity_from_priority(e.get("priority"))
+        counts[sev] += 1
+        message = e.get("message") or ""
+        fp = fingerprint(message)
+        group = groups.get(fp)
+        if group is None:
+            groups[fp] = {"count": 1, "severity": sev, "message": message}
+            order.append(fp)
+        else:
+            group["count"] += 1
+            if _SEVERITY_RANK[sev] > _SEVERITY_RANK[group["severity"]]:
+                group["severity"] = sev
+    ranked = sorted(order, key=lambda fp: groups[fp]["count"], reverse=True)
+    truncated = len(ranked) > _MAX_FINGERPRINTS
+    fingerprints = [
+        {
+            "fp": fp,
+            "count": groups[fp]["count"],
+            "severity": groups[fp]["severity"],
+            "excerpt": redact(groups[fp]["message"])[:_MAX_EXCERPT],
+        }
+        for fp in ranked[:_MAX_FINGERPRINTS]
+    ]
+    return {"counts": counts, "fingerprints": fingerprints}, truncated
+
+
+def _since_arg(since):
+    """journalctl --since value: epoch seconds become @<epoch>, else passed through."""
+    if isinstance(since, bool):
+        return None
+    if isinstance(since, (int, float)):
+        return f"@{int(since)}"
+    if isinstance(since, str) and since:
+        return since
     return None
+
+
+def _capture_entries(unit, since, lines, timeout=_CAPTURE_TIMEOUT):
+    """Run a bounded journalctl slice. Returns a list of entries on success
+    (possibly empty), or None on failure (timeout / non-zero exit / error)."""
+    cmd = ["journalctl", "-u", str(unit), "-o", "json", "-n", str(int(lines))]
+    since_arg = _since_arg(since)
+    if since_arg is not None:
+        cmd += ["--since", since_arg]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, env=get_clean_env()
+        )
+    except subprocess.TimeoutExpired:
+        log(f"journalctl capture timed out for {unit!r}", "error")
+        return None
+    except Exception as e:
+        log(f"journalctl capture failed for {unit!r}: {e}", "error")
+        return None
+    if result.returncode != 0:
+        log(f"journalctl capture rc={result.returncode}: {result.stderr}", "error")
+        return None
+    entries = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        message = obj.get("MESSAGE")
+        if not isinstance(message, str):
+            continue  # binary/array MESSAGE: skip (best-effort)
+        entries.append({"priority": obj.get("PRIORITY"), "message": message})
+    return entries
+
+
+def build_capture_bundle(job, _entries_fn=_capture_entries):
+    """Build the /logs bundle for one capture job, or None to skip.
+
+    Returns None only on capture FAILURE (timeout/error), so the backend re-issues
+    after expiry. An empty journal window still returns a bundle (with an empty
+    digest) so the capture_id ack closes the loop.
+    """
+    unit = job.get("unit")
+    entries = _entries_fn(unit, job.get("since"), job.get("lines") or _DEFAULT_LINES)
+    if entries is None:
+        log(f"build_capture_bundle: capture failed for {unit!r}, no bundle", "error")
+        return None
+    digest, truncated = build_digest(entries)
+    return {
+        "capture_id": job.get("capture_id"),
+        "unit": unit,
+        "since": job.get("since"),
+        "posture": "digest",
+        "truncated": truncated,
+        "redaction": {
+            "version": REDACTION_VERSION,
+            "applied": True,
+            "best_effort": True,
+        },
+        "digest": digest,
+        "raw": None,
+    }

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -30,6 +30,12 @@ from fivenines_agent.subprocess_utils import get_clean_env
 
 _CAPTURE_TIMEOUT = 30  # seconds; matches packages.py (timeout-the-data-path)
 _DEFAULT_LINES = 1000
+# Hard agent-side ceiling on captured lines, independent of the backend-supplied
+# `lines`. journalctl buffers the whole slice in RAM before any digest
+# truncation, so an unbounded backend value (a huge -n over an ancient --since)
+# would be a one-request OOM. The backend is trusted-but-verify: enforce our own
+# resource bound regardless of what it asks for.
+_MAX_CAPTURE_LINES = 10000
 _MAX_FINGERPRINTS = 50
 _MAX_EXCERPT = 500
 REDACTION_VERSION = 1
@@ -60,6 +66,10 @@ _REDACTIONS = [
         re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"),
         "[REDACTED_EMAIL]",
     ),
+    # Long opaque base64/hex run (>=40 chars): PEM key bodies, API tokens, hashes,
+    # session blobs. Higher threshold than the fingerprint mask so readable
+    # excerpts are not over-redacted.
+    (re.compile(r"[A-Za-z0-9+/]{40,}={0,2}"), "[REDACTED_BLOB]"),
 ]
 
 # Fingerprint masking: collapse volatile tokens so the same error template hashes
@@ -96,8 +106,15 @@ def redact(text):
 
 
 def fingerprint(message):
-    """Stable fingerprint of an error template (volatile tokens masked, then hashed)."""
-    masked = message
+    """Stable fingerprint of an error template.
+
+    Redact FIRST, then mask volatile tokens, then hash. Redacting first collapses
+    per-occurrence secrets/PII (emails, tokens, opaque blobs) to constant markers,
+    so the same error template with different secret values fingerprints
+    identically instead of fragmenting recurrence/top-N counts (which matters most
+    during an incident, when those values churn).
+    """
+    masked = redact(message)
     for pattern, repl in _MASKS:
         masked = pattern.sub(repl, masked)
     return hashlib.sha256(masked.encode("utf-8")).hexdigest()[:12]
@@ -219,7 +236,14 @@ def assemble_multiline(entries):
 def _capture_entries(unit, since, lines, timeout=_CAPTURE_TIMEOUT):
     """Run a bounded journalctl slice. Returns a list of entries on success
     (possibly empty), or None on failure (timeout / non-zero exit / error)."""
-    cmd = ["journalctl", "-u", str(unit), "-o", "json", "-n", str(int(lines))]
+    # Clamp lines to a hard agent ceiling: `lines` is backend-supplied and
+    # journalctl buffers the whole slice in RAM, so an unbounded value is an OOM
+    # DoS. A non-numeric value falls back to the default rather than raising.
+    try:
+        capped_lines = min(int(lines), _MAX_CAPTURE_LINES)
+    except (TypeError, ValueError):
+        capped_lines = _DEFAULT_LINES
+    cmd = ["journalctl", "-u", str(unit), "-o", "json", "-n", str(capped_lines)]
     since_arg = _since_arg(since)
     if since_arg is not None:
         cmd += ["--since", since_arg]
@@ -298,6 +322,11 @@ _SIGNAL_LINES = 5000  # upper bound of journal entries scanned per unit per tick
 _SIGNAL_TIMEOUT = 5  # signals scan a small window; short timeout avoids the
 # watchdog risk of N units x 30s on the collection loop at a low incident interval.
 _DEFAULT_WINDOW_S = 60  # signal window fallback when the backend sends no/invalid value
+# Hard cap on units scanned for signals per tick. Each unit runs one journalctl
+# (up to _SIGNAL_TIMEOUT) sequentially on the main collection loop, so an
+# oversized backend allowlist could exceed WatchdogSec (90s) and self-trigger a
+# restart loop. _MAX_SIGNAL_UNITS x _SIGNAL_TIMEOUT stays well under the watchdog.
+_MAX_SIGNAL_UNITS = 12
 _TOP_FINGERPRINTS = 20
 
 
@@ -337,6 +366,20 @@ def _signals_for_unit(entries):
     }
 
 
+_signal_units_capped_warned = False
+
+
+def _warn_units_capped_once(total):
+    global _signal_units_capped_warned
+    if not _signal_units_capped_warned:
+        log(
+            f"log signals: allowlist has {total} units, scanning only the first "
+            f"{_MAX_SIGNAL_UNITS}/tick to stay under the systemd watchdog",
+            "error",
+        )
+        _signal_units_capped_warned = True
+
+
 def collect_log_signals(
     units=None,
     signal_interval_s=None,
@@ -359,7 +402,10 @@ def collect_log_signals(
         return {"window_s": window, "units": {}}
     since = int(_now()) - int(window)
     result = {"window_s": window, "units": {}}
-    for unit in units or []:
+    all_units = units or []
+    if len(all_units) > _MAX_SIGNAL_UNITS:
+        _warn_units_capped_once(len(all_units))
+    for unit in all_units[:_MAX_SIGNAL_UNITS]:
         try:
             entries = _entries_fn(unit, since, _SIGNAL_LINES, _SIGNAL_TIMEOUT)
             if entries is None:

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -190,8 +190,16 @@ def _capture_entries(unit, since, lines, timeout=_CAPTURE_TIMEOUT):
         if not isinstance(obj, dict):
             continue
         message = obj.get("MESSAGE")
-        if not isinstance(message, str):
-            continue  # binary/array MESSAGE: skip (best-effort)
+        if isinstance(message, list):
+            # journald emits non-UTF8 payloads as byte arrays; decode them
+            # (same handling as the systemd collector's journal tail) rather
+            # than dropping the entry.
+            try:
+                message = bytes(message).decode("utf-8", errors="replace")
+            except (TypeError, ValueError):
+                continue
+        if not isinstance(message, str) or not message:
+            continue
         entries.append({"priority": obj.get("PRIORITY"), "message": message})
     return entries
 

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -73,8 +73,15 @@ _MASKS = [
         "<UUID>",
     ),
     (re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b"), "<IP>"),
+    # IPv6: >=3 colon-separated hex groups (a HH:MM:SS time has only 2 colons,
+    # so it is not matched here; its digits collapse via the \d+ rule below).
+    (re.compile(r"(?:[0-9a-fA-F]{1,4}:){3,}[0-9a-fA-F]{0,4}"), "<IP>"),
     (re.compile(r"0x[0-9a-fA-F]+"), "<HEX>"),
     (re.compile(r"\b[0-9a-fA-F]{16,}\b"), "<HEX>"),
+    # base64 / opaque token: >=20 base64 chars containing at least one digit.
+    # The digit lookahead skips long plain-letter identifiers (class names,
+    # method paths) so distinct errors are not over-collapsed into one fp.
+    (re.compile(r"(?=[A-Za-z0-9+/]*\d)[A-Za-z0-9+/]{20,}={0,2}"), "<B64>"),
     # Any digit run, even when glued to a unit (30s, 5ms), so the same error
     # template collapses to one fingerprint regardless of the number.
     (re.compile(r"\d+"), "<N>"),
@@ -221,6 +228,8 @@ def build_capture_bundle(job, _entries_fn=_capture_entries):
 # --- Brique C: continuous per-tick log signals (error/warn rate + fingerprints) ---
 
 _SIGNAL_LINES = 5000  # upper bound of journal entries scanned per unit per tick
+_SIGNAL_TIMEOUT = 5  # signals scan a small window; short timeout avoids the
+# watchdog risk of N units x 30s on the collection loop at a low incident interval.
 _TOP_FINGERPRINTS = 20
 
 
@@ -284,7 +293,7 @@ def collect_log_signals(
     result = {"window_s": window, "units": {}}
     for unit in units or []:
         try:
-            entries = _entries_fn(unit, since, _SIGNAL_LINES)
+            entries = _entries_fn(unit, since, _SIGNAL_LINES, _SIGNAL_TIMEOUT)
             if entries is None:
                 continue  # capture failed for this unit; skip, others still run
             result["units"][unit] = _signals_for_unit(entries)

--- a/fivenines_agent/logs.py
+++ b/fivenines_agent/logs.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import re
 import subprocess
+import time
 
 from fivenines_agent.debug import log
 from fivenines_agent.subprocess_utils import get_clean_env
@@ -215,3 +216,78 @@ def build_capture_bundle(job, _entries_fn=_capture_entries):
         "digest": digest,
         "raw": None,
     }
+
+
+# --- Brique C: continuous per-tick log signals (error/warn rate + fingerprints) ---
+
+_SIGNAL_LINES = 5000  # upper bound of journal entries scanned per unit per tick
+_TOP_FINGERPRINTS = 20
+
+
+def _signals_for_unit(entries):
+    """error/warn rate + top redacted fingerprints for one unit's window."""
+    counts = {"error": 0, "warn": 0}
+    groups = {}
+    order = []
+    for e in entries:
+        sev = severity_from_priority(e.get("priority"))
+        if sev not in counts:
+            continue  # signals track error/warn only; info is dropped for size
+        counts[sev] += 1
+        message = e.get("message") or ""
+        fp = fingerprint(message)
+        group = groups.get(fp)
+        if group is None:
+            groups[fp] = {"count": 1, "severity": sev, "message": message}
+            order.append(fp)
+        else:
+            group["count"] += 1
+            if _SEVERITY_RANK[sev] > _SEVERITY_RANK[group["severity"]]:
+                group["severity"] = sev
+    ranked = sorted(order, key=lambda fp: groups[fp]["count"], reverse=True)
+    return {
+        "error_rate": counts["error"],
+        "warn_rate": counts["warn"],
+        "fingerprints": [
+            {
+                "fp": fp,
+                "count": groups[fp]["count"],
+                "severity": groups[fp]["severity"],
+                "sample": redact(groups[fp]["message"])[:_MAX_EXCERPT],
+            }
+            for fp in ranked[:_TOP_FINGERPRINTS]
+        ],
+    }
+
+
+def collect_log_signals(
+    units=None,
+    signal_interval_s=None,
+    enabled=True,
+    _entries_fn=_capture_entries,
+    _now=time.time,
+    **kwargs,
+):
+    """Brique C: per-tick, per-unit error/warn rates + top fingerprints.
+
+    Stateless on purpose: it reports the fingerprints + counts for the last
+    window; the backend derives new-vs-recurring from its own cross-tick history
+    (the agent stays dumb). Each unit is isolated so one bad unit never blanks the
+    others (registry-collector-needs-per-item-isolation).
+    """
+    window = signal_interval_s
+    if isinstance(window, bool) or not isinstance(window, (int, float)) or window <= 0:
+        window = 60
+    if not enabled:
+        return {"window_s": window, "units": {}}
+    since = int(_now()) - int(window)
+    result = {"window_s": window, "units": {}}
+    for unit in units or []:
+        try:
+            entries = _entries_fn(unit, since, _SIGNAL_LINES)
+            if entries is None:
+                continue  # capture failed for this unit; skip, others still run
+            result["units"][unit] = _signals_for_unit(entries)
+        except Exception as e:
+            log(f"log signals failed for {unit!r}: {e}", "error")
+    return result

--- a/fivenines_agent/permissions.py
+++ b/fivenines_agent/permissions.py
@@ -47,6 +47,7 @@ CAPABILITY_HINTS = {
     "temperatures": "no accessible sensors",
     "fans": "no accessible sensors",
     "snmp": "requires net-snmp",
+    "journald": "requires systemd-journal group",
     "disk_health": "requires WMI Storage namespace access",
     "software_inventory": "requires Uninstall registry key access",
 }
@@ -60,6 +61,7 @@ LINUX_BANNER_GROUPS = [
     ("Services", ["docker", "qemu", "proxmox"]),
     ("Security", ["fail2ban", "packages"]),
     ("Networking", ["snmp"]),
+    ("Logs", ["journald"]),
 ]
 
 WINDOWS_BANNER_GROUPS = [
@@ -192,6 +194,8 @@ class PermissionProbe:
             "packages": (self._can_list_packages, ()),
             # SNMP polling - needs net-snmp CLI tools
             "snmp": (self._has_snmpget, ()),
+            # Log monitoring - needs journald read access (systemd-journal group)
+            "journald": (self._can_read_journal, ()),
         }
 
     def _build_linux_capabilities(self):
@@ -567,6 +571,41 @@ class PermissionProbe:
                 f"{docker_socket} not accessible (readable={readable}, writable={writable})"
             )
         return accessible
+
+    def _can_read_journal(self):
+        """Probe journald read access the way the log collector reads it: a
+        trivial `journalctl -n 0`. True means the agent (which runs as the
+        unprivileged fivenines user) can actually read the journal - in practice
+        that requires systemd-journal group membership. Mirroring the real read
+        avoids guessing about file modes or persistent-vs-volatile storage."""
+        journalctl = shutil.which("journalctl")
+        if not journalctl:
+            log("_can_read_journal: journalctl not found", "debug")
+            self._set_reason("journalctl not found in PATH")
+            return False
+        try:
+            result = subprocess.run(
+                [journalctl, "-n", "0", "--quiet"],
+                capture_output=True,
+                timeout=5,
+                env=get_clean_env(),
+            )
+        except subprocess.TimeoutExpired:
+            log("_can_read_journal: journalctl timed out", "debug")
+            self._set_reason("journalctl timed out")
+            return False
+        except Exception as e:
+            log(f"_can_read_journal: {type(e).__name__}: {e}", "debug")
+            self._set_reason(f"{type(e).__name__}: {e}")
+            return False
+        ok = result.returncode == 0
+        log(
+            f"_can_read_journal: rc={result.returncode} -> {'OK' if ok else 'NO'}",
+            "debug",
+        )
+        if not ok:
+            self._set_reason("journalctl non-zero exit (systemd-journal group?)")
+        return ok
 
     def _can_access_libvirt(self):
         """Probe QEMU/libvirt the way the collector connects: attempt

--- a/fivenines_agent/synchronizer.py
+++ b/fivenines_agent/synchronizer.py
@@ -121,6 +121,16 @@ class Synchronizer(Thread):
         """Send packages data to /packages. Returns response or None."""
         return self._post("/packages", packages_data)
 
+    def send_logs(self, bundle):
+        """Send a log-capture bundle to /logs. Returns response or None.
+
+        Mirrors send_packages: gzip + auth + bounded retries via _post. Called
+        from the dedicated LogUploader thread (not the collection loop or the
+        /collect synchronizer drain), so a slow/large upload never blocks metric
+        collection or config sync.
+        """
+        return self._post("/logs", bundle)
+
     def get_conn(self):
         url = api_url()
         if not url.startswith("localhost"):

--- a/fivenines_agent/systemd.py
+++ b/fivenines_agent/systemd.py
@@ -53,6 +53,7 @@ from fivenines_agent.cgroup import detect_hierarchy, read_unit_resources
 from fivenines_agent.cgroup import reset_cache as cgroup_reset_cache
 from fivenines_agent.debug import debug, log
 from fivenines_agent.env import dry_run
+from fivenines_agent.logs import redact
 from fivenines_agent.subprocess_utils import get_clean_env
 
 # Subprocess timeouts (seconds)
@@ -493,8 +494,13 @@ def _parse_journalctl_failed(stdout):
             except (TypeError, ValueError):
                 msg = ""
         if msg:
+            # Journal tails ship in the /collect payload, so scrub secrets/PII
+            # with the same best-effort redaction as the log-monitoring digests
+            # (an error line often embeds the credential that caused the
+            # failure). Redact BEFORE truncating: truncating first could split
+            # a token and let the remainder slip past the patterns.
             # Payload bound: journald's LineMax default is 48K per line.
-            messages.append(msg[:JOURNAL_MSG_MAX_CHARS])
+            messages.append(redact(msg)[:JOURNAL_MSG_MAX_CHARS])
     return messages
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.10.0"
+version = "1.10.1"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/test_agent_capture.py
+++ b/tests/test_agent_capture.py
@@ -56,3 +56,25 @@ def test_handle_capture_refuses_unit_outside_allowlist(tmp_path):
     agent = _agent(tmp_path, uploader=MagicMock())
     agent._handle_capture_request(_cfg(unit="secret.service"))  # default-deny
     assert agent.log_queue.qsize() == 0
+
+
+def test_cleanup_stops_uploader_with_sentinel_then_join(tmp_path):
+    """_cleanup must stop the uploader thread: stop(), push the None sentinel
+    (unblocks the queue.get), then join. A wrong order would hang agent exit."""
+    import pytest
+
+    from fivenines_agent.agent import Agent as _Agent
+
+    agent = _Agent.__new__(_Agent)
+    agent.queue = MagicMock()
+    agent.synchronizer = None
+    agent.log_uploader = MagicMock()
+    agent.log_queue = MagicMock()
+
+    with pytest.raises(SystemExit) as exc_info:
+        agent._cleanup()
+
+    assert exc_info.value.code == 0
+    agent.log_uploader.stop.assert_called_once()
+    agent.log_queue.put.assert_called_once_with(None)
+    agent.log_uploader.join.assert_called_once()

--- a/tests/test_agent_capture.py
+++ b/tests/test_agent_capture.py
@@ -1,0 +1,58 @@
+"""Tests for the incident log-capture wiring in Agent (_handle_capture_request).
+
+The nonce + persistence + allowlist live in CaptureCoordinator (see
+test_log_capture); this checks the thin Agent glue: no-op when uploading is
+disabled, enqueue once when a new capture command fires, no duplicate on replay.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# libvirt-python cannot build on macOS; mock it before importing the agent
+# (mirrors test_agent_recheck). The other service libs install normally.
+sys.modules.setdefault("libvirt", MagicMock())
+
+from fivenines_agent.agent import Agent  # noqa: E402
+from fivenines_agent.log_capture import CaptureCoordinator  # noqa: E402
+from fivenines_agent.synchronization_queue import SynchronizationQueue  # noqa: E402
+
+
+def _agent(tmp_path, uploader):
+    agent = Agent.__new__(Agent)
+    agent.log_uploader = uploader
+    agent.log_queue = SynchronizationQueue(maxsize=10)
+    agent.capture_coordinator = CaptureCoordinator(str(tmp_path / "last_capture_id"))
+    return agent
+
+
+def _cfg(capture_id="id-1", unit="nginx.service"):
+    return {
+        "logs": {"units": ["nginx.service"]},
+        "capture_logs": {"capture_id": capture_id, "unit": unit, "since": 1000},
+    }
+
+
+def test_handle_capture_noop_when_uploader_disabled(tmp_path):
+    agent = _agent(tmp_path, uploader=None)
+    agent._handle_capture_request(_cfg())  # valid command, but no uploader
+    assert agent.log_queue.qsize() == 0
+
+
+def test_handle_capture_enqueues_on_new_command(tmp_path):
+    agent = _agent(tmp_path, uploader=MagicMock())
+    agent._handle_capture_request(_cfg())
+    assert agent.log_queue.qsize() == 1
+    assert agent.log_queue.get_nowait()["capture_id"] == "id-1"
+
+
+def test_handle_capture_no_duplicate_on_replay(tmp_path):
+    agent = _agent(tmp_path, uploader=MagicMock())
+    agent._handle_capture_request(_cfg())
+    agent._handle_capture_request(_cfg())  # same capture_id -> replay guard
+    assert agent.log_queue.qsize() == 1
+
+
+def test_handle_capture_refuses_unit_outside_allowlist(tmp_path):
+    agent = _agent(tmp_path, uploader=MagicMock())
+    agent._handle_capture_request(_cfg(unit="secret.service"))  # default-deny
+    assert agent.log_queue.qsize() == 0

--- a/tests/test_agent_dry_run.py
+++ b/tests/test_agent_dry_run.py
@@ -23,6 +23,7 @@ def make_dry_run_agent():
     synchronizer is None, config will be set from _DRY_RUN_CONFIG in run()."""
     agent = Agent.__new__(Agent)
     agent.synchronizer = None
+    agent.log_uploader = None
     agent.permissions = MagicMock()
     agent.permissions.get_all.return_value = {}
     agent.permissions.refresh_due.return_value = False

--- a/tests/test_agent_watchdog.py
+++ b/tests/test_agent_watchdog.py
@@ -17,6 +17,7 @@ def make_agent():
     agent = Agent.__new__(Agent)
     agent.config = {"enabled": True, "interval": 60}
     agent.synchronizer = MagicMock()
+    agent.log_uploader = None
     agent.permissions = MagicMock()
     agent.permissions.get_all.return_value = {}
     agent.permissions.refresh_due.return_value = False

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -297,6 +297,21 @@ def test_capability_overrides_raid_storage():
     mock_fn.assert_not_called()
 
 
+def test_capability_overrides_logs_journald():
+    """logs config gates on the journald capability (not a 'logs' capability)."""
+    _reset_skip_log()
+    mock_fn = MagicMock(return_value="x")
+    registry = [("logs", [("logs", mock_fn, True)])]
+    config = {"logs": {"units": ["nginx.service"]}}
+    permissions = {"journald": False}
+    data = {}
+
+    with patch("fivenines_agent.collectors.COLLECTORS", registry):
+        collect_metrics(config, data, permissions=permissions)
+
+    mock_fn.assert_not_called()
+
+
 def test_skip_logged_only_once_per_process():
     """Subsequent skipped invocations do not re-log."""
     _reset_skip_log()

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -20,6 +20,7 @@ def test_registry_has_expected_config_keys():
         "network",
         "partitions",
         "io",
+        "logs",
         "smart_storage_health",
         "raid_storage_health",
         "processes",

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -34,9 +34,12 @@ def test_new_capture_fires_and_returns_job(tmp_path):
     }
 
 
-def test_fire_persists_capture_id(tmp_path):
+def test_evaluate_does_not_persist_mark_uploaded_does(tmp_path):
     path = os.path.join(str(tmp_path), "last_capture_id")
-    CaptureCoordinator(path).evaluate(_cmd(), ALLOW)
+    c = CaptureCoordinator(path)
+    c.evaluate(_cmd(), ALLOW)
+    assert not os.path.exists(path)  # in flight, not yet served
+    c.mark_uploaded("id-1")
     with open(path) as f:
         assert f.read() == "id-1"
 
@@ -44,7 +47,7 @@ def test_fire_persists_capture_id(tmp_path):
 def test_same_capture_id_does_not_refire(tmp_path):
     c = _coord(tmp_path)
     assert c.evaluate(_cmd(), ALLOW) is not None
-    assert c.evaluate(_cmd(), ALLOW) is None  # replay guard
+    assert c.evaluate(_cmd(), ALLOW) is None  # blocked while in flight
 
 
 def test_absent_or_empty_capture_id_is_noop(tmp_path):
@@ -85,18 +88,43 @@ def test_bool_expiry_is_ignored(tmp_path):
 
 def test_persistence_survives_restart(tmp_path):
     path = os.path.join(str(tmp_path), "last_capture_id")
-    CaptureCoordinator(path).evaluate(_cmd(), ALLOW)  # serves id-1, persists
+    c = CaptureCoordinator(path)
+    c.evaluate(_cmd(), ALLOW)
+    c.mark_uploaded("id-1")  # only an uploaded capture persists as served
     # "restart": a fresh coordinator loads the persisted id and must not replay.
     fresh = CaptureCoordinator(path)
     assert fresh.evaluate(_cmd(), ALLOW) is None
 
 
-def test_persist_failure_still_returns_job(tmp_path):
+def test_persist_failure_in_mark_uploaded_is_best_effort(tmp_path):
     # state_path under a nonexistent dir -> write raises -> caught best-effort.
     bad = os.path.join(str(tmp_path), "missing", "last_capture_id")
     c = CaptureCoordinator(bad)
-    assert c.evaluate(_cmd(), ALLOW) is not None  # capture still proceeds
-    assert c.evaluate(_cmd(), ALLOW) is None  # in-memory guard still holds
+    assert c.evaluate(_cmd(), ALLOW) is not None  # fires (in flight)
+    c.mark_uploaded("id-1")  # persist raises -> caught; in-memory served holds
+    assert c.evaluate(_cmd(), ALLOW) is None  # last_served guard (in-memory)
+
+
+def test_mark_failed_releases_for_retry(tmp_path):
+    c = _coord(tmp_path)
+    assert c.evaluate(_cmd(), ALLOW) is not None  # in flight
+    assert c.evaluate(_cmd(), ALLOW) is None  # blocked while in flight
+    c.mark_failed("id-1")  # upload failed -> release the slot
+    assert c.evaluate(_cmd(), ALLOW) is not None  # retried on a later tick
+
+
+def test_mark_uploaded_blocks_refire(tmp_path):
+    c = _coord(tmp_path)
+    assert c.evaluate(_cmd(), ALLOW) is not None
+    c.mark_uploaded("id-1")
+    assert c.evaluate(_cmd(), ALLOW) is None  # served, no replay
+
+
+def test_mark_helpers_ignore_empty_capture_id(tmp_path):
+    c = _coord(tmp_path)
+    c.mark_uploaded(None)  # no-op, no crash
+    c.mark_failed("")  # no-op
+    assert c.evaluate(_cmd(), ALLOW) is not None  # state untouched
 
 
 def test_load_error_when_state_path_is_dir(tmp_path):

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -127,6 +127,20 @@ def test_mark_helpers_ignore_empty_capture_id(tmp_path):
     assert c.evaluate(_cmd(), ALLOW) is not None  # state untouched
 
 
+def test_enqueue_sheds_capture_when_queue_full(tmp_path):
+    # A full bounded queue would drop-oldest silently, orphaning the dropped
+    # job's in-flight slot; instead shed the NEW capture and release its slot so
+    # it can retry (the backend re-mints after expiry) rather than leak.
+    q = SynchronizationQueue(maxsize=1)
+    q.put({"capture_id": "old"})  # queue now full
+    c = _coord(tmp_path)
+    job = evaluate_and_enqueue(c, q, {"logs": {"units": ALLOW}, "capture_logs": _cmd()})
+    assert job is None
+    assert q.qsize() == 1  # new capture not enqueued, old not evicted
+    # in-flight was released -> the same capture_id can fire again (retry)
+    assert c.evaluate(_cmd(), ALLOW) is not None
+
+
 def test_load_error_when_state_path_is_dir(tmp_path):
     # An unreadable state path (a directory) degrades to no baseline, fires once.
     d = os.path.join(str(tmp_path), "as_dir")

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -1,0 +1,147 @@
+"""Tests for the backend-pull capture coordinator (nonce + disk persistence).
+
+Pure: no Agent, no journald, no network. The coordinator owns the replay guard
+that Codex flagged (config is replaced each tick, so a command would re-fire), and
+the disk persistence that makes it survive a Restart=always restart.
+"""
+
+import os
+
+from fivenines_agent.log_capture import CaptureCoordinator, evaluate_and_enqueue
+from fivenines_agent.synchronization_queue import SynchronizationQueue
+
+ALLOW = ["nginx.service", "postgresql.service"]
+
+
+def _cmd(**over):
+    base = {"capture_id": "id-1", "unit": "nginx.service", "since": 1000, "lines": 500}
+    base.update(over)
+    return base
+
+
+def _coord(tmp_path, **kw):
+    return CaptureCoordinator(os.path.join(str(tmp_path), "last_capture_id"), **kw)
+
+
+def test_new_capture_fires_and_returns_job(tmp_path):
+    job = _coord(tmp_path).evaluate(_cmd(), ALLOW)
+    assert job == {
+        "capture_id": "id-1",
+        "unit": "nginx.service",
+        "since": 1000,
+        "lines": 500,
+        "max_bytes": None,
+    }
+
+
+def test_fire_persists_capture_id(tmp_path):
+    path = os.path.join(str(tmp_path), "last_capture_id")
+    CaptureCoordinator(path).evaluate(_cmd(), ALLOW)
+    with open(path) as f:
+        assert f.read() == "id-1"
+
+
+def test_same_capture_id_does_not_refire(tmp_path):
+    c = _coord(tmp_path)
+    assert c.evaluate(_cmd(), ALLOW) is not None
+    assert c.evaluate(_cmd(), ALLOW) is None  # replay guard
+
+
+def test_absent_or_empty_capture_id_is_noop(tmp_path):
+    c = _coord(tmp_path)
+    assert c.evaluate({"unit": "nginx.service"}, ALLOW) is None
+    assert c.evaluate(_cmd(capture_id=None), ALLOW) is None
+    assert c.evaluate(_cmd(capture_id=""), ALLOW) is None
+
+
+def test_non_dict_capture_logs_is_noop(tmp_path):
+    c = _coord(tmp_path)
+    assert c.evaluate(None, ALLOW) is None
+    assert c.evaluate("nope", ALLOW) is None
+
+
+def test_unit_not_in_allowlist_refused_and_not_persisted(tmp_path):
+    path = os.path.join(str(tmp_path), "last_capture_id")
+    c = CaptureCoordinator(path)
+    assert c.evaluate(_cmd(unit="secret.service"), ALLOW) is None
+    assert not os.path.exists(path)  # default-deny, nothing served
+
+
+def test_expired_command_is_stale(tmp_path):
+    c = _coord(tmp_path, now_fn=lambda: 2000)
+    assert c.evaluate(_cmd(expiry=1500), ALLOW) is None  # now 2000 > 1500
+
+
+def test_not_expired_command_fires(tmp_path):
+    c = _coord(tmp_path, now_fn=lambda: 1000)
+    assert c.evaluate(_cmd(expiry=1500), ALLOW) is not None
+
+
+def test_bool_expiry_is_ignored(tmp_path):
+    # bool is a subclass of int; True must not be treated as an epoch.
+    c = _coord(tmp_path, now_fn=lambda: 1000)
+    assert c.evaluate(_cmd(expiry=True), ALLOW) is not None
+
+
+def test_persistence_survives_restart(tmp_path):
+    path = os.path.join(str(tmp_path), "last_capture_id")
+    CaptureCoordinator(path).evaluate(_cmd(), ALLOW)  # serves id-1, persists
+    # "restart": a fresh coordinator loads the persisted id and must not replay.
+    fresh = CaptureCoordinator(path)
+    assert fresh.evaluate(_cmd(), ALLOW) is None
+
+
+def test_persist_failure_still_returns_job(tmp_path):
+    # state_path under a nonexistent dir -> write raises -> caught best-effort.
+    bad = os.path.join(str(tmp_path), "missing", "last_capture_id")
+    c = CaptureCoordinator(bad)
+    assert c.evaluate(_cmd(), ALLOW) is not None  # capture still proceeds
+    assert c.evaluate(_cmd(), ALLOW) is None  # in-memory guard still holds
+
+
+def test_load_error_when_state_path_is_dir(tmp_path):
+    # An unreadable state path (a directory) degrades to no baseline, fires once.
+    d = os.path.join(str(tmp_path), "as_dir")
+    os.mkdir(d)
+    assert CaptureCoordinator(d).evaluate(_cmd(), ALLOW) is not None
+
+
+def test_warn_once_per_id_for_rejected_unit(tmp_path):
+    c = _coord(tmp_path)
+    bad = _cmd(unit="secret.service")
+    assert c.evaluate(bad, ALLOW) is None
+    assert c.evaluate(bad, ALLOW) is None  # second call: warn-once guard, still None
+    assert c._last_warned_id == "id-1"
+
+
+# --- evaluate_and_enqueue glue ---
+
+
+def test_enqueue_puts_job_when_fired(tmp_path):
+    q = SynchronizationQueue(maxsize=10)
+    job = evaluate_and_enqueue(
+        _coord(tmp_path), q, {"logs": {"units": ALLOW}, "capture_logs": _cmd()}
+    )
+    assert job is not None
+    assert q.qsize() == 1
+    assert q.get_nowait()["capture_id"] == "id-1"
+
+
+def test_enqueue_noop_when_no_capture(tmp_path):
+    q = SynchronizationQueue(maxsize=10)
+    assert evaluate_and_enqueue(_coord(tmp_path), q, {"logs": {"units": ALLOW}}) is None
+    assert q.qsize() == 0
+
+
+def test_enqueue_defaults_empty_allowlist_when_logs_cfg_absent(tmp_path):
+    q = SynchronizationQueue(maxsize=10)
+    # No logs config -> allowlist defaults to [] -> default-deny.
+    assert evaluate_and_enqueue(_coord(tmp_path), q, {"capture_logs": _cmd()}) is None
+    assert q.qsize() == 0
+
+
+def test_enqueue_handles_non_dict_logs_cfg(tmp_path):
+    q = SynchronizationQueue(maxsize=10)
+    cfg = {"logs": "garbage", "capture_logs": _cmd()}
+    assert evaluate_and_enqueue(_coord(tmp_path), q, cfg) is None
+    assert q.qsize() == 0

--- a/tests/test_log_signals.py
+++ b/tests/test_log_signals.py
@@ -65,7 +65,7 @@ def test_collect_disabled_is_empty():
 def test_collect_window_clamping():
     seen = {}
 
-    def fake(unit, since, lines):
+    def fake(unit, since, lines, timeout=None):
         seen["since"] = since
         return []
 
@@ -81,7 +81,7 @@ def test_collect_window_clamping():
 
 
 def test_collect_per_unit_isolation():
-    def fake(unit, since, lines):
+    def fake(unit, since, lines, timeout=None):
         if unit == "bad":
             raise RuntimeError("boom")
         return [{"priority": "3", "message": "e"}]
@@ -93,13 +93,26 @@ def test_collect_per_unit_isolation():
 
 
 def test_collect_skips_unit_on_capture_failure():
-    def fake(unit, since, lines):
+    def fake(unit, since, lines, timeout=None):
         return None if unit == "x" else [{"priority": "3", "message": "e"}]
 
     out = logs.collect_log_signals(
         units=["x", "y"], _entries_fn=fake, _now=lambda: 1000
     )
     assert list(out["units"].keys()) == ["y"]
+
+
+def test_collect_uses_short_signal_timeout():
+    # Signals use a short timeout (A6) - distinct from the 30s capture timeout -
+    # so N units x a low incident interval cannot starve the systemd watchdog.
+    seen = {}
+
+    def fake(unit, since, lines, timeout=None):
+        seen["timeout"] = timeout
+        return []
+
+    logs.collect_log_signals(units=["a"], _entries_fn=fake, _now=lambda: 1000)
+    assert seen["timeout"] == logs._SIGNAL_TIMEOUT == 5
 
 
 def test_collect_absorbs_extra_config_kwargs():

--- a/tests/test_log_signals.py
+++ b/tests/test_log_signals.py
@@ -115,6 +115,23 @@ def test_collect_uses_short_signal_timeout():
     assert seen["timeout"] == logs._SIGNAL_TIMEOUT == 5
 
 
+def test_collect_caps_units_per_tick_and_warns_once():
+    # An oversized backend allowlist is capped so N sequential journalctl calls
+    # on the main loop can't exceed the systemd watchdog and self-restart.
+    logs._signal_units_capped_warned = False  # reset module-level warn-once flag
+    seen = []
+
+    def fake(unit, since, lines, timeout=None):
+        seen.append(unit)
+        return [{"priority": "3", "message": "e"}]
+
+    many = [f"u{i}.service" for i in range(20)]
+    out = logs.collect_log_signals(units=many, _entries_fn=fake, _now=lambda: 1000)
+    assert len(seen) == logs._MAX_SIGNAL_UNITS  # only the first N scanned
+    assert len(out["units"]) == logs._MAX_SIGNAL_UNITS
+    assert logs._signal_units_capped_warned is True
+
+
 def test_collect_absorbs_extra_config_kwargs():
     # posture / redaction come from the logs config block; must not break the call.
     out = logs.collect_log_signals(

--- a/tests/test_log_signals.py
+++ b/tests/test_log_signals.py
@@ -1,0 +1,110 @@
+"""Tests for Brique C: continuous per-tick log signals.
+
+Pure: _signals_for_unit is tested directly; collect_log_signals injects the
+entries seam and the clock. No real journald.
+"""
+
+from fivenines_agent import logs
+
+# --- _signals_for_unit ---
+
+
+def test_signals_counts_groups_and_drops_info():
+    entries = [
+        {"priority": "3", "message": "timeout 1s"},
+        {"priority": "3", "message": "timeout 2s"},  # same fp as above
+        {"priority": "4", "message": "slow query"},
+        {"priority": "6", "message": "all good"},  # info: dropped
+    ]
+    out = logs._signals_for_unit(entries)
+    assert out["error_rate"] == 2
+    assert out["warn_rate"] == 1
+    timeout = [f for f in out["fingerprints"] if f["count"] == 2][0]
+    assert timeout["severity"] == "error"
+
+
+def test_signals_sample_is_redacted():
+    out = logs._signals_for_unit([{"priority": "3", "message": "token=sk_live_1 boom"}])
+    assert "sk_live_1" not in out["fingerprints"][0]["sample"]
+
+
+def test_signals_severity_escalates_within_group():
+    entries = [
+        {"priority": "4", "message": "db slow shard 1"},
+        {"priority": "3", "message": "db slow shard 2"},
+    ]
+    out = logs._signals_for_unit(entries)
+    assert out["fingerprints"][0]["severity"] == "error"
+    assert out["fingerprints"][0]["count"] == 2
+    assert out["error_rate"] == 1 and out["warn_rate"] == 1
+
+
+def test_signals_top_fingerprints_capped():
+    entries = [{"priority": "3", "message": f"err {chr(65 + i)}"} for i in range(30)]
+    out = logs._signals_for_unit(entries)
+    assert len(out["fingerprints"]) == logs._TOP_FINGERPRINTS
+
+
+# --- collect_log_signals ---
+
+
+def test_collect_units_none_is_empty():
+    assert logs.collect_log_signals(units=None, _now=lambda: 1000) == {
+        "window_s": 60,
+        "units": {},
+    }
+
+
+def test_collect_disabled_is_empty():
+    out = logs.collect_log_signals(
+        units=["a.service"], enabled=False, _now=lambda: 1000
+    )
+    assert out["units"] == {}
+
+
+def test_collect_window_clamping():
+    seen = {}
+
+    def fake(unit, since, lines):
+        seen["since"] = since
+        return []
+
+    logs.collect_log_signals(
+        units=["a"], signal_interval_s=30, _entries_fn=fake, _now=lambda: 1000
+    )
+    assert seen["since"] == 970  # 1000 - 30
+    for bad in ("x", True, 0, -5):
+        logs.collect_log_signals(
+            units=["a"], signal_interval_s=bad, _entries_fn=fake, _now=lambda: 1000
+        )
+        assert seen["since"] == 940  # clamped to 60 -> 1000 - 60
+
+
+def test_collect_per_unit_isolation():
+    def fake(unit, since, lines):
+        if unit == "bad":
+            raise RuntimeError("boom")
+        return [{"priority": "3", "message": "e"}]
+
+    out = logs.collect_log_signals(
+        units=["bad", "good"], _entries_fn=fake, _now=lambda: 1000
+    )
+    assert "good" in out["units"] and "bad" not in out["units"]
+
+
+def test_collect_skips_unit_on_capture_failure():
+    def fake(unit, since, lines):
+        return None if unit == "x" else [{"priority": "3", "message": "e"}]
+
+    out = logs.collect_log_signals(
+        units=["x", "y"], _entries_fn=fake, _now=lambda: 1000
+    )
+    assert list(out["units"].keys()) == ["y"]
+
+
+def test_collect_absorbs_extra_config_kwargs():
+    # posture / redaction come from the logs config block; must not break the call.
+    out = logs.collect_log_signals(
+        units=[], posture="digest", redaction={"version": 1}, _now=lambda: 1000
+    )
+    assert out == {"window_s": 60, "units": {}}

--- a/tests/test_log_uploader.py
+++ b/tests/test_log_uploader.py
@@ -1,0 +1,97 @@
+"""Unit tests for the dedicated log-upload worker thread.
+
+Pure dependency injection: build_fn / send_fn are stubs, so these exercise the
+thread's drain / isolation / shutdown logic without journald, the network, or
+the Synchronizer.
+"""
+
+from fivenines_agent.log_uploader import LogUploader
+from fivenines_agent.synchronization_queue import SynchronizationQueue
+
+
+def _run(build_fn, send_fn, jobs):
+    """Start an uploader, feed it jobs + the shutdown sentinel, join it."""
+    q = SynchronizationQueue(maxsize=50)
+    up = LogUploader(q, build_fn, send_fn)
+    up.start()
+    for j in jobs:
+        q.put(j)
+    q.put(None)  # shutdown sentinel
+    up.join(timeout=2)
+    assert not up.is_alive()
+
+
+def test_uploader_builds_then_sends():
+    built, sent = [], []
+
+    def build(job):
+        built.append(job)
+        return {"for": job["capture_id"]}
+
+    def send(bundle):
+        sent.append(bundle)
+        return True
+
+    _run(build, send, [{"capture_id": "X"}])
+    assert built == [{"capture_id": "X"}]
+    assert sent == [{"for": "X"}]
+
+
+def test_uploader_skips_when_build_returns_none():
+    sent = []
+    _run(lambda job: None, lambda b: sent.append(b) or True, [{"capture_id": "Y"}])
+    assert sent == []
+
+
+def test_uploader_isolates_build_exception():
+    processed = []
+
+    def build(job):
+        if job["capture_id"] == "bad":
+            raise ValueError("boom")
+        return {"ok": job["capture_id"]}
+
+    _run(
+        build,
+        lambda b: processed.append(b) or True,
+        [{"capture_id": "bad"}, {"capture_id": "good"}],
+    )
+    # The bad job is isolated; the good job is still processed.
+    assert processed == [{"ok": "good"}]
+
+
+def test_uploader_continues_on_send_failure():
+    calls = []
+
+    def send(b):
+        calls.append(b)
+        return False  # upload failed
+
+    _run(
+        lambda job: {"j": job["capture_id"]},
+        send,
+        [{"capture_id": "A"}, {"capture_id": "B"}],
+    )
+    assert len(calls) == 2  # both attempted, thread survived the failure
+
+
+def test_uploader_isolates_send_exception():
+    calls = []
+
+    def send(b):
+        calls.append(b)
+        raise RuntimeError("net down")
+
+    _run(
+        lambda job: {"j": job["capture_id"]},
+        send,
+        [{"capture_id": "A"}, {"capture_id": "B"}],
+    )
+    assert len(calls) == 2  # raise isolated, both jobs processed
+
+
+def test_stop_sets_event():
+    up = LogUploader(SynchronizationQueue(), lambda j: None, lambda b: True)
+    assert not up._stop_event.is_set()
+    up.stop()
+    assert up._stop_event.is_set()

--- a/tests/test_log_uploader.py
+++ b/tests/test_log_uploader.py
@@ -95,3 +95,66 @@ def test_stop_sets_event():
     assert not up._stop_event.is_set()
     up.stop()
     assert up._stop_event.is_set()
+
+
+# --- coordinator callbacks (B2 retry) ---
+
+
+def _run_cb(build_fn, send_fn, jobs, **cbs):
+    q = SynchronizationQueue(maxsize=50)
+    up = LogUploader(q, build_fn, send_fn, **cbs)
+    up.start()
+    for j in jobs:
+        q.put(j)
+    q.put(None)
+    up.join(timeout=2)
+
+
+def test_on_success_called_with_capture_id():
+    got = []
+    _run_cb(
+        lambda job: {"b": job["capture_id"]},
+        lambda b: True,
+        [{"capture_id": "X"}],
+        on_success=lambda cid: got.append(("ok", cid)),
+        on_failure=lambda cid: got.append(("fail", cid)),
+    )
+    assert got == [("ok", "X")]
+
+
+def test_on_failure_called_on_send_false():
+    got = []
+    _run_cb(
+        lambda job: {"b": 1},
+        lambda b: False,
+        [{"capture_id": "Y"}],
+        on_failure=lambda cid: got.append(cid),
+    )
+    assert got == ["Y"]
+
+
+def test_on_failure_called_on_send_exception():
+    got = []
+
+    def send(b):
+        raise RuntimeError("net down")
+
+    _run_cb(lambda job: {"b": 1}, send, [{"capture_id": "Z"}], on_failure=got.append)
+    assert got == ["Z"]
+
+
+def test_on_failure_called_on_build_none_and_exception():
+    got = []
+
+    def build(job):
+        if job["capture_id"] == "boom":
+            raise ValueError("x")
+        return None  # capture failed -> retry
+
+    _run_cb(
+        build,
+        lambda b: True,
+        [{"capture_id": "none"}, {"capture_id": "boom"}],
+        on_failure=got.append,
+    )
+    assert got == ["none", "boom"]

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -70,6 +70,32 @@ def test_fingerprint_masks_uuid_and_ip():
     assert a == b
 
 
+def test_fingerprint_masks_ipv6():
+    a = fingerprint("peer 2001:0db8:85a3:0000:0000:8a2e:0370:7334 closed")
+    b = fingerprint("peer fe80:0000:0000:0000:0202:b3ff:fe1e:8329 closed")
+    assert a == b
+
+
+def test_fingerprint_masks_base64_token():
+    a = fingerprint("auth token c3VwZXJzZWNyZXQ1MjM0NXZhbHVl rejected")
+    b = fingerprint("auth token aGVsbG93b3JsZDk5OTl0b2tlbnh5 rejected")
+    assert a == b
+
+
+def test_fingerprint_keeps_plain_letter_identifiers_distinct():
+    # No digit -> not masked as base64, so distinct long identifiers stay distinct
+    # (guards against over-collapsing different errors into one fingerprint).
+    a = fingerprint("NullPointerException in OrderServiceHandlerFactory")
+    b = fingerprint("NullPointerException in PaymentGatewayDispatcher")
+    assert a != b
+
+
+def test_fingerprint_collapses_timestamps_via_digits():
+    a = fingerprint("request at 12:34:56 failed")
+    b = fingerprint("request at 01:02:03 failed")
+    assert a == b
+
+
 def test_fingerprint_different_template_differs():
     assert fingerprint("disk full") != fingerprint("connection refused")
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,246 @@
+"""Tests for Brique A: incident journald capture -> enriched digest.
+
+Pure helpers (redact, fingerprint, severity, build_digest) are tested directly;
+_capture_entries mocks subprocess.run; build_capture_bundle injects the entries
+seam. No real journald is touched.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from fivenines_agent import logs
+from fivenines_agent.logs import (
+    build_capture_bundle,
+    build_digest,
+    fingerprint,
+    redact,
+    severity_from_priority,
+)
+
+# --- redact (best-effort secret/PII) ---
+
+
+def test_redact_jwt():
+    out = redact("auth eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc-DEF_123")
+    assert "eyJ" not in out and "[REDACTED_JWT]" in out
+
+
+def test_redact_bearer_token():
+    out = redact("Authorization: Bearer sk-aBc123XyZ.tok_456")
+    assert "sk-aBc123XyZ" not in out and "[REDACTED]" in out
+
+
+def test_redact_connection_string_password():
+    out = redact("dsn=postgres://app:s3cr3tPass@db.host:5432/main")
+    assert "s3cr3tPass" not in out and "[REDACTED]" in out
+
+
+def test_redact_generic_secret_assignment():
+    assert "hunter2" not in redact("password: hunter2")
+    assert "tok_abc" not in redact("api_key=tok_abc")
+
+
+def test_redact_email():
+    out = redact("user alice.smith@example.com failed")
+    assert "alice.smith@example.com" not in out and "[REDACTED_EMAIL]" in out
+
+
+def test_redact_aws_key_and_private_key():
+    assert "AKIA" not in redact("key AKIAIOSFODNN7EXAMPLE here")
+    out = redact("-----BEGIN RSA PRIVATE KEY-----")
+    assert "[REDACTED_PRIVATE_KEY]" in out and "BEGIN" not in out
+
+
+def test_redact_leaves_plain_text_untouched():
+    assert redact("connection refused on socket") == "connection refused on socket"
+
+
+# --- fingerprint ---
+
+
+def test_fingerprint_same_template_different_numbers_collapses():
+    assert fingerprint("timeout after 30s on conn 5") == fingerprint(
+        "timeout after 900s on conn 42"
+    )
+
+
+def test_fingerprint_masks_uuid_and_ip():
+    a = fingerprint("user 550e8400-e29b-41d4-a716-446655440000 from 10.0.0.1")
+    b = fingerprint("user 550e8400-e29b-41d4-a716-446655449999 from 192.168.1.9")
+    assert a == b
+
+
+def test_fingerprint_different_template_differs():
+    assert fingerprint("disk full") != fingerprint("connection refused")
+
+
+def test_fingerprint_is_deterministic_short_hash():
+    fp = fingerprint("oom killed pid 1234")
+    assert fp == fingerprint("oom killed pid 9999")
+    assert len(fp) == 12
+
+
+# --- severity_from_priority ---
+
+
+def test_severity_mapping():
+    assert severity_from_priority("0") == "error"
+    assert severity_from_priority(3) == "error"
+    assert severity_from_priority("4") == "warn"
+    assert severity_from_priority("6") == "info"
+    assert severity_from_priority(None) == "info"
+    assert severity_from_priority("not-a-number") == "info"
+
+
+# --- build_digest ---
+
+
+def test_build_digest_counts_and_groups():
+    entries = [
+        {"priority": "3", "message": "timeout after 1s"},
+        {"priority": "3", "message": "timeout after 9s"},  # same fp as above
+        {"priority": "4", "message": "cache miss"},
+        {"priority": "6", "message": "started ok"},
+    ]
+    digest, truncated = build_digest(entries)
+    assert truncated is False
+    assert digest["counts"] == {"error": 2, "warn": 1, "info": 1}
+    timeout_fp = [f for f in digest["fingerprints"] if f["count"] == 2][0]
+    assert timeout_fp["severity"] == "error"
+    assert timeout_fp["count"] == 2
+
+
+def test_build_digest_excerpt_is_redacted():
+    entries = [{"priority": "3", "message": "login token=sk_live_999 rejected"}]
+    digest, _ = build_digest(entries)
+    assert "sk_live_999" not in digest["fingerprints"][0]["excerpt"]
+
+
+def test_build_digest_severity_escalates_within_group():
+    # Same template seen first as warn (4) then error (3) -> group labelled error.
+    entries = [
+        {"priority": "4", "message": "db slow on shard 1"},
+        {"priority": "3", "message": "db slow on shard 2"},
+    ]
+    digest, _ = build_digest(entries)
+    assert digest["fingerprints"][0]["severity"] == "error"
+    assert digest["fingerprints"][0]["count"] == 2
+
+
+def test_build_digest_truncates_above_cap():
+    entries = [
+        {"priority": "3", "message": f"distinct error {chr(65 + i)}"} for i in range(60)
+    ]
+    digest, truncated = build_digest(entries)
+    assert truncated is True
+    assert len(digest["fingerprints"]) == logs._MAX_FINGERPRINTS
+
+
+def test_build_digest_empty():
+    digest, truncated = build_digest([])
+    assert truncated is False
+    assert digest == {"counts": {"error": 0, "warn": 0, "info": 0}, "fingerprints": []}
+
+
+# --- _capture_entries (subprocess seam) ---
+
+
+def _result(returncode=0, stdout="", stderr=""):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_capture_entries_parses_json_skips_garbage():
+    stdout = "\n".join(
+        [
+            json.dumps({"PRIORITY": "3", "MESSAGE": "boom"}),
+            "",  # blank
+            "not json",  # bad
+            json.dumps(["array", "not", "dict"]),  # non-dict
+            json.dumps({"PRIORITY": "6", "MESSAGE": [1, 2, 3]}),  # binary MESSAGE
+            json.dumps({"PRIORITY": "4", "MESSAGE": "warn here"}),
+        ]
+    )
+    with patch.object(
+        logs.subprocess, "run", return_value=_result(stdout=stdout)
+    ) as run:
+        entries = logs._capture_entries("nginx.service", 1000, 500)
+    assert entries == [
+        {"priority": "3", "message": "boom"},
+        {"priority": "4", "message": "warn here"},
+    ]
+    # timeout + clean env are passed (the two learnings).
+    _, kwargs = run.call_args
+    assert kwargs["timeout"] == logs._CAPTURE_TIMEOUT
+    assert "env" in kwargs
+
+
+def test_capture_entries_since_epoch_becomes_at_arg():
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout="")) as run:
+        logs._capture_entries("u", 1700000000, 100)
+    cmd = run.call_args[0][0]
+    assert "--since" in cmd and "@1700000000" in cmd
+
+
+def test_capture_entries_since_string_passthrough_and_bool_ignored():
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout="")) as run:
+        logs._capture_entries("u", "2 hours ago", 100)
+    assert "2 hours ago" in run.call_args[0][0]
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout="")) as run:
+        logs._capture_entries("u", True, 100)
+    assert "--since" not in run.call_args[0][0]
+
+
+def test_capture_entries_timeout_returns_none():
+    import subprocess as _sp
+
+    with patch.object(
+        logs.subprocess, "run", side_effect=_sp.TimeoutExpired("journalctl", 30)
+    ):
+        assert logs._capture_entries("u", None, 100) is None
+
+
+def test_capture_entries_nonzero_exit_returns_none():
+    with patch.object(
+        logs.subprocess, "run", return_value=_result(returncode=1, stderr="nope")
+    ):
+        assert logs._capture_entries("u", None, 100) is None
+
+
+def test_capture_entries_generic_exception_returns_none():
+    with patch.object(logs.subprocess, "run", side_effect=OSError("boom")):
+        assert logs._capture_entries("u", None, 100) is None
+
+
+# --- build_capture_bundle ---
+
+
+def test_bundle_none_when_capture_fails():
+    assert (
+        build_capture_bundle(
+            {"capture_id": "x", "unit": "u"}, _entries_fn=lambda *a: None
+        )
+        is None
+    )
+
+
+def test_bundle_empty_window_still_acks():
+    bundle = build_capture_bundle(
+        {"capture_id": "cap-1", "unit": "nginx.service", "since": 1000},
+        _entries_fn=lambda *a: [],
+    )
+    assert bundle["capture_id"] == "cap-1"
+    assert bundle["posture"] == "digest"
+    assert bundle["raw"] is None
+    assert bundle["truncated"] is False
+    assert bundle["digest"]["counts"] == {"error": 0, "warn": 0, "info": 0}
+    assert bundle["redaction"] == {"version": 1, "applied": True, "best_effort": True}
+
+
+def test_bundle_with_entries_builds_digest():
+    entries = [{"priority": "3", "message": "kernel panic"}]
+    bundle = build_capture_bundle(
+        {"capture_id": "cap-2", "unit": "u"}, _entries_fn=lambda *a: entries
+    )
+    assert bundle["digest"]["counts"]["error"] == 1
+    assert bundle["digest"]["fingerprints"][0]["severity"] == "error"
+    assert bundle["truncated"] is False

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -168,6 +168,113 @@ def test_build_digest_empty():
     assert digest == {"counts": {"error": 0, "warn": 0, "info": 0}, "fingerprints": []}
 
 
+# --- assemble_multiline (E3: single-source assembly BEFORE fingerprint) ---
+
+
+def _e(msg, prio="6"):
+    return {"priority": prio, "message": msg}
+
+
+def test_multiline_python_traceback_is_one_entry_one_fingerprint():
+    """The critical plan test: a stdout-captured Python crash (one journal
+    entry per line) collapses to ONE entry -> ONE fingerprint, including the
+    final unindented exception line."""
+    crash = [
+        _e("Traceback (most recent call last):", "3"),
+        _e('  File "app.py", line 10, in <module>'),
+        _e("    main()"),
+        _e('  File "app.py", line 7, in main'),
+        _e("    raise ValueError('boom 42')"),
+        _e("ValueError: boom 42"),
+    ]
+    out = logs.assemble_multiline(crash)
+    assert len(out) == 1
+    assert "ValueError: boom 42" in out[0]["message"]
+    # Same crash with different line numbers -> same single fingerprint.
+    crash2 = [
+        _e("Traceback (most recent call last):", "3"),
+        _e('  File "app.py", line 99, in <module>'),
+        _e("    main()"),
+        _e('  File "app.py", line 55, in main'),
+        _e("    raise ValueError('boom 7')"),
+        _e("ValueError: boom 7"),
+    ]
+    (only,) = logs.assemble_multiline(crash2)
+    assert fingerprint(only["message"]) == fingerprint(out[0]["message"])
+
+
+def test_multiline_traceback_terminator_closes_block():
+    # The line AFTER the exception terminator is a fresh entry, not merged.
+    out = logs.assemble_multiline(
+        [
+            _e("Traceback (most recent call last):"),
+            _e("  File 'x'"),
+            _e("KeyError: 'k'"),
+            _e("worker restarted"),
+        ]
+    )
+    assert len(out) == 2
+    assert out[1]["message"] == "worker restarted"
+
+
+def test_multiline_java_chain_merges():
+    out = logs.assemble_multiline(
+        [
+            _e("Exception in thread main java.lang.RuntimeException: x", "3"),
+            _e("\tat com.app.Main.run(Main.java:10)"),
+            _e("Caused by: java.io.IOException: disk"),
+            _e("\tat com.app.Disk.read(Disk.java:5)"),
+        ]
+    )
+    assert len(out) == 1
+    assert "Caused by" in out[0]["message"]
+
+
+def test_multiline_severity_escalates_to_worst_line():
+    out = logs.assemble_multiline([_e("Exception: x", "4"), _e("\tat frame", "3")])
+    assert len(out) == 1
+    assert logs.severity_from_priority(out[0]["priority"]) == "error"
+
+
+def test_multiline_plain_lines_do_not_merge():
+    out = logs.assemble_multiline(
+        [_e("connection refused"), _e("retrying"), _e("connected")]
+    )
+    assert len(out) == 3
+
+
+def test_multiline_leading_continuation_starts_own_group():
+    # Window cut mid-traceback: first entry is indented -> becomes its own group.
+    out = logs.assemble_multiline([_e("  File 'x'"), _e("KeyError: 'k'")])
+    assert len(out) == 2
+
+
+def test_multiline_cap_bounds_text_but_keeps_grouping():
+    entries = [_e("Traceback (most recent call last):")] + [
+        _e(f"  frame {i}") for i in range(80)
+    ]
+    out = logs.assemble_multiline(entries)
+    assert len(out) == 1  # grouping never splits past the cap
+    # text growth stops at the cap
+    assert len(out[0]["message"].splitlines()) == logs._MAX_ASSEMBLED_LINES
+
+
+def test_capture_entries_applies_multiline_assembly():
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {"PRIORITY": "3", "MESSAGE": "Traceback (most recent call last):"}
+            ),
+            json.dumps({"PRIORITY": "3", "MESSAGE": "  File 'app.py', line 1"}),
+            json.dumps({"PRIORITY": "3", "MESSAGE": "TypeError: bad"}),
+        ]
+    )
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout=stdout)):
+        entries = logs._capture_entries("u", None, 100)
+    assert len(entries) == 1
+    assert "TypeError: bad" in entries[0]["message"]
+
+
 # --- _capture_entries (subprocess seam) ---
 
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -182,7 +182,11 @@ def test_capture_entries_parses_json_skips_garbage():
             "",  # blank
             "not json",  # bad
             json.dumps(["array", "not", "dict"]),  # non-dict
-            json.dumps({"PRIORITY": "6", "MESSAGE": [1, 2, 3]}),  # binary MESSAGE
+            # binary MESSAGE (byte array): decoded, not dropped (mirrors the
+            # systemd collector's journal-tail handling)
+            json.dumps({"PRIORITY": "6", "MESSAGE": [104, 105]}),
+            json.dumps({"PRIORITY": "6", "MESSAGE": [999999]}),  # undecodable
+            json.dumps({"PRIORITY": "6", "MESSAGE": ""}),  # empty: skipped
             json.dumps({"PRIORITY": "4", "MESSAGE": "warn here"}),
         ]
     )
@@ -192,6 +196,7 @@ def test_capture_entries_parses_json_skips_garbage():
         entries = logs._capture_entries("nginx.service", 1000, 500)
     assert entries == [
         {"priority": "3", "message": "boom"},
+        {"priority": "6", "message": "hi"},
         {"priority": "4", "message": "warn here"},
     ]
     # timeout + clean env are passed (the two learnings).

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -55,6 +55,14 @@ def test_redact_leaves_plain_text_untouched():
     assert redact("connection refused on socket") == "connection refused on socket"
 
 
+def test_redact_long_opaque_blob():
+    # A PEM key body line / long token (>=40 base64 chars) is redacted so
+    # multiline / high-entropy secrets don't leave in the digest excerpt.
+    body = "MIIEpAIBAAKCAQEA7Yk3v9fVxQzL8mN0pQ4rS6tU8wX1yZ3aB5cD7eF9gH0iJ2kL4m"
+    out = redact(f"key material {body} loaded")
+    assert body not in out and "[REDACTED_BLOB]" in out
+
+
 # --- fingerprint ---
 
 
@@ -94,6 +102,18 @@ def test_fingerprint_collapses_timestamps_via_digits():
     a = fingerprint("request at 12:34:56 failed")
     b = fingerprint("request at 01:02:03 failed")
     assert a == b
+
+
+def test_fingerprint_collapses_per_occurrence_secrets():
+    # Redact-before-fingerprint: emails/tokens that vary per occurrence collapse
+    # to constant markers, so the same error template stays ONE fingerprint
+    # instead of fragmenting recurrence/top-N during an incident.
+    assert fingerprint("auth failed for alice@corp.com") == fingerprint(
+        "auth failed for bob@other.org"
+    )
+    assert fingerprint("login token=sk_live_aaa rejected") == fingerprint(
+        "login token=sk_live_bbb rejected"
+    )
 
 
 def test_fingerprint_different_template_differs():
@@ -310,6 +330,22 @@ def test_capture_entries_parses_json_skips_garbage():
     _, kwargs = run.call_args
     assert kwargs["timeout"] == logs._CAPTURE_TIMEOUT
     assert "env" in kwargs
+
+
+def test_capture_entries_clamps_lines_to_ceiling():
+    # A huge backend-supplied `lines` is clamped so journalctl can't buffer an
+    # unbounded slice in RAM (OOM DoS).
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout="")) as run:
+        logs._capture_entries("u", None, 10**9)
+    cmd = run.call_args[0][0]
+    assert cmd[cmd.index("-n") + 1] == str(logs._MAX_CAPTURE_LINES)
+
+
+def test_capture_entries_non_numeric_lines_falls_back():
+    with patch.object(logs.subprocess, "run", return_value=_result(stdout="")) as run:
+        logs._capture_entries("u", None, "garbage")
+    cmd = run.call_args[0][0]
+    assert cmd[cmd.index("-n") + 1] == str(logs._DEFAULT_LINES)
 
 
 def test_capture_entries_since_epoch_becomes_at_arg():

--- a/tests/test_logs_transport.py
+++ b/tests/test_logs_transport.py
@@ -1,17 +1,11 @@
-"""Coverage for the small transport seams: Synchronizer.send_logs and the
-Brique A capture stub (build_capture_bundle, implemented in a follow-up chunk)."""
+"""Coverage for the Synchronizer.send_logs transport seam.
+
+Brique A (build_capture_bundle) and its helpers are covered in test_logs.py."""
 
 from unittest.mock import MagicMock
 
-from fivenines_agent.logs import build_capture_bundle
 from fivenines_agent.synchronization_queue import SynchronizationQueue
 from fivenines_agent.synchronizer import Synchronizer
-
-
-def test_build_capture_bundle_stub_returns_none():
-    # The Brique A capture is a follow-up chunk; the seam returns None for now so
-    # the LogUploader simply skips (no bundle to send).
-    assert build_capture_bundle({"capture_id": "x", "unit": "nginx.service"}) is None
 
 
 def test_send_logs_posts_to_logs_endpoint():

--- a/tests/test_logs_transport.py
+++ b/tests/test_logs_transport.py
@@ -1,0 +1,21 @@
+"""Coverage for the small transport seams: Synchronizer.send_logs and the
+Brique A capture stub (build_capture_bundle, implemented in a follow-up chunk)."""
+
+from unittest.mock import MagicMock
+
+from fivenines_agent.logs import build_capture_bundle
+from fivenines_agent.synchronization_queue import SynchronizationQueue
+from fivenines_agent.synchronizer import Synchronizer
+
+
+def test_build_capture_bundle_stub_returns_none():
+    # The Brique A capture is a follow-up chunk; the seam returns None for now so
+    # the LogUploader simply skips (no bundle to send).
+    assert build_capture_bundle({"capture_id": "x", "unit": "nginx.service"}) is None
+
+
+def test_send_logs_posts_to_logs_endpoint():
+    s = Synchronizer("tok", SynchronizationQueue())
+    s._post = MagicMock(return_value={"ok": True})
+    assert s.send_logs({"capture_id": "x"}) == {"ok": True}
+    s._post.assert_called_once_with("/logs", {"capture_id": "x"})

--- a/tests/test_permissions_journald.py
+++ b/tests/test_permissions_journald.py
@@ -1,0 +1,66 @@
+"""Tests for the journald read-access capability probe (_can_read_journal).
+
+Mirrors how the log collector reads the journal: a trivial `journalctl -n 0`.
+Constructed via __new__ so we exercise only the probe, not the full _probe_all.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from fivenines_agent import permissions
+from fivenines_agent.permissions import PermissionProbe
+
+
+def _probe():
+    p = PermissionProbe.__new__(PermissionProbe)
+    p._current_reason = None
+    return p
+
+
+def test_journald_false_when_journalctl_missing():
+    with patch.object(permissions.shutil, "which", return_value=None):
+        p = _probe()
+        assert p._can_read_journal() is False
+        assert "not found" in p._current_reason
+
+
+def test_journald_true_when_readable():
+    with patch.object(
+        permissions.shutil, "which", return_value="/usr/bin/journalctl"
+    ), patch.object(
+        permissions.subprocess, "run", return_value=MagicMock(returncode=0)
+    ) as run:
+        assert _probe()._can_read_journal() is True
+    # bounded subprocess: clean env + timeout (the two learnings).
+    _, kwargs = run.call_args
+    assert kwargs["timeout"] == 5
+    assert "env" in kwargs
+
+
+def test_journald_false_on_nonzero_exit():
+    with patch.object(
+        permissions.shutil, "which", return_value="/usr/bin/journalctl"
+    ), patch.object(
+        permissions.subprocess, "run", return_value=MagicMock(returncode=1)
+    ):
+        p = _probe()
+        assert p._can_read_journal() is False
+        assert "systemd-journal" in p._current_reason
+
+
+def test_journald_false_on_timeout():
+    with patch.object(
+        permissions.shutil, "which", return_value="/usr/bin/journalctl"
+    ), patch.object(
+        permissions.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired("journalctl", 5),
+    ):
+        assert _probe()._can_read_journal() is False
+
+
+def test_journald_false_on_generic_exception():
+    with patch.object(
+        permissions.shutil, "which", return_value="/usr/bin/journalctl"
+    ), patch.object(permissions.subprocess, "run", side_effect=OSError("boom")):
+        assert _probe()._can_read_journal() is False

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -503,6 +503,20 @@ def test_parse_journalctl_byte_array_invalid():
     assert result == []
 
 
+def test_parse_journalctl_tail_is_redacted():
+    """Journal tails ship in the /collect payload: secrets embedded in error
+    lines (often the credential that caused the failure) must be scrubbed with
+    the same best-effort redaction as the log-monitoring digests."""
+    lines = [
+        json.dumps({"MESSAGE": "FATAL: postgres://app:S3cretPass@db:5432 refused"}),
+        json.dumps({"MESSAGE": "auth failed for token=sk_live_abc123"}),
+    ]
+    result = _parse_journalctl_failed("\n".join(lines))
+    assert len(result) == 2
+    assert "S3cretPass" not in result[0] and "[REDACTED]" in result[0]
+    assert "sk_live_abc123" not in result[1]
+
+
 def test_parse_journalctl_missing_message_key():
     line = json.dumps({"_PID": "1234"})
     assert _parse_journalctl_failed(line) == []

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -2317,7 +2317,10 @@ def test_parse_reverse_deps_capped():
 
 
 def test_journal_messages_truncated():
-    huge = "x" * (systemd.JOURNAL_MSG_MAX_CHARS + 500)
+    # Word-separated free text (so best-effort redaction leaves it intact) longer
+    # than the bound is truncated. A single long char run would instead be
+    # redacted as an opaque blob, which is a different path.
+    huge = "spam " * systemd.JOURNAL_MSG_MAX_CHARS
     out = json.dumps({"MESSAGE": huge})
     msgs = _parse_journalctl_failed(out)
     assert len(msgs[0]) == systemd.JOURNAL_MSG_MAX_CHARS


### PR DESCRIPTION
## Summary

Agent-side **log monitoring V1** for the fivenines-agent. It adds Netdata-style
"query in place" log observability (no log shipping / no central store) in two
bricks, plus a dedicated upload thread so log work never blocks metric collection.

**Brique C - continuous signals (every tick)**
- `e1c6ec0` new `logs.py` signals collector: per-unit error/warn rates + fingerprinted
  top-N recurring lines from journald, emitted with the normal `/collect` payload.
- `0915d51` hardened fingerprint masking (numbers, UUID, IPv4/IPv6, hex, base64) and a
  short 5s signal timeout so a slow journald never stalls the tick.

**Brique A - flight recorder (on-demand capture)**
- `8eb04e5` transport foundation + backend-pull protocol: `send_logs` -> `/logs`,
  dedicated `LogUploader` thread, bounded log queue.
- `363ef05` `build_capture_bundle`: journald slice (`journalctl -u <unit> --since @<epoch>
  -o json`) -> redacted, enriched digest (severity, fingerprints, excerpts).
- `628a4a3` exactly-once capture via a `capture_id` nonce + disk persistence
  (`CONFIG_DIR/last_capture_id`), in-flight guard, and post-upload persist so a failed
  upload retries instead of being lost.
- `e7f983f` (E3) assemble multiline stack traces into one logical entry before
  fingerprinting, so a traceback is one signal instead of N noisy lines.

**Permissions / plumbing**
- `b5a0e4c` `journald` capability probe (`journalctl -n 0`), `SupplementaryGroups=systemd-journal`
  in the service unit, banner "Logs" group, `logs` collector wired into the registry.

**Hardening & review fixes**
- `4f381f7` redact systemd failure-journal tails (F1) and decode binary `MESSAGE` fields
  during capture (shared `redact()` now used by `systemd.py` too).
- `edef574` closed 5 adversarial-review (Codex) findings: backend-controlled `lines`
  capped agent-side (`_MAX_CAPTURE_LINES`) to kill a journalctl-RAM DoS, `_MAX_SIGNAL_UNITS`
  watchdog cap, queue-full shed that releases the in-flight slot, redact-before-fingerprint,
  and a long base64/hex blob redaction rule.
- `e5b9f5f` pre-landing review nits: stale docstrings + a named constant.

**Tests / docs**
- `689793c` coverage for ship gaps (journald gating map, uploader cleanup ordering).
- `d11092e` doc sync (see Documentation below).

**Versioning.** Shipped as **1.11.1 (PATCH)** on top of main's current **1.11.0** baseline
(this branch was merged up to include Redis #84, so the PR diff stays scoped to log monitoring).
PATCH, not MINOR: every new code path is gated on backend config (`capture_logs` command +
`logs` flag) and the `journald` capability, so on an un-updated backend the agent is fully
inert - no new user-visible behavior until the paired backend `/collect`+`/logs` change ships.
The feature-enabling MINOR lands with that backend rollout.

## Test Coverage

New modules are fully covered:

```
Name                              Stmts   Miss  Cover
fivenines_agent/log_capture.py       71      0   100%
fivenines_agent/log_uploader.py      44      0   100%
fivenines_agent/logs.py             190      0   100%
TOTAL                               305      0   100%
```

Full suite green: **1207 passed, 2 skipped**. New test files: `test_logs.py`,
`test_log_capture.py`, `test_log_uploader.py`, `test_log_signals.py`,
`test_logs_transport.py`, `test_agent_capture.py`, `test_permissions_journald.py`.

## Pre-Landing Review

Maintainability + inline pass run before landing. Findings fixed in `e5b9f5f`
(stale docstrings, magic number -> named constant). Two DRY duplications
(`_signals_for_unit`/`build_digest` fingerprint grouping; journald `-o json`
MESSAGE parsing shared with `systemd.py`) were judged deferrable and are tracked
in `TODOS.md` rather than refactored at ship time.

## Design Review

No frontend files changed - design review skipped.

## Eval Results

No prompt-related files changed - evals skipped.

## Greptile Review

No Greptile comments.

## Plan Completion

Plan `ceo-plans/2026-06-30-log-file-monitoring.md` - V1 lean scope complete:
hybrid Brique A + C, backend-pull nonce protocol, dedicated uploader thread,
best-effort redaction, fingerprinting, and E3 multiline assembly all delivered.

Deferred (by design, tracked in `TODOS.md`):
- E2 flat-file (non-journald) source - V1 is journald-only.
- E1 ML edge trigger / local instant-capture trigger / Windows Event Log / raw posture opt-in.
- DRY debt from the pre-landing review.

Backend is out of scope for this PR: the agent is inert until a separate change
implements the `/collect` `capture_logs` command and the `/logs` endpoint (contract
in `.context/`).

## TODOS

`TODOS.md` gained the log-monitoring fast-follow sections (E2 flat-file source,
E1/local-trigger/Windows/raw-posture, DRY debt). No prior TODO items were completed
by this PR.

## Documentation

Docs synced for log-monitoring V1 (v1.11.1) against `origin/main`. Updates are reference-level only; the feature stays inert until the backend implements the `/collect` `capture_logs` command and the `/logs` endpoint.

**Updated**
- `CLAUDE.md`: added the `journald` capability to the permission-probing list; new "Log Uploader" core component (`log_uploader.py` + `log_capture.py`); new "Log monitoring" metric-collector entry (`logs.py`); noted systemd failure journal tails are now redacted before send; documented the `logs` + `capture_logs` config keys.
- `README.md`: added a log-monitoring (journald) row to the no-sudo permissions table, and a `Logs / Journald` group to the capabilities-banner sample (the 1.11.1 agent now prints it).

**Documentation debt (deferred, not blocking)**
- No user-facing "Log Monitoring" README section yet (parallel to Ceph/SNMP). Withheld on purpose: the feature is inert end-to-end until the backend ships. Add it alongside the backend `/collect`+`/logs` rollout; `/document-generate` can draft it.
- `TODOS.md` already tracks the code follow-ups (flat-file/E2 source, raw-posture opt-in, DRY debt).

## Test plan
- [x] Full pytest suite passes (1207 passed, 2 skipped)
- [x] New log modules at 100% coverage (logs.py, log_capture.py, log_uploader.py)
- [x] ASCII-only verified on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

