### PR TITLE
v1.10.0 feat: explicit Proxmox collection flags block (cluster-scope T5, #80)

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.9.1'
+VERSION = '1.10.0'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_agent/proxmox.py
+++ b/fivenines_agent/proxmox.py
@@ -17,6 +17,28 @@ except ImportError:  # pragma: no cover
     ProxmoxAPI = None  # type: ignore[assignment, misc]
 
 
+# Defensive cap on the collection.error hint. The messages the collector emits
+# are short and structured; this only bounds a pathological value.
+_ERROR_MAX_LEN = 500
+
+
+def _record_failure(collection, flag, message):
+    """Flip a section completeness flag off and record the first failure.
+
+    `collection` is the mutable flags block collect() threads through every
+    section. It is None when a _collect_* helper is exercised in isolation (the
+    unit tests call them directly), in which case recording is a no-op so the
+    helper's return value is unchanged. collect() runs the sections in a fixed
+    order (cluster, nodes, vms, lxc, storage), so the first message recorded is
+    deterministic: it wins, and later failures only flip their own flag.
+    """
+    if collection is None:
+        return
+    collection[flag] = False
+    if collection["error"] is None:
+        collection["error"] = message[:_ERROR_MAX_LEN]
+
+
 class ProxmoxCollector:
     """Collector for Proxmox VE metrics."""
 
@@ -77,13 +99,24 @@ class ProxmoxCollector:
         refused, or auth failure). proxmoxer builds the token-auth client
         lazily, so an unreachable API is not caught at construction time --
         every request raises instead. Left un-normalized the result would be
-        {"version": None, "cluster": None, "nodes": [], "vms": [], "lxc": [],
-        "storage": []}: a shape a reachable node can never produce (it always
+        an empty-but-shaped dict a reachable node can never produce (it always
         reports a version and lists at least itself) yet still easy to misread
         as "empty but healthy". Collapsing whole-module failure to None gives
         the server one unambiguous signal -- data["proxmox"] is null iff the
         API was unreachable -- instead of inferring reachability from empty
-        arrays. See tests/fixtures/proxmox_contract_payload.json.
+        arrays.
+
+        A non-null payload also carries an explicit `collection` flags block
+        (reachable / cluster_ok / nodes_ok / guests_ok / storage_ok / error),
+        ceph-style, so the server no longer has to infer per-section
+        completeness from the payload shape. Each *_ok flag is True iff every
+        API call backing that section succeeded (`guests_ok` covers both the
+        qemu and lxc loops); `error` is the first failure message. The key
+        disambiguation the block adds: cluster:null with cluster_ok True is a
+        genuine standalone node, whereas cluster:null with cluster_ok False is
+        a clustered reporter whose /cluster/status call failed -- two shapes
+        the server otherwise could not tell apart. See
+        tests/fixtures/proxmox_contract_payload.json.
         """
         if not self.proxmox:
             return None
@@ -94,8 +127,17 @@ class ProxmoxCollector:
             'nodes': [],
             'vms': [],
             'lxc': [],
-            'storage': []
+            'storage': [],
+            'collection': {
+                'reachable': False,
+                'cluster_ok': True,
+                'nodes_ok': True,
+                'guests_ok': True,
+                'storage_ok': True,
+                'error': None,
+            },
         }
+        collection = result['collection']
 
         reachable = False
 
@@ -122,40 +164,56 @@ class ProxmoxCollector:
                 log(f"Proxmox API unreachable, skipping collection: {e}", 'debug')
                 return None
 
+        # We reached this point, so the API responded (an unreachable API
+        # returned None above). State reachability explicitly rather than
+        # leaving the server to re-derive it from a non-null payload.
+        collection['reachable'] = True
+
         # Collect cluster status
         try:
-            result['cluster'] = self._collect_cluster()
+            result['cluster'] = self._collect_cluster(collection)
         except Exception as e:
             log(f"Error collecting cluster metrics: {e}", 'error')
+            _record_failure(collection, 'cluster_ok', 'cluster status query failed')
 
         # Collect node metrics
         try:
-            result['nodes'] = self._collect_nodes()
+            result['nodes'] = self._collect_nodes(collection)
         except Exception as e:
             log(f"Error collecting node metrics: {e}", 'error')
+            _record_failure(collection, 'nodes_ok', 'node listing failed')
 
         # Collect VM metrics
         try:
-            result['vms'] = self._collect_vms()
+            result['vms'] = self._collect_vms(collection)
         except Exception as e:
             log(f"Error collecting VM metrics: {e}", 'error')
+            _record_failure(collection, 'guests_ok', 'node listing failed')
 
         # Collect LXC metrics
         try:
-            result['lxc'] = self._collect_lxc()
+            result['lxc'] = self._collect_lxc(collection)
         except Exception as e:
             log(f"Error collecting LXC metrics: {e}", 'error')
+            _record_failure(collection, 'guests_ok', 'node listing failed')
 
         # Collect storage metrics
         try:
-            result['storage'] = self._collect_storage()
+            result['storage'] = self._collect_storage(collection)
         except Exception as e:
             log(f"Error collecting storage metrics: {e}", 'error')
+            _record_failure(collection, 'storage_ok', 'node listing failed')
 
         return result
 
-    def _collect_cluster(self):
-        """Collect cluster status information."""
+    def _collect_cluster(self, collection=None):
+        """Collect cluster status information.
+
+        Returns None both for a genuine standalone node (no cluster-type entry
+        in /cluster/status) and when the /cluster/status call itself fails --
+        but only the latter flips cluster_ok, so the server can tell the two
+        apart. A standalone node leaves cluster_ok True.
+        """
         try:
             cluster_status = self.proxmox.cluster.status.get()
 
@@ -186,9 +244,10 @@ class ProxmoxCollector:
 
         except Exception as e:
             log(f"Error getting cluster status: {e}", 'debug')
+            _record_failure(collection, 'cluster_ok', 'cluster status query failed')
             return None
 
-    def _collect_nodes(self):
+    def _collect_nodes(self, collection=None):
         """Collect metrics for all nodes."""
         nodes = []
         try:
@@ -233,13 +292,19 @@ class ProxmoxCollector:
 
                 except Exception as e:
                     log(f"Error getting status for node {node_name}: {e}", 'error')
+                    _record_failure(
+                        collection,
+                        'nodes_ok',
+                        f'node {node_name}: status query failed',
+                    )
 
         except Exception as e:
             log(f"Error listing nodes: {e}", 'error')
+            _record_failure(collection, 'nodes_ok', 'node listing failed')
 
         return nodes
 
-    def _collect_vms(self):
+    def _collect_vms(self, collection=None):
         """Collect metrics for all QEMU/KVM VMs."""
         vms = []
         try:
@@ -279,13 +344,19 @@ class ProxmoxCollector:
 
                 except Exception as e:
                     log(f"Error getting VMs for node {node_name}: {e}", 'error')
+                    _record_failure(
+                        collection,
+                        'guests_ok',
+                        f'node {node_name}: qemu query failed',
+                    )
 
         except Exception as e:
             log(f"Error listing VMs: {e}", 'error')
+            _record_failure(collection, 'guests_ok', 'node listing failed')
 
         return vms
 
-    def _collect_lxc(self):
+    def _collect_lxc(self, collection=None):
         """Collect metrics for all LXC containers."""
         containers = []
         try:
@@ -322,13 +393,19 @@ class ProxmoxCollector:
 
                 except Exception as e:
                     log(f"Error getting LXC containers for node {node_name}: {e}", 'error')
+                    _record_failure(
+                        collection,
+                        'guests_ok',
+                        f'node {node_name}: lxc query failed',
+                    )
 
         except Exception as e:
             log(f"Error listing LXC containers: {e}", 'error')
+            _record_failure(collection, 'guests_ok', 'node listing failed')
 
         return containers
 
-    def _collect_storage(self):
+    def _collect_storage(self, collection=None):
         """Collect metrics for all storage pools."""
         storage_pools = []
         try:
@@ -360,9 +437,15 @@ class ProxmoxCollector:
 
                 except Exception as e:
                     log(f"Error getting storage for node {node_name}: {e}", 'error')
+                    _record_failure(
+                        collection,
+                        'storage_ok',
+                        f'node {node_name}: storage query failed',
+                    )
 
         except Exception as e:
             log(f"Error listing storage: {e}", 'error')
+            _record_failure(collection, 'storage_ok', 'node listing failed')
 
         return storage_pools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.9.1"
+version = "1.10.0"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/proxmox_contract_payload.json
+++ b/tests/fixtures/proxmox_contract_payload.json
@@ -1,7 +1,16 @@
 {
-  "description": "Shared Proxmox contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/proxmox_contract_payload.json, asserted end-to-end by tests/test_proxmox.py::test_contract_fixture_scenarios (only proxmoxer.ProxmoxAPI is mocked). For each scenario, 'api' is the agent-side proxmoxer mock input (fed to tests/test_proxmox.py::make_proxmox_mock; the server ignores it, it only documents how the payload arises) and 'payload' is the artifact the agent emits under data['proxmox'] -- the exact thing the server's cluster-scope ingester must parse. Unlike the ceph payload there is NO per-cluster 'collection' flags block: the Proxmox payload carries no completeness metadata, so the server infers reachable / cluster_ok / nodes_ok / guests_ok / storage_ok from the payload SHAPE. That inference is only safe because these shapes are pinned by tests on the agent side. Change only in lockstep with spec/fixtures/proxmox_contract_payload.json on the server.",
-  "agent_min_version": "1.9.0",
+  "description": "Shared Proxmox contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/proxmox_contract_payload.json, asserted end-to-end by tests/test_proxmox.py::test_contract_fixture_scenarios (only proxmoxer.ProxmoxAPI is mocked). For each scenario, 'api' is the agent-side proxmoxer mock input (fed to tests/test_proxmox.py::make_proxmox_mock; the server ignores it, it only documents how the payload arises) and 'payload' is the artifact the agent emits under data['proxmox'] -- the exact thing the server's cluster-scope ingester must parse. As of agent 1.10.0 the payload carries an explicit ceph-style 'collection' flags block (reachable / cluster_ok / nodes_ok / guests_ok / storage_ok / error); the server MUST prefer these flags over shape inference when the block is present. 'inference_contract' below is retained as the pre-1.10.0 fallback: how the server derives the same signals from payload SHAPE when 'collection' is absent (an older agent). Both must agree on every scenario here. Change only in lockstep with spec/fixtures/proxmox_contract_payload.json on the server.",
+  "agent_min_version": "1.10.0",
+  "collection_contract": {
+    "reachable": "collection.reachable. Always true inside a non-null payload -- an unreachable API yields a null payload (proxmox_metrics() -> None), never a payload with reachable:false. Stated explicitly so the server reads a flag rather than re-deriving 'reachable == payload is not null'.",
+    "cluster_ok": "collection.cluster_ok. True iff the /cluster/status call succeeded. Resolves the cluster:null ambiguity the inference contract could not: standalone node => cluster:null AND cluster_ok:true (the call succeeded, there was simply no cluster-type entry); clustered reporter whose /cluster/status failed => cluster:null AND cluster_ok:false. See scenarios 'standalone' vs 'cluster_fetch_failed'.",
+    "nodes_ok": "collection.nodes_ok. True iff the /nodes listing AND every per-node /nodes/<n>/status call succeeded. A node dropped from payload.nodes because its status fetch raised mid-loop sets nodes_ok:false (see 'partial_node_timeout', 'quorum_lost'). Unlike the shape heuristic (len(nodes)==cluster.nodes_online) this fires even when the dropped node is genuinely offline and excluded from nodes_online -- it reports call success, not head-count agreement.",
+    "guests_ok": "collection.guests_ok. True iff every qemu AND lxc listing across all reporting nodes succeeded (covers both guest loops). A single node's qemu or lxc call raising sets guests_ok:false; the guests of that node are absent from payload.vms/lxc.",
+    "storage_ok": "collection.storage_ok. True iff every per-node /nodes/<n>/storage call succeeded. Independent of the other flags: a lone storage timeout leaves nodes_ok/guests_ok true and only storage_ok false (see 'storage_query_failed'). This is what the shape heuristic could never express -- 'no storages exist' (empty array, storage_ok:true) vs 'storage query failed' (empty/partial array, storage_ok:false).",
+    "error": "collection.error. First failure message across the sections in collect() order (cluster, nodes, vms, lxc, storage), or null when every flag is true. A short structured hint ('node pve2: storage query failed'), truncated to 500 chars; the full exception goes to the agent log, not the payload. Opaque to the server -- surfaced as a diagnostic, never parsed."
+  },
   "inference_contract": {
+    "_note": "PRE-1.10.0 FALLBACK ONLY. When the explicit 'collection' block is present (agent >= 1.10.0) the server MUST use it (see 'collection_contract'); these shape rules are how the same signals are recovered from older agents that emit no flags.",
     "reachable": "payload is not null. A null payload (proxmox_metrics() -> None) is the ONLY unreachable/auth-failure signal; there is no partial 'all empty' payload to disambiguate (normalized agent-side in ProxmoxCollector.collect).",
     "cluster_ok": "payload.cluster is not null. CAVEAT: payload.cluster is also null for a genuine standalone node (see scenario 'standalone'). cluster:null is therefore ambiguous between (a) standalone, no corosync, and (b) a clustered reporter whose /cluster/status call failed -- ProxmoxCollector._collect_cluster returns None for both. The server must disambiguate with its own cross-reporter knowledge (a lone reporter => standalone; one of N cluster reporters returning cluster:null => that reporter's cluster fetch failed).",
     "nodes_ok": "when payload.cluster is present, len(payload.nodes) == payload.cluster.nodes_online. A node counted online by corosync (cluster.status) but missing from payload.nodes means its per-node detail collection failed mid-loop (see scenario 'partial_node_timeout'). For a standalone node (cluster:null) expect exactly one node entry.",
@@ -92,7 +101,8 @@
           {"name": "local-lvm", "node": "pve2", "type": "lvmthin", "total": 137438953472, "used": 20000000000, "available": 117438953472, "active": true},
           {"name": "ceph-pool", "node": "pve3", "type": "rbd", "total": 10995116277760, "used": 3298534883328, "available": 7696581394432, "active": true},
           {"name": "local-lvm", "node": "pve3", "type": "lvmthin", "total": 68719476736, "used": 10000000000, "available": 58719476736, "active": true}
-        ]
+        ],
+        "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": true, "guests_ok": true, "storage_ok": true, "error": null}
       }
     },
     "quorum_lost": {
@@ -137,7 +147,8 @@
         "lxc": [],
         "storage": [
           {"name": "local", "node": "pve1", "type": "dir", "total": 100000000000, "used": 40000000000, "available": 60000000000, "active": true}
-        ]
+        ],
+        "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": false, "guests_ok": false, "storage_ok": false, "error": "node pve2: status query failed"}
       }
     },
     "standalone": {
@@ -177,7 +188,8 @@
         "storage": [
           {"name": "local", "node": "standalone-pve", "type": "dir", "total": 100000000000, "used": 30000000000, "available": 70000000000, "active": true},
           {"name": "local-lvm", "node": "standalone-pve", "type": "lvmthin", "total": 200000000000, "used": 50000000000, "available": 150000000000, "active": true}
-        ]
+        ],
+        "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": true, "guests_ok": true, "storage_ok": true, "error": null}
       }
     },
     "unreachable": {
@@ -190,7 +202,7 @@
       "payload": null
     },
     "partial_node_timeout": {
-      "description": "Healthy 3-node quorate cluster where pve2's per-node API hangs (times out) mid-loop while corosync still counts it online. The cluster-wide /cluster/status call succeeds, so payload.cluster.nodes_online stays 3, but pve2's status/qemu/lxc/storage calls each raise and are swallowed per-node -- pve2 silently drops from nodes/vms/lxc/storage. Pins the partial-collection shape: cluster.nodes_online (3) != len(nodes) (2) is the server's nodes_ok=false signal; pve2's guests and storage vanish with it (guests_ok/storage_ok derived transitively).",
+      "description": "Healthy 3-node quorate cluster where pve2's per-node API hangs (times out) mid-loop while corosync still counts it online. The cluster-wide /cluster/status call succeeds, so payload.cluster.nodes_online stays 3, but pve2's status/qemu/lxc/storage calls each raise and are swallowed per-node -- pve2 silently drops from nodes/vms/lxc/storage. The explicit collection block reports this directly: nodes_ok/guests_ok/storage_ok all false (cluster_ok stays true), error the first failure ('node pve2: status query failed'). It also pins the pre-1.10.0 fallback shape for the same signal: cluster.nodes_online (3) != len(nodes) (2).",
       "api": {
         "version": {"version": "8.2.4"},
         "cluster_status": [
@@ -249,7 +261,91 @@
         "storage": [
           {"name": "local-lvm", "node": "pve1", "type": "lvmthin", "total": 137438953472, "used": 34359738368, "available": 103079215104, "active": true},
           {"name": "local-lvm", "node": "pve3", "type": "lvmthin", "total": 68719476736, "used": 10000000000, "available": 58719476736, "active": true}
-        ]
+        ],
+        "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": false, "guests_ok": false, "storage_ok": false, "error": "node pve2: status query failed"}
+      }
+    },
+    "cluster_fetch_failed": {
+      "description": "Clustered reporter whose /cluster/status call fails (mon/pmxcfs hiccup) while its own node detail, guests, and storage all succeed. _collect_cluster swallows the error and returns None, so payload.cluster is null -- SHAPE-identical to 'standalone'. The explicit flag is what tells them apart: here cluster_ok is false (the call raised), whereas 'standalone' has cluster_ok true (the call succeeded, there was just no cluster entry). This is the disambiguation the whole collection block exists to provide. error is the first (and only) failure. version + nodes present => reachable true.",
+      "api": {
+        "version": {"version": "8.2.4"},
+        "cluster_status_raises": true,
+        "nodes": [
+          {"node": "pve1", "status": "online", "cpu": 0.09, "mem": 4294967296, "maxmem": 17179869184}
+        ],
+        "node_status_by_name": {"pve1": {"uptime": 500000}},
+        "qemu_by_node": {"pve1": []},
+        "lxc_by_node": {"pve1": []},
+        "storage_by_node": {
+          "pve1": [
+            {"storage": "local", "type": "dir", "total": 100000000000, "used": 25000000000, "avail": 75000000000, "active": 1}
+          ]
+        }
+      },
+      "payload": {
+        "version": "8.2.4",
+        "cluster": null,
+        "nodes": [
+          {"name": "pve1", "status": "online", "cpu_usage": 0.09, "memory_used": 4294967296, "memory_total": 17179869184, "uptime": 500000, "vms_running": 0, "lxc_running": 0}
+        ],
+        "vms": [],
+        "lxc": [],
+        "storage": [
+          {"name": "local", "node": "pve1", "type": "dir", "total": 100000000000, "used": 25000000000, "available": 75000000000, "active": true}
+        ],
+        "collection": {"reachable": true, "cluster_ok": false, "nodes_ok": true, "guests_ok": true, "storage_ok": true, "error": "cluster status query failed"}
+      }
+    },
+    "storage_query_failed": {
+      "description": "Healthy 2-node quorate cluster where ONLY pve2's /nodes/pve2/storage call fails (e.g. a wedged storage plugin) -- its status, qemu, and lxc calls all succeed. pve2 stays in payload.nodes with its guests; just its storage rows drop. Pins storage_ok independence: nodes_ok/guests_ok stay true and only storage_ok is false, the exact shape from issue #80's example. This is what shape inference could never express: an empty/partial storage array here means 'query failed' (storage_ok:false), not 'no storages exist' (storage_ok:true).",
+      "api": {
+        "version": {"version": "8.2.4"},
+        "cluster_status": [
+          {"type": "cluster", "name": "production", "quorate": 1, "nodes": 2},
+          {"type": "node", "name": "pve1", "online": 1},
+          {"type": "node", "name": "pve2", "online": 1}
+        ],
+        "nodes": [
+          {"node": "pve1", "status": "online", "cpu": 0.1, "mem": 4294967296, "maxmem": 17179869184},
+          {"node": "pve2", "status": "online", "cpu": 0.2, "mem": 2147483648, "maxmem": 17179869184}
+        ],
+        "node_status_by_name": {"pve1": {"uptime": 700000}, "pve2": {"uptime": 700001}},
+        "qemu_by_node": {
+          "pve1": [
+            {"vmid": 100, "name": "web-01", "status": "running", "cpu": 0.08, "mem": 2147483648, "maxmem": 4294967296, "diskread": 1048576, "diskwrite": 2097152, "netin": 3145728, "netout": 4194304, "uptime": 699900}
+          ],
+          "pve2": []
+        },
+        "lxc_by_node": {
+          "pve1": [],
+          "pve2": [
+            {"vmid": 200, "name": "proxy-01", "status": "running", "cpu": 0.02, "mem": 536870912, "maxmem": 1073741824, "diskread": 524288, "diskwrite": 1048576, "netin": 2097152, "netout": 3145728, "uptime": 699800}
+          ]
+        },
+        "storage_by_node": {
+          "pve1": [
+            {"storage": "local-lvm", "type": "lvmthin", "total": 137438953472, "used": 34359738368, "avail": 103079215104, "active": 1}
+          ]
+        },
+        "storage_raises_for": ["pve2"]
+      },
+      "payload": {
+        "version": "8.2.4",
+        "cluster": {"name": "production", "quorate": true, "nodes": 2, "nodes_online": 2},
+        "nodes": [
+          {"name": "pve1", "status": "online", "cpu_usage": 0.1, "memory_used": 4294967296, "memory_total": 17179869184, "uptime": 700000, "vms_running": 1, "lxc_running": 0},
+          {"name": "pve2", "status": "online", "cpu_usage": 0.2, "memory_used": 2147483648, "memory_total": 17179869184, "uptime": 700001, "vms_running": 0, "lxc_running": 1}
+        ],
+        "vms": [
+          {"vmid": 100, "name": "web-01", "node": "pve1", "status": "running", "cpu_usage": 0.08, "memory_used": 2147483648, "memory_max": 4294967296, "disk_read": 1048576, "disk_write": 2097152, "net_in": 3145728, "net_out": 4194304, "uptime": 699900}
+        ],
+        "lxc": [
+          {"vmid": 200, "name": "proxy-01", "node": "pve2", "status": "running", "cpu_usage": 0.02, "memory_used": 536870912, "memory_max": 1073741824, "disk_read": 524288, "disk_write": 1048576, "net_in": 2097152, "net_out": 3145728, "uptime": 699800}
+        ],
+        "storage": [
+          {"name": "local-lvm", "node": "pve1", "type": "lvmthin", "total": 137438953472, "used": 34359738368, "available": 103079215104, "active": true}
+        ],
+        "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": true, "guests_ok": true, "storage_ok": false, "error": "node pve2: storage query failed"}
       }
     }
   }

--- a/tests/test_proxmox.py
+++ b/tests/test_proxmox.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fivenines_agent.proxmox import ProxmoxCollector, proxmox_metrics
+from fivenines_agent.proxmox import ProxmoxCollector, _record_failure, proxmox_metrics
 
 
 def make_proxmox_mock(
@@ -234,8 +234,9 @@ def test_collect_returns_none_when_proxmox_is_none():
     assert c.collect() is None
 
 
-def test_collect_returns_dict_with_six_keys():
-    """T14: collect returns dict with all six top-level keys."""
+def test_collect_returns_dict_with_seven_keys():
+    """T14: collect returns dict with all seven top-level keys (six data keys
+    plus the 1.10.0 'collection' flags block)."""
     c = make_collector(
         proxmox_mock=make_proxmox_mock(
             version={"version": "8"}, cluster_status=[], nodes=[]
@@ -249,6 +250,7 @@ def test_collect_returns_dict_with_six_keys():
         "vms",
         "lxc",
         "storage",
+        "collection",
     }
 
 
@@ -1036,6 +1038,253 @@ def test_proxmox_metrics_unreachable_returns_none_end_to_end():
         assert proxmox_metrics(token_id="root@pam!c", token_secret="s") is None
 
 
+# --- explicit collection flags block (1.10.0) -------------------------------
+#
+# data['proxmox'].collection = {reachable, cluster_ok, nodes_ok, guests_ok,
+# storage_ok, error}. Each *_ok is True iff every API call backing that section
+# succeeded (guests_ok covers both the qemu and lxc loops); the server reads
+# these instead of inferring completeness from the payload shape. reachable is
+# always True inside a non-null payload -- an unreachable API returns None (see
+# the 1.9.0 tests above), never a payload with reachable:false.
+
+
+def _collection(result):
+    """Pull the collection block, asserting the payload is non-null first."""
+    assert result is not None
+    return result["collection"]
+
+
+def test_record_failure_noop_when_collection_none():
+    """T68: _record_failure is a no-op when collection is None, so every
+    _collect_* helper stays callable in isolation (as the unit tests above do)
+    without a flags block to thread through."""
+    assert _record_failure(None, "nodes_ok", "ignored") is None
+
+
+def test_collection_all_ok_on_healthy_collection():
+    """T69: every section succeeding sets all flags True and error None."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[
+                {"type": "cluster", "name": "c1", "quorate": 1, "nodes": 1},
+                {"type": "node", "online": 1},
+            ],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_by_node={"pve1": []},
+        )
+    )
+    assert _collection(c.collect()) == {
+        "reachable": True,
+        "cluster_ok": True,
+        "nodes_ok": True,
+        "guests_ok": True,
+        "storage_ok": True,
+        "error": None,
+    }
+
+
+def test_collection_cluster_ok_false_when_cluster_status_raises():
+    """T70: /cluster/status raising sets cluster_ok False (cluster stays null)
+    and records the error; the node/guest/storage sections are unaffected."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status_raises=True,
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_by_node={"pve1": []},
+        )
+    )
+    result = c.collect()
+    assert result["cluster"] is None
+    coll = _collection(result)
+    assert coll["cluster_ok"] is False
+    assert coll["nodes_ok"] is True
+    assert coll["guests_ok"] is True
+    assert coll["storage_ok"] is True
+    assert coll["error"] == "cluster status query failed"
+
+
+def test_collection_standalone_keeps_cluster_ok_true():
+    """T71 [DISAMBIGUATION]: a standalone node (no cluster-type entry) leaves
+    cluster:null but cluster_ok True -- the flag the server uses to tell it
+    apart from a failed /cluster/status (cluster:null, cluster_ok False)."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[{"type": "node", "online": 1}],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_by_node={"pve1": []},
+        )
+    )
+    result = c.collect()
+    assert result["cluster"] is None
+    coll = _collection(result)
+    assert coll["cluster_ok"] is True
+    assert coll["error"] is None
+
+
+def test_collection_nodes_ok_false_when_node_status_raises():
+    """T72: a per-node status fetch raising drops that node and sets nodes_ok
+    False; the error names the node. guests_ok/storage_ok stay True here, so
+    the failure is attributed to the node section alone."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[],
+            nodes=[{"node": "pve1"}, {"node": "pve2"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            node_status_raises_for={"pve2"},
+            qemu_by_node={"pve1": [], "pve2": []},
+            lxc_by_node={"pve1": [], "pve2": []},
+            storage_by_node={"pve1": [], "pve2": []},
+        )
+    )
+    result = c.collect()
+    assert [n["name"] for n in result["nodes"]] == ["pve1"]
+    coll = _collection(result)
+    assert coll["nodes_ok"] is False
+    assert coll["guests_ok"] is True
+    assert coll["storage_ok"] is True
+    assert coll["error"] == "node pve2: status query failed"
+
+
+def test_collection_node_listing_failure_marks_all_node_derived_flags():
+    """T73: the /nodes listing itself raising fails the node, guest, and
+    storage sections together (each re-lists nodes). reachability still holds
+    via the version call, and cluster_ok is untouched."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[],
+            nodes_raises=True,
+        )
+    )
+    coll = _collection(c.collect())
+    assert coll["reachable"] is True
+    assert coll["cluster_ok"] is True
+    assert coll["nodes_ok"] is False
+    assert coll["guests_ok"] is False
+    assert coll["storage_ok"] is False
+    assert coll["error"] == "node listing failed"
+
+
+def test_collection_guests_ok_false_when_qemu_raises():
+    """T74: a per-node qemu listing raising sets guests_ok False; nodes_ok and
+    storage_ok are unaffected."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_raises_for={"pve1"},
+            lxc_by_node={"pve1": []},
+            storage_by_node={"pve1": []},
+        )
+    )
+    coll = _collection(c.collect())
+    assert coll["guests_ok"] is False
+    assert coll["nodes_ok"] is True
+    assert coll["storage_ok"] is True
+    assert coll["error"] == "node pve1: qemu query failed"
+
+
+def test_collection_guests_ok_false_when_lxc_raises():
+    """T75: a per-node lxc listing raising also sets guests_ok False -- the flag
+    covers both guest loops (qemu and lxc)."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_raises_for={"pve1"},
+            storage_by_node={"pve1": []},
+        )
+    )
+    coll = _collection(c.collect())
+    assert coll["guests_ok"] is False
+    assert coll["nodes_ok"] is True
+    assert coll["storage_ok"] is True
+    assert coll["error"] == "node pve1: lxc query failed"
+
+
+def test_collection_storage_ok_false_in_isolation():
+    """T76: a lone storage failure sets ONLY storage_ok False -- nodes_ok and
+    guests_ok stay True (issue #80's example shape). This is what shape
+    inference cannot express: an empty storage array here means 'query failed',
+    not 'no storages exist'."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status=[],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_raises_for={"pve1"},
+        )
+    )
+    coll = _collection(c.collect())
+    assert coll["storage_ok"] is False
+    assert coll["nodes_ok"] is True
+    assert coll["guests_ok"] is True
+    assert coll["cluster_ok"] is True
+    assert coll["error"] == "node pve1: storage query failed"
+
+
+def test_collection_error_is_first_failure_in_section_order():
+    """T77: with failures in multiple sections, error is the FIRST one in
+    collect() order (cluster before storage), not the last -- and later
+    failures still flip their own flag."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version={"version": "8"},
+            cluster_status_raises=True,
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_raises_for={"pve1"},
+        )
+    )
+    coll = _collection(c.collect())
+    assert coll["cluster_ok"] is False
+    assert coll["storage_ok"] is False
+    assert coll["error"] == "cluster status query failed"
+
+
+def test_collection_reachable_true_when_version_denied_but_nodes_listed():
+    """T78: reachable is True even when /version is denied, as long as the node
+    listing probe succeeds -- the payload exists, so reachable is stated True
+    (version is null, but that is carried by result['version'], not a flag)."""
+    c = make_collector(
+        proxmox_mock=make_proxmox_mock(
+            version_raises=True,
+            cluster_status=[],
+            nodes=[{"node": "pve1"}],
+            node_status_by_name={"pve1": {"uptime": 1}},
+            qemu_by_node={"pve1": []},
+            lxc_by_node={"pve1": []},
+            storage_by_node={"pve1": []},
+        )
+    )
+    result = c.collect()
+    assert result["version"] is None
+    assert _collection(result)["reachable"] is True
+
+
 # --- cross-repo contract (fivenines-server) ---------------------------------
 #
 # Shared fixture tests/fixtures/proxmox_contract_payload.json is asserted on
@@ -1043,10 +1292,12 @@ def test_proxmox_metrics_unreachable_returns_none_end_to_end():
 # spec in scenario["api"] must equal scenario["payload"], with only
 # proxmoxer.ProxmoxAPI mocked -- so the whole connect -> collect -> payload
 # pipeline is pinned. On fivenines-server: spec posts each scenario["payload"]
-# under data["proxmox"] and asserts the cluster-scope ingester derives the right
-# completeness flags. Unlike ceph the payload has NO 'collection' block:
-# completeness is inferred from SHAPE, so these shapes must stay pinned. Change
-# payloads only in lockstep with the server's byte-identical fixture copy.
+# under data["proxmox"] and asserts the cluster-scope ingester reads the right
+# completeness flags. As of agent 1.10.0 the payload carries an explicit
+# ceph-style 'collection' block (reachable/cluster_ok/nodes_ok/guests_ok/
+# storage_ok/error); the server prefers it over shape inference. Both the flags
+# AND the underlying shapes must stay pinned (shape is the pre-1.10.0 fallback).
+# Change payloads only in lockstep with the server's byte-identical fixture copy.
 
 _CONTRACT_FIXTURE_PATH = os.path.join(
     os.path.dirname(__file__), "fixtures", "proxmox_contract_payload.json"
@@ -1059,7 +1310,15 @@ _CONTRACT_SCENARIOS = _CONTRACT["scenarios"]
 
 # Top-level and per-entry key sets the server's shape inference depends on. A
 # rename or dropped key must fail HERE, not silently zero a server-side metric.
-_PAYLOAD_KEYS = {"version", "cluster", "nodes", "vms", "lxc", "storage"}
+_PAYLOAD_KEYS = {"version", "cluster", "nodes", "vms", "lxc", "storage", "collection"}
+_COLLECTION_KEYS = {
+    "reachable",
+    "cluster_ok",
+    "nodes_ok",
+    "guests_ok",
+    "storage_ok",
+    "error",
+}
 _CLUSTER_KEYS = {"name", "quorate", "nodes", "nodes_online"}
 _NODE_KEYS = {
     "name",
@@ -1108,6 +1367,7 @@ def test_contract_payload_key_sets(scenario_name):
     if payload is None:  # 'unreachable' -> data["proxmox"] is null
         return
     assert set(payload) == _PAYLOAD_KEYS
+    assert set(payload["collection"]) == _COLLECTION_KEYS
     if payload["cluster"] is not None:
         assert set(payload["cluster"]) == _CLUSTER_KEYS
     for node in payload["nodes"]:
@@ -1146,3 +1406,38 @@ def test_contract_standalone_cluster_is_null():
     assert standalone["cluster"] is None
     assert standalone["version"] is not None
     assert len(standalone["nodes"]) == 1
+
+
+def test_contract_collection_reachable_matches_non_null_payload():
+    """collection.reachable is True in every non-null payload; the only
+    unreachable signal remains a null payload ('unreachable')."""
+    for name, scenario in _CONTRACT_SCENARIOS.items():
+        payload = scenario["payload"]
+        if payload is None:
+            assert name == "unreachable"
+        else:
+            assert payload["collection"]["reachable"] is True
+
+
+def test_contract_collection_disambiguates_standalone_from_cluster_failure():
+    """The whole point of #80: 'standalone' and 'cluster_fetch_failed' both emit
+    cluster:null, and the explicit cluster_ok flag is what separates them --
+    a distinction the pre-1.10.0 shape inference could not make."""
+    standalone = _CONTRACT_SCENARIOS["standalone"]["payload"]
+    failed = _CONTRACT_SCENARIOS["cluster_fetch_failed"]["payload"]
+    assert standalone["cluster"] is None
+    assert failed["cluster"] is None
+    assert standalone["collection"]["cluster_ok"] is True
+    assert failed["collection"]["cluster_ok"] is False
+    assert failed["collection"]["error"] == "cluster status query failed"
+
+
+def test_contract_collection_storage_ok_independent():
+    """'storage_query_failed' pins storage_ok independence: only storage_ok is
+    false while nodes_ok/guests_ok/cluster_ok stay true (issue #80's example)."""
+    coll = _CONTRACT_SCENARIOS["storage_query_failed"]["payload"]["collection"]
+    assert coll["storage_ok"] is False
+    assert coll["nodes_ok"] is True
+    assert coll["guests_ok"] is True
+    assert coll["cluster_ok"] is True
+    assert coll["error"] == "node pve2: storage query failed"


### PR DESCRIPTION
## Summary

T5 of the Proxmox cluster-scope epic (server epic Five-Nines-io/fivenines_server#521). Adds an explicit ceph-style `collection` flags block to every non-null `data["proxmox"]` payload, so the server stops **inferring** reporter completeness from payload shape.

```json
"collection": {
  "reachable": true,
  "cluster_ok": true,
  "nodes_ok": true,
  "guests_ok": true,
  "storage_ok": false,
  "error": "node pve2: storage query failed"
}
```

Each `*_ok` flag is `true` iff every API call backing that section succeeded (`guests_ok` covers both the qemu and lxc loops). `error` is the first failure in `collect()` order — a short structured hint truncated to 500 chars (the full exception stays in the agent log). `reachable` is always `true` inside a non-null payload; an unreachable API still returns `null` (the sole unreachable signal, unchanged since 1.9.0).

**The key win:** `cluster:null` + `cluster_ok:true` = genuine standalone node; `cluster:null` + `cluster_ok:false` = a clustered reporter whose `/cluster/status` call failed. The server previously could not tell these two shapes apart.

## Implementation

- Module-level `_record_failure(collection, flag, message)` threaded through each `_collect_*(self, collection=None)`. When `collection` is `None` (helpers called in isolation by the unit tests) recording is a no-op, so no existing direct-call test changed.
- **Additive key** — the six existing data keys (`version`, `cluster`, `nodes`, `vms`, `lxc`, `storage`) are unchanged in shape and value. Existing server consumers are unaffected.

## Contract fixture (cross-repo source of truth)

`tests/fixtures/proxmox_contract_payload.json` gains the `collection` block on all 5 existing scenarios plus **2 new ones**:
- `cluster_fetch_failed` — `cluster:null` + `cluster_ok:false` (the standalone disambiguation partner).
- `storage_query_failed` — only `storage_ok:false` (this issue's example shape; pins flag independence).

The `inference_contract` narrative is retained and reframed as the pre-1.10.0 shape-inference fallback; a new `collection_contract` documents each flag.

## :warning: Needs a paired server PR (lockstep)

Per the issue, this repo is the source of truth. The server needs a paired PR to:
1. Sync the byte-identical fixture copy to `spec/fixtures/proxmox_contract_payload.json` (including the 2 new scenarios).
2. Make `Ingesters::Proxmox` **prefer the explicit flags over shape inference** when the block is present (additive; the server was built for this).

## Testing

- **114 proxmox tests pass, 100% coverage** on `proxmox.py` (with `proxmoxer` installed to match CI).
- Full suite: **1097 passed, 2 skipped, 0 failures** — zero regressions.
- flake8 clean, mypy clean, 0 non-ASCII, bandit unchanged (2 pre-existing Low findings).

## Version

`1.9.1` -> `1.10.0` (minor: additive payload feature, per the issue).

## Acceptance

- [x] Flags emitted on healthy + each error path
- [x] Existing consumers unaffected (additive key)
- [x] Fixture updated (agent-side source of truth)
- [x] Version bump
- [ ] Paired server PR linked (to be opened against fivenines_server)
- CHANGELOG: repo has no CHANGELOG file (convention: version in commit/PR title)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
