### PR TITLE
v1.11.3 feat: native ZFS pool health collector (#49)

### DIFF
--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -82,6 +82,9 @@ _DRY_RUN_CONFIG = {
     "smart_storage_health": True,
     "raid_storage_health": True,
     "ceph": {"clusters": [{"name": "ceph"}]},
+    # Host-level collector (generic zpool, no external config); True uses the
+    # default poll interval. Gated on the "zfs" capability like smart/raid.
+    "zfs": True,
     "fail2ban": True,
     "disk_health": True,
     # Dict (not bare True) because systemd_metrics takes **kwargs; scan=False

--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.11.0'
+VERSION = '1.11.3'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.10.0'
+VERSION = '1.11.0'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -29,6 +29,7 @@ from fivenines_agent.smart_storage import (
 )
 from fivenines_agent.systemd import systemd_metrics
 from fivenines_agent.temperatures import temperatures
+from fivenines_agent.zfs import zfs_storage_health
 
 # Registry of metric collectors.
 # Each entry: (config_key, [(data_key, callable, pass_kwargs), ...])
@@ -72,6 +73,10 @@ COLLECTORS = [
     # Ceph: list-driven multi-cluster. config["ceph"] == {"clusters": [...]} is
     # unpacked (pass_kwargs) into ceph_metrics(clusters=[...]).
     ("ceph", [("ceph", ceph_metrics, True)]),
+    # ZFS: host-local pool health (generic, not Proxmox-scoped). config["zfs"]
+    # may be True (defaults) or {"interval": N}, unpacked into
+    # zfs_storage_health(interval=N). Gated on the "zfs" capability.
+    ("zfs", [("zfs", zfs_storage_health, True)]),
     ("processes", [("processes", processes, False)]),
     ("ports", [("ports", listening_ports, True)]),
     ("temperatures", [("temperatures", temperatures, False)]),

--- a/fivenines_agent/zfs.py
+++ b/fivenines_agent/zfs.py
@@ -1,4 +1,4 @@
-import os
+import re
 import shutil
 import subprocess
 import time
@@ -6,68 +6,152 @@ import time
 from fivenines_agent.debug import debug, log
 from fivenines_agent.subprocess_utils import get_clean_env
 
+# Default poll throttle (seconds). Overridable via the "zfs" config dict, which
+# collectors.py unpacks as kwargs: {"interval": N} -> zfs_storage_health(interval=N).
+_DEFAULT_INTERVAL = 60
+
 _zfs_cache = {
     "timestamp": 0,
-    "data": []
+    "data": [],
 }
+
+# Stable wire contract: zpool health string -> numeric code. Append-only, never
+# renumber (the server's ZFS ingester depends on these values). Unknown -> None,
+# and the raw "health" string is kept so the backend can still react to it.
+_HEALTH_CODES = {
+    "ONLINE": 0,
+    "DEGRADED": 1,
+    "FAULTED": 2,
+    "OFFLINE": 3,
+    "REMOVED": 4,
+    "UNAVAIL": 5,
+    "SUSPENDED": 6,
+}
+
+# vdev/device states that count toward degraded_vdevs. ONLINE and spare states
+# (AVAIL/INUSE) are healthy and excluded.
+_UNHEALTHY_VDEV_STATES = {"DEGRADED", "FAULTED", "OFFLINE", "REMOVED", "UNAVAIL"}
+
+# `zpool status` line labels, used to bound the multi-line scan block.
+_STATUS_LABELS = (
+    "pool:",
+    "state:",
+    "status:",
+    "action:",
+    "see:",
+    "scan:",
+    "config:",
+    "errors:",
+    "remove:",
+    "checkpoint:",
+    "dedup:",
+)
+
 
 def zfs_available() -> bool:
     """Check if ZFS is available on the system."""
     return shutil.which("zpool") is not None
 
-def get_zfs_version():
-    """Get ZFS version information."""
-    try:
-        result = subprocess.run(
-            ["zpool", "version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=True,
-            env=get_clean_env()
-        )
-        return result.stdout.split('\n')[0].strip()
-    except Exception as e:
-        log(f"Error fetching ZFS version: {e}", 'error')
-        return None
-
-def list_zfs_pools():
-    """List all ZFS pools."""
-    pools = []
-    try:
-        result = subprocess.run(
-            ["zpool", "list", "-H", "-o", "name"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            check=True,
-            env=get_clean_env()
-        )
-        for line in result.stdout.splitlines():
-            if line.strip():
-                pools.append(line.strip())
-    except Exception as e:
-        log(f"Error listing ZFS pools: {e}", 'error')
-    return pools
 
 def _run(cmd):
     return subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, check=False, env=get_clean_env()
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+        env=get_clean_env(),
     )
+
+
+def get_zfs_version():
+    """Get ZFS version information (first line of `zpool version`)."""
+    r = _run(["zpool", "version"])
+    if r.returncode != 0:
+        return None
+    line = r.stdout.split("\n", 1)[0].strip()
+    return line or None
+
+
+def list_zfs_pools():
+    """List all ZFS pool names."""
+    r = _run(["zpool", "list", "-H", "-o", "name"])
+    if r.returncode != 0:
+        return []
+    return [ln.strip() for ln in r.stdout.splitlines() if ln.strip()]
+
 
 def _safe_int(x, default=None):
     try:
         return int(x)
-    except Exception:
+    except (TypeError, ValueError):
         try:
             return int(float(x))
-        except Exception:
+        except (TypeError, ValueError):
             return default
+
+
+def _health_code(health):
+    """Map a zpool health string to the stable numeric contract code (or None)."""
+    if not health:
+        return None
+    return _HEALTH_CODES.get(health.strip().upper())
+
+
+def _count_degraded_vdevs(vdev_tree):
+    """Count devices/vdevs below the pool root whose state is unhealthy.
+
+    Walks the primary child tree only. Section devices (spares/cache/logs) are
+    already reachable there via the indentation parser, so they are counted once.
+    Returns None when there is no vdev tree (status unavailable).
+    """
+    if not vdev_tree:
+        return None
+    count = 0
+    stack = list(vdev_tree.get("children", []) or [])
+    while stack:
+        node = stack.pop()
+        state = node.get("state")
+        if state and state.strip().upper() in _UNHEALTHY_VDEV_STATES:
+            count += 1
+        stack.extend(node.get("children", []) or [])
+    return count
+
+
+def _parse_resilver_progress(scan_text):
+    """Percent (0-100) of an in-progress resilver; 0.0 when not resilvering.
+
+    Returns None when no scan information is available (status unavailable).
+    """
+    if scan_text is None:
+        return None
+    if "resilver in progress" not in scan_text.lower():
+        return 0.0
+    m = re.search(r"(\d+(?:\.\d+)?)\s*% done", scan_text)
+    return float(m.group(1)) if m else 0.0
+
+
+def _parse_scrub_errors(scan_text):
+    """Error count reported by the last completed scrub.
+
+    Returns None when the last scan was not a completed scrub (never scrubbed,
+    resilver in progress, or status unavailable), so the backend can tell a clean
+    scrub (0) from an unknown one.
+    """
+    if not scan_text or "scrub repaired" not in scan_text.lower():
+        return None
+    m = re.search(r"with (\d+) errors", scan_text)
+    return _safe_int(m.group(1)) if m else None
+
 
 def _indent_width(line):
     expanded = line.expandtabs(8)
     return len(expanded) - len(expanded.lstrip(" "))
+
+
+def _is_status_label(stripped):
+    return any(stripped.startswith(lbl) for lbl in _STATUS_LABELS)
+
 
 def _push_by_indent(indent_stack, root, indent, node):
     while indent_stack and indent_stack[-1][0] >= indent:
@@ -79,11 +163,13 @@ def _push_by_indent(indent_stack, root, indent, node):
         root.setdefault("children", []).append(node)
     indent_stack.append((indent, node))
 
+
 def _parse_zpool_status(text):
     pools = {}
     cur = None
     in_config = False
     header_seen = False
+    in_scan = False
     indent_stack = []
     section = None  # logs/spares/cache/special
     pool_name = None
@@ -100,17 +186,26 @@ def _parse_zpool_status(text):
             finalize_current()
             pool_name = line.split(":", 1)[1].strip()
             cur = {
-                "name": pool_name,
                 "scan": None,
+                "scan_full": None,
                 "errors": None,
                 "vdev_tree": {
-                    "name": None, "state": None, "read": None, "write": None, "cksum": None,
-                    "children": [], "logs": [], "spares": [], "cache": [], "special": []
+                    "name": None,
+                    "state": None,
+                    "read": None,
+                    "write": None,
+                    "cksum": None,
+                    "children": [],
+                    "logs": [],
+                    "spares": [],
+                    "cache": [],
+                    "special": [],
                 },
-                "parser_warnings": []
+                "_scan_lines": [],
             }
             in_config = False
             header_seen = False
+            in_scan = False
             indent_stack = []
             section = None
             continue
@@ -118,11 +213,28 @@ def _parse_zpool_status(text):
         if not cur:
             continue
 
+        # Accumulate the multi-line scan block. Continuation lines are indented
+        # and are not themselves status labels. This must run before the label
+        # handlers so the "% done" / "with N errors" details are not dropped.
+        if in_scan:
+            stripped_c = line.strip()
+            if (
+                line[:1] in (" ", "\t")
+                and stripped_c
+                and not _is_status_label(stripped_c)
+            ):
+                cur["_scan_lines"].append(stripped_c)
+                continue
+            in_scan = False  # not a continuation: fall through to normal handling
+
         if line.startswith(" state:"):
             cur["vdev_tree"]["state"] = line.split(":", 1)[1].strip()
             continue
         if line.strip().startswith("scan:"):
-            cur["scan"] = line.split(":", 1)[1].strip()
+            first = line.split(":", 1)[1].strip()
+            cur["scan"] = first
+            cur["_scan_lines"] = [first]
+            in_scan = True
             continue
         if line.strip().startswith("errors:"):
             cur["errors"] = line.split(":", 1)[1].strip()
@@ -152,29 +264,29 @@ def _parse_zpool_status(text):
             section = st
             continue
 
-        # Device/vdev row
+        # Device/vdev row (line is already known non-empty here)
         leading = _indent_width(line)
         cols = line.split()
-        if not cols:
-            continue
-
         name = cols[0]
         state = cols[1] if len(cols) > 1 else None
 
         def _num(i):
             try:
                 return int(cols[i])
-            except Exception:
+            except (IndexError, ValueError):
                 return None
 
-        read = _num(2)
-        write = _num(3)
-        cksum = _num(4)
-        node = {"name": name, "state": state, "read": read, "write": write, "cksum": cksum}
+        node = {
+            "name": name,
+            "state": state,
+            "read": _num(2),
+            "write": _num(3),
+            "cksum": _num(4),
+        }
 
         root = cur["vdev_tree"]
 
-        if root["name"] is None and name == cur["name"]:
+        if root["name"] is None and name == pool_name:
             root.update(node)
             indent_stack = [(leading, root)]
             continue
@@ -187,11 +299,26 @@ def _parse_zpool_status(text):
 
     finalize_current()
 
+    # Collapse the scan block into a single string for numeric derivation and
+    # drop the scratch field.
+    for p in pools.values():
+        lines = p.pop("_scan_lines", [])
+        p["scan_full"] = " ".join(lines) if lines else p.get("scan")
+
     return pools
+
 
 def _zpool_list_summary():
     res = {}
-    q = _run(["zpool", "list", "-Hp", "-o", "name,health,size,alloc,free,frag,cap,dedupratio"])
+    q = _run(
+        [
+            "zpool",
+            "list",
+            "-Hp",
+            "-o",
+            "name,health,size,alloc,free,frag,cap,dedupratio",
+        ]
+    )
     if q.returncode != 0:
         return res
     for line in filter(None, q.stdout.splitlines()):
@@ -208,67 +335,81 @@ def _zpool_list_summary():
                 "frag_percent": _safe_int(frag),
                 "capacity_percent": _safe_int(cap),
                 "dedup_ratio": (None if dedup in ("-", "") else float(dedup)),
-            }
+            },
         }
     return res
 
+
 def get_zfs_pool_info(pool_name):
-    """Get comprehensive ZFS pool information."""
+    """Collect the health contract for a single ZFS pool."""
     try:
         list_summary = _zpool_list_summary()
-        status_cp = _run(["zpool", "status", "-PLv", pool_name])
+
+        # -p (parseable) is unsupported on very old ZFS; fall back to -PLv.
+        status_cp = _run(["zpool", "status", "-pPLv", pool_name])
+        if status_cp.returncode != 0:
+            status_cp = _run(["zpool", "status", "-PLv", pool_name])
 
         if status_cp.returncode != 0 and pool_name not in list_summary:
-            log(f"Error getting ZFS pool info for {pool_name}: {status_cp.stderr.strip() or 'zpool failed'}", 'error')
+            log(
+                f"Error getting ZFS pool info for {pool_name}: "
+                f"{status_cp.stderr.strip() or 'zpool failed'}",
+                "error",
+            )
             return None
 
-        details = _parse_zpool_status(status_cp.stdout) if status_cp.returncode == 0 else {}
+        details = (
+            _parse_zpool_status(status_cp.stdout) if status_cp.returncode == 0 else {}
+        )
         d = details.get(pool_name, {})
         s = list_summary.get(pool_name, {})
+        summary = s.get("summary")
+        health = s.get("health")
         vdev_tree = d.get("vdev_tree")
+        scan_full = d.get("scan_full")
 
-        parser_warnings = d.get("parser_warnings", [])
-        if vdev_tree and vdev_tree.get("name") != pool_name:
-            parser_warnings.append(f"root.name={vdev_tree.get('name')} != pool {pool_name}")
-
-        pool_info = {
+        return {
             "name": pool_name,
-            "health": s.get("health"),
-            "summary": s.get("summary"),
-            "scan": d.get("scan"),
+            "health": health,
+            "health_code": _health_code(health),
+            "degraded_vdevs": _count_degraded_vdevs(vdev_tree),
+            "resilver_progress": _parse_resilver_progress(scan_full),
+            "scrub_errors": _parse_scrub_errors(scan_full),
+            "fragmentation": (summary or {}).get("frag_percent"),
+            "summary": summary,
             "errors": d.get("errors"),
             "vdev_tree": vdev_tree,
-            "parser_warnings": parser_warnings,
-            "status_raw": status_cp.stdout if status_cp.returncode == 0 else None,
         }
 
-        return pool_info
-
     except Exception as e:
-        log(f"Error fetching ZFS pool info for {pool_name}: {e}", 'error')
+        log(f"Error fetching ZFS pool info for {pool_name}: {e}", "error")
         return None
 
-@debug('zfs_storage_health')
-def zfs_storage_health():
+
+@debug("zfs_storage_health")
+def zfs_storage_health(interval=_DEFAULT_INTERVAL):
+    """Collect health for all ZFS pools.
+
+    Throttled to at most once per `interval` seconds (default 60); the agent's
+    global tick can be shorter than a zpool poll is worth.
     """
-    Collect health info for all ZFS pools.
-    Cached for 60 seconds.
-    """
-    global _zfs_cache
     now = time.time()
 
-    if now - _zfs_cache["timestamp"] < 60:
+    ttl = _safe_int(interval, _DEFAULT_INTERVAL)
+    if ttl < 0:
+        ttl = _DEFAULT_INTERVAL
+
+    if now - _zfs_cache["timestamp"] < ttl:
         return _zfs_cache["data"]
 
     if not zfs_available():
-        log("ZFS not available", 'error')
+        log("ZFS not available", "debug")
         data = []
     else:
         zfs_version = get_zfs_version()
-
         pools = list_zfs_pools()
         if not pools:
-            log("No ZFS pools found", 'error')
+            log("No ZFS pools found", "debug")
             data = []
         else:
             data = [get_zfs_pool_info(pool) for pool in pools]

--- a/fivenines_agent/zfs.py
+++ b/fivenines_agent/zfs.py
@@ -10,6 +10,13 @@ from fivenines_agent.subprocess_utils import get_clean_env
 # collectors.py unpacks as kwargs: {"interval": N} -> zfs_storage_health(interval=N).
 _DEFAULT_INTERVAL = 60
 
+# Hard subprocess timeout (seconds). A wedged `zpool` call -- SUSPENDED pool,
+# dying controller, kernel stuck on I/O, the exact states this collector exists
+# to report -- must never hang the whole collect tick. zpool reads kernel state
+# and answers in milliseconds when healthy, so 10s is generous. Mirrors
+# ceph.py's SUBPROCESS_TIMEOUT posture.
+_SUBPROCESS_TIMEOUT = 10
+
 _zfs_cache = {
     "timestamp": 0,
     "data": [],
@@ -54,14 +61,26 @@ def zfs_available() -> bool:
 
 
 def _run(cmd):
-    return subprocess.run(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-        env=get_clean_env(),
-    )
+    """Run a zpool command, bounded by _SUBPROCESS_TIMEOUT.
+
+    A timeout is returned as a synthetic failed result (returncode 1, empty
+    stdout, stderr "timeout") so it is indistinguishable from any other command
+    failure. Every existing failure path then applies unchanged: the
+    -pPLv -> -PLv retry, the list-only degrade, the pool skip, and the
+    collector returning [].
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=_SUBPROCESS_TIMEOUT,
+            env=get_clean_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="timeout")
 
 
 def get_zfs_version():
@@ -74,10 +93,16 @@ def get_zfs_version():
 
 
 def list_zfs_pools():
-    """List all ZFS pool names."""
+    """List ZFS pool names, or None if the `zpool list` command failed.
+
+    None (command failure/timeout) is deliberately distinct from [] (command
+    succeeded, host has zero pools): the collector maps the former to a null
+    payload (collection failure) and the latter to an empty list, so the server
+    never mistakes a transient CLI failure for "all pools destroyed".
+    """
     r = _run(["zpool", "list", "-H", "-o", "name"])
     if r.returncode != 0:
-        return []
+        return None
     return [ln.strip() for ln in r.stdout.splitlines() if ln.strip()]
 
 
@@ -390,8 +415,19 @@ def get_zfs_pool_info(pool_name):
 def zfs_storage_health(interval=_DEFAULT_INTERVAL):
     """Collect health for all ZFS pools.
 
-    Throttled to at most once per `interval` seconds (default 60); the agent's
-    global tick can be shorter than a zpool poll is worth.
+    Returns one of three outcomes, cached for `interval` seconds (default 60):
+
+    - ``None`` -- COLLECTION FAILURE: the `zpool` binary vanished mid-run, the
+      pool listing failed/timed out, or pools exist but every per-pool read
+      failed. Surfaced as ``data["zfs"] = null`` so the server never mistakes a
+      transient CLI failure for "all pools destroyed" and prunes health rows
+      (same null-vs-empty discipline as the docker contract).
+    - ``[]`` -- the listing succeeded and the host genuinely has zero pools
+      (safe for the server to prune).
+    - a non-empty list of per-pool health objects.
+
+    The outcome (including ``None``) is cached like any other, so a failure does
+    not turn into a per-tick re-probe storm.
     """
     now = time.time()
 
@@ -402,22 +438,37 @@ def zfs_storage_health(interval=_DEFAULT_INTERVAL):
     if now - _zfs_cache["timestamp"] < ttl:
         return _zfs_cache["data"]
 
-    if not zfs_available():
-        log("ZFS not available", "debug")
-        data = []
-    else:
-        zfs_version = get_zfs_version()
-        pools = list_zfs_pools()
-        if not pools:
-            log("No ZFS pools found", "debug")
-            data = []
-        else:
-            data = [get_zfs_pool_info(pool) for pool in pools]
-            data = [d for d in data if d is not None]
-            for pool_info in data:
-                pool_info["zfs_version"] = zfs_version
+    data = _collect_zfs_pools()
 
     _zfs_cache["timestamp"] = now
     _zfs_cache["data"] = data
 
     return data
+
+
+def _collect_zfs_pools():
+    """Collect all pools, or None on any collection failure. See caller."""
+    if not zfs_available():
+        # zpool binary gone mid-run -> collection failure, not "no pools".
+        log("ZFS not available", "debug")
+        return None
+
+    pools = list_zfs_pools()
+    if pools is None:
+        log("ZFS pool listing failed", "debug")
+        return None
+    if not pools:
+        # Listing succeeded, host genuinely has zero pools.
+        return []
+
+    zfs_version = get_zfs_version()
+    infos = [get_zfs_pool_info(pool) for pool in pools]
+    infos = [d for d in infos if d is not None]
+    if not infos:
+        # Pools exist but not one could be read -> collection failure.
+        log("ZFS pools present but all reads failed", "debug")
+        return None
+
+    for pool_info in infos:
+        pool_info["zfs_version"] = zfs_version
+    return infos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.10.0"
+version = "1.11.0"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.11.0"
+version = "1.11.3"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/zfs_contract_payload.json
+++ b/tests/fixtures/zfs_contract_payload.json
@@ -1,6 +1,7 @@
 {
-  "description": "Shared ZFS contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/zfs_contract_payload.json, asserted end-to-end by tests/test_zfs.py::test_contract_fixture_round_trip (only zfs._run and shutil.which are mocked with the canned zpool CLI output below). 'config' is the shape config['zfs'] takes (True, or {'interval': N}); 'payload' is the artifact the agent emits under data['zfs'] -- a list of per-pool health objects the server's ZFS ingester must parse. The collector is GENERIC (host-local zpool), not Proxmox-scoped: the server joins these pools to proxmox_storages where storage_type='zfs' on (host, pool name). Change the payload shape only in lockstep with the server spec and its fixture copy.",
+  "description": "Shared ZFS contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/zfs_contract_payload.json, asserted end-to-end by tests/test_zfs.py::test_contract_fixture_round_trip (only zfs._run and shutil.which are mocked with the canned zpool CLI below). Each scenario's 'config' is the shape config['zfs'] takes (True, or {'interval': N}); 'payload' is the artifact the agent emits under data['zfs']. The collector is GENERIC (host-local zpool), not Proxmox-scoped: the server treats each pool as a HOST-SCOPED entity keyed (host, pool name). Proxmox correlation is a possible LATER enrichment, NOT part of this contract and NOT a simple join on proxmox_storages.name -- that column is the PVE storage ID (e.g. 'local-zfs'), not the zpool name (e.g. 'rpool'); a stock PVE install has storage 'local-zfs' -> dataset 'rpool/data' while zpool list reports 'rpool', so the names never match. Mapping would require collecting the PVE storage's 'pool' property, which neither side does today. See 'null_contract' for the null-vs-empty pruning rule. Change the payload shape only in lockstep with the server spec and its byte-identical fixture copy.",
   "agent_min_version": "1.11.3",
+  "null_contract": "data['zfs'] is one of THREE outcomes and the server MUST branch on them: (a) null (JSON null / Python None) = COLLECTION FAILURE -- `zpool list` failed or timed out, the zpool binary vanished mid-run, or pools exist but every per-pool read failed. The server MUST NOT prune zfs_pools rows or auto-resolve zfs_pool_health incidents on null: a transient CLI failure is not 'all pools destroyed', and treating it as recovery is a false-recovery bug on a monitoring product. (b) [] (empty array) = the listing succeeded and the host genuinely has ZERO pools -- safe to prune. (c) a non-empty array of per-pool objects = the live set. Same null-vs-empty discipline as the docker contract (data['docker'] = null = collection failure). The agent caches the null outcome under the poll interval like any other, so a failure does not become a per-tick re-probe storm.",
   "health_code_contract": {
     "_note": "Stable, append-only mapping of the zpool health string to payload.health_code. Never renumber. Unrecognized states -> null, with the raw 'health' string preserved so the backend can still react.",
     "0": "ONLINE",
@@ -15,106 +16,112 @@
   "field_contract": {
     "health": "raw zpool list health string, preserved verbatim.",
     "health_code": "health mapped via health_code_contract; null if unrecognized.",
-    "degraded_vdevs": "count of devices/vdevs below the pool root whose state is DEGRADED/FAULTED/OFFLINE/REMOVED/UNAVAIL. null when zpool status was unavailable.",
-    "resilver_progress": "percent 0-100 of an in-progress resilver; 0.0 when not resilvering; null when zpool status was unavailable.",
+    "degraded_vdevs": "count of devices/vdevs below the pool root whose state is DEGRADED/FAULTED/OFFLINE/REMOVED/UNAVAIL. null when zpool status was unavailable. SHARP EDGE: counts EVERY unhealthy node in the tree -- intermediate vdevs AND leaves (one FAULTED disk in a mirror = 2: the DEGRADED mirror + the FAULTED leaf, as in the 'tank' scenario). Use it for >0 alerting; do NOT render it as 'N disks failed'.",
+    "resilver_progress": "percent 0-100 of an in-progress resilver; 0.0 when not resilvering; null when zpool status was unavailable. SHARP EDGE: 0.0 means BOTH 'not resilvering' AND 'resilver just started, no % done printed yet'. Detect that a resilver is HAPPENING from health/scan state, never from progress > 0.",
     "scrub_errors": "error count from the LAST COMPLETED scrub ('...with N errors'); null when the last scan was not a completed scrub (never scrubbed, resilver in progress, or status unavailable) -- distinguishes clean (0) from unknown (null). Distinct from 'errors' (current known data errors).",
-    "fragmentation": "pool fragmentation percent (mirror of summary.frag_percent, surfaced top-level for the backend join).",
+    "fragmentation": "pool fragmentation percent (mirror of summary.frag_percent, surfaced top-level for convenience).",
     "summary": "capacity block from 'zpool list -Hp': byte totals, frag/capacity percent, dedup_ratio (null when '-').",
     "errors": "raw 'errors:' line from zpool status (current known data errors), NOT the scrub error count.",
-    "vdev_tree": "parsed device hierarchy (diagnostic); each node carries name/state/read/write/cksum and nested children; section devices in logs/spares/cache/special.",
+    "vdev_tree": "parsed device hierarchy (diagnostic); each node carries name/state/read/write/cksum and nested children. SHARP EDGE: section devices (logs/cache/spares/special) appear BOTH nested under 'children' (via the indent parser -- which is what lets the degraded_vdevs walk reach them) AND in their own section list. Deliberate; the server must not double-render them.",
     "zfs_version": "first line of 'zpool version', repeated per pool."
   },
-  "config": { "interval": 60 },
-  "scenario": {
-    "rpool": "healthy: ONLINE, last scrub completed with 0 errors, not resilvering -> health_code 0, degraded_vdevs 0, resilver_progress 0.0, scrub_errors 0.",
-    "tank": "degraded: one mirror leg FAULTED, resilver in progress at 42.13% -> health_code 1, degraded_vdevs 2 (the DEGRADED mirror + the FAULTED leaf), resilver_progress 42.13, scrub_errors null (last scan is a resilver, not a scrub)."
-  },
-  "payload": [
-    {
-      "name": "rpool",
-      "health": "ONLINE",
-      "health_code": 0,
-      "degraded_vdevs": 0,
-      "resilver_progress": 0.0,
-      "scrub_errors": 0,
-      "fragmentation": 5,
-      "summary": {
-        "size_bytes": 1000204886016,
-        "alloc_bytes": 500102443008,
-        "free_bytes": 500102443008,
-        "frag_percent": 5,
-        "capacity_percent": 50,
-        "dedup_ratio": 1.0
-      },
-      "errors": "No known data errors",
-      "vdev_tree": {
-        "name": "rpool",
-        "state": "ONLINE",
-        "read": 0,
-        "write": 0,
-        "cksum": 0,
-        "children": [
-          {
-            "name": "mirror-0",
+  "scenarios": {
+    "healthy_and_degraded": {
+      "description": "Two pools. rpool: ONLINE, last scrub completed with 0 errors, not resilvering -> health_code 0, degraded_vdevs 0, resilver_progress 0.0, scrub_errors 0. tank: one mirror leg FAULTED, resilver in progress at 42.13% -> health_code 1, degraded_vdevs 2 (the DEGRADED mirror + the FAULTED leaf), resilver_progress 42.13, scrub_errors null (last scan is a resilver, not a scrub).",
+      "config": { "interval": 60 },
+      "payload": [
+        {
+          "name": "rpool",
+          "health": "ONLINE",
+          "health_code": 0,
+          "degraded_vdevs": 0,
+          "resilver_progress": 0.0,
+          "scrub_errors": 0,
+          "fragmentation": 5,
+          "summary": {
+            "size_bytes": 1000204886016,
+            "alloc_bytes": 500102443008,
+            "free_bytes": 500102443008,
+            "frag_percent": 5,
+            "capacity_percent": 50,
+            "dedup_ratio": 1.0
+          },
+          "errors": "No known data errors",
+          "vdev_tree": {
+            "name": "rpool",
             "state": "ONLINE",
             "read": 0,
             "write": 0,
             "cksum": 0,
             "children": [
-              { "name": "sda", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
-              { "name": "sdb", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 }
-            ]
-          }
-        ],
-        "logs": [],
-        "spares": [],
-        "cache": [],
-        "special": []
-      },
-      "zfs_version": "zfs-2.2.2-1"
-    },
-    {
-      "name": "tank",
-      "health": "DEGRADED",
-      "health_code": 1,
-      "degraded_vdevs": 2,
-      "resilver_progress": 42.13,
-      "scrub_errors": null,
-      "fragmentation": 12,
-      "summary": {
-        "size_bytes": 4000787030016,
-        "alloc_bytes": 1200236109004,
-        "free_bytes": 2800550921012,
-        "frag_percent": 12,
-        "capacity_percent": 30,
-        "dedup_ratio": 1.0
-      },
-      "errors": "No known data errors",
-      "vdev_tree": {
-        "name": "tank",
-        "state": "DEGRADED",
-        "read": 0,
-        "write": 0,
-        "cksum": 0,
-        "children": [
-          {
-            "name": "mirror-0",
+              {
+                "name": "mirror-0",
+                "state": "ONLINE",
+                "read": 0,
+                "write": 0,
+                "cksum": 0,
+                "children": [
+                  { "name": "sda", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
+                  { "name": "sdb", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 }
+                ]
+              }
+            ],
+            "logs": [],
+            "spares": [],
+            "cache": [],
+            "special": []
+          },
+          "zfs_version": "zfs-2.2.2-1"
+        },
+        {
+          "name": "tank",
+          "health": "DEGRADED",
+          "health_code": 1,
+          "degraded_vdevs": 2,
+          "resilver_progress": 42.13,
+          "scrub_errors": null,
+          "fragmentation": 12,
+          "summary": {
+            "size_bytes": 4000787030016,
+            "alloc_bytes": 1200236109004,
+            "free_bytes": 2800550921012,
+            "frag_percent": 12,
+            "capacity_percent": 30,
+            "dedup_ratio": 1.0
+          },
+          "errors": "No known data errors",
+          "vdev_tree": {
+            "name": "tank",
             "state": "DEGRADED",
             "read": 0,
             "write": 0,
             "cksum": 0,
             "children": [
-              { "name": "sdc", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
-              { "name": "sdd", "state": "FAULTED", "read": 3, "write": 0, "cksum": 0 }
-            ]
-          }
-        ],
-        "logs": [],
-        "spares": [],
-        "cache": [],
-        "special": []
-      },
-      "zfs_version": "zfs-2.2.2-1"
+              {
+                "name": "mirror-0",
+                "state": "DEGRADED",
+                "read": 0,
+                "write": 0,
+                "cksum": 0,
+                "children": [
+                  { "name": "sdc", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
+                  { "name": "sdd", "state": "FAULTED", "read": 3, "write": 0, "cksum": 0 }
+                ]
+              }
+            ],
+            "logs": [],
+            "spares": [],
+            "cache": [],
+            "special": []
+          },
+          "zfs_version": "zfs-2.2.2-1"
+        }
+      ]
+    },
+    "collection_failure": {
+      "description": "`zpool list` failed / timed out (or the listing succeeded but every per-pool read failed, or the zpool binary vanished mid-run). The agent emits data['zfs'] = null. The server MUST NOT prune zfs_pools rows or auto-resolve health incidents -- this is a transient failure, not 'all pools destroyed'. Contrast the empty-array case (listing succeeded, zero pools), which IS safe to prune.",
+      "config": { "interval": 60 },
+      "payload": null
     }
-  ]
+  }
 }

--- a/tests/fixtures/zfs_contract_payload.json
+++ b/tests/fixtures/zfs_contract_payload.json
@@ -1,0 +1,120 @@
+{
+  "description": "Shared ZFS contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/zfs_contract_payload.json, asserted end-to-end by tests/test_zfs.py::test_contract_fixture_round_trip (only zfs._run and shutil.which are mocked with the canned zpool CLI output below). 'config' is the shape config['zfs'] takes (True, or {'interval': N}); 'payload' is the artifact the agent emits under data['zfs'] -- a list of per-pool health objects the server's ZFS ingester must parse. The collector is GENERIC (host-local zpool), not Proxmox-scoped: the server joins these pools to proxmox_storages where storage_type='zfs' on (host, pool name). Change the payload shape only in lockstep with the server spec and its fixture copy.",
+  "agent_min_version": "1.11.0",
+  "health_code_contract": {
+    "_note": "Stable, append-only mapping of the zpool health string to payload.health_code. Never renumber. Unrecognized states -> null, with the raw 'health' string preserved so the backend can still react.",
+    "0": "ONLINE",
+    "1": "DEGRADED",
+    "2": "FAULTED",
+    "3": "OFFLINE",
+    "4": "REMOVED",
+    "5": "UNAVAIL",
+    "6": "SUSPENDED",
+    "null": "unrecognized health string"
+  },
+  "field_contract": {
+    "health": "raw zpool list health string, preserved verbatim.",
+    "health_code": "health mapped via health_code_contract; null if unrecognized.",
+    "degraded_vdevs": "count of devices/vdevs below the pool root whose state is DEGRADED/FAULTED/OFFLINE/REMOVED/UNAVAIL. null when zpool status was unavailable.",
+    "resilver_progress": "percent 0-100 of an in-progress resilver; 0.0 when not resilvering; null when zpool status was unavailable.",
+    "scrub_errors": "error count from the LAST COMPLETED scrub ('...with N errors'); null when the last scan was not a completed scrub (never scrubbed, resilver in progress, or status unavailable) -- distinguishes clean (0) from unknown (null). Distinct from 'errors' (current known data errors).",
+    "fragmentation": "pool fragmentation percent (mirror of summary.frag_percent, surfaced top-level for the backend join).",
+    "summary": "capacity block from 'zpool list -Hp': byte totals, frag/capacity percent, dedup_ratio (null when '-').",
+    "errors": "raw 'errors:' line from zpool status (current known data errors), NOT the scrub error count.",
+    "vdev_tree": "parsed device hierarchy (diagnostic); each node carries name/state/read/write/cksum and nested children; section devices in logs/spares/cache/special.",
+    "zfs_version": "first line of 'zpool version', repeated per pool."
+  },
+  "config": { "interval": 60 },
+  "scenario": {
+    "rpool": "healthy: ONLINE, last scrub completed with 0 errors, not resilvering -> health_code 0, degraded_vdevs 0, resilver_progress 0.0, scrub_errors 0.",
+    "tank": "degraded: one mirror leg FAULTED, resilver in progress at 42.13% -> health_code 1, degraded_vdevs 2 (the DEGRADED mirror + the FAULTED leaf), resilver_progress 42.13, scrub_errors null (last scan is a resilver, not a scrub)."
+  },
+  "payload": [
+    {
+      "name": "rpool",
+      "health": "ONLINE",
+      "health_code": 0,
+      "degraded_vdevs": 0,
+      "resilver_progress": 0.0,
+      "scrub_errors": 0,
+      "fragmentation": 5,
+      "summary": {
+        "size_bytes": 1000204886016,
+        "alloc_bytes": 500102443008,
+        "free_bytes": 500102443008,
+        "frag_percent": 5,
+        "capacity_percent": 50,
+        "dedup_ratio": 1.0
+      },
+      "errors": "No known data errors",
+      "vdev_tree": {
+        "name": "rpool",
+        "state": "ONLINE",
+        "read": 0,
+        "write": 0,
+        "cksum": 0,
+        "children": [
+          {
+            "name": "mirror-0",
+            "state": "ONLINE",
+            "read": 0,
+            "write": 0,
+            "cksum": 0,
+            "children": [
+              { "name": "sda", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
+              { "name": "sdb", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 }
+            ]
+          }
+        ],
+        "logs": [],
+        "spares": [],
+        "cache": [],
+        "special": []
+      },
+      "zfs_version": "zfs-2.2.2-1"
+    },
+    {
+      "name": "tank",
+      "health": "DEGRADED",
+      "health_code": 1,
+      "degraded_vdevs": 2,
+      "resilver_progress": 42.13,
+      "scrub_errors": null,
+      "fragmentation": 12,
+      "summary": {
+        "size_bytes": 4000787030016,
+        "alloc_bytes": 1200236109004,
+        "free_bytes": 2800550921012,
+        "frag_percent": 12,
+        "capacity_percent": 30,
+        "dedup_ratio": 1.0
+      },
+      "errors": "No known data errors",
+      "vdev_tree": {
+        "name": "tank",
+        "state": "DEGRADED",
+        "read": 0,
+        "write": 0,
+        "cksum": 0,
+        "children": [
+          {
+            "name": "mirror-0",
+            "state": "DEGRADED",
+            "read": 0,
+            "write": 0,
+            "cksum": 0,
+            "children": [
+              { "name": "sdc", "state": "ONLINE", "read": 0, "write": 0, "cksum": 0 },
+              { "name": "sdd", "state": "FAULTED", "read": 3, "write": 0, "cksum": 0 }
+            ]
+          }
+        ],
+        "logs": [],
+        "spares": [],
+        "cache": [],
+        "special": []
+      },
+      "zfs_version": "zfs-2.2.2-1"
+    }
+  ]
+}

--- a/tests/fixtures/zfs_contract_payload.json
+++ b/tests/fixtures/zfs_contract_payload.json
@@ -1,6 +1,6 @@
 {
   "description": "Shared ZFS contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/zfs_contract_payload.json, asserted end-to-end by tests/test_zfs.py::test_contract_fixture_round_trip (only zfs._run and shutil.which are mocked with the canned zpool CLI output below). 'config' is the shape config['zfs'] takes (True, or {'interval': N}); 'payload' is the artifact the agent emits under data['zfs'] -- a list of per-pool health objects the server's ZFS ingester must parse. The collector is GENERIC (host-local zpool), not Proxmox-scoped: the server joins these pools to proxmox_storages where storage_type='zfs' on (host, pool name). Change the payload shape only in lockstep with the server spec and its fixture copy.",
-  "agent_min_version": "1.11.0",
+  "agent_min_version": "1.11.3",
   "health_code_contract": {
     "_note": "Stable, append-only mapping of the zpool health string to payload.health_code. Never renumber. Unrecognized states -> null, with the raw 'health' string preserved so the backend can still react.",
     "0": "ONLINE",

--- a/tests/test_agent_dry_run.py
+++ b/tests/test_agent_dry_run.py
@@ -67,6 +67,13 @@ def test_dry_run_config_includes_systemd():
     assert _DRY_RUN_CONFIG.get("systemd")  # present and truthy
 
 
+def test_dry_run_config_includes_zfs():
+    """ZFS is a host-level collector (generic zpool, no external config), so
+    --dry-run must exercise it. Same regression class as systemd: without the
+    key, collect_metrics' `if not config_value` gate silently skips it."""
+    assert _DRY_RUN_CONFIG.get("zfs")  # present and truthy
+
+
 @patch("fivenines_agent.agent.dry_run", return_value=True)
 def test_dry_run_cleanup_skips_synchronizer(mock_dr):
     """_cleanup() must not crash when synchronizer is None."""

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -22,6 +22,7 @@ def test_registry_has_expected_config_keys():
         "smart_storage_health",
         "raid_storage_health",
         "ceph",
+        "zfs",
         "processes",
         "ports",
         "temperatures",

--- a/tests/test_zfs.py
+++ b/tests/test_zfs.py
@@ -78,6 +78,22 @@ def test_run_passes_through_to_subprocess(monkeypatch):
     assert proc.stdout == "ok"
     assert captured["cmd"] == ["zpool", "version"]
     assert captured["kwargs"]["check"] is False
+    assert captured["kwargs"]["timeout"] == zfs._SUBPROCESS_TIMEOUT
+
+
+def test_run_timeout_returns_synthetic_failure(monkeypatch):
+    """A hung zpool must not hang the tick. TimeoutExpired is caught in _run and
+    returned as a failed result -- indistinguishable from a failed command, so
+    every downstream failure path applies unchanged. No exception escapes."""
+
+    def boom(cmd, **kwargs):
+        raise zfs.subprocess.TimeoutExpired(cmd, zfs._SUBPROCESS_TIMEOUT)
+
+    monkeypatch.setattr(zfs.subprocess, "run", boom)
+    proc = zfs._run(["zpool", "status", "-pPLv", "rpool"])
+    assert proc.returncode != 0
+    assert proc.stdout == ""
+    assert "timeout" in proc.stderr
 
 
 def _contract_run(cmd):
@@ -115,22 +131,37 @@ def test_contract_fixture_round_trip(monkeypatch):
     """SHARED FIXTURE (cross-repo contract): fixtures/zfs_contract_payload.json.
 
     The same file is asserted on both sides:
-    - here: zfs_storage_health(**fixture["config"]) must equal fixture["payload"]
-      with only zfs._run and shutil.which mocked (canned CLI above), pinning the
+    - here: zfs_storage_health(**config) must equal the scenario payload with
+      only zfs._run and shutil.which mocked (canned CLI above), pinning the
       whole probe -> parse -> payload pipeline;
-    - fivenines-server: its ZFS ingester posts fixture["payload"] under data["zfs"].
+    - fivenines-server: its ZFS ingester posts the payload under data["zfs"].
 
     Change the payload shape only in lockstep with the server spec and its copy.
     """
     with open(_FIXTURE_PATH) as f:
         fixture = json.load(f)
+    scenario = fixture["scenarios"]["healthy_and_degraded"]
 
     monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
     monkeypatch.setattr(zfs, "_run", _contract_run)
 
-    out = zfs.zfs_storage_health(**fixture["config"])
+    out = zfs.zfs_storage_health(**scenario["config"])
 
-    assert out == fixture["payload"]
+    assert out == scenario["payload"]
+
+
+def test_contract_fixture_null_scenario(monkeypatch):
+    """The collection-failure scenario pins data["zfs"] = null: a real listing
+    failure must produce exactly None (the server keys off this to NOT prune)."""
+    with open(_FIXTURE_PATH) as f:
+        fixture = json.load(f)
+    scenario = fixture["scenarios"]["collection_failure"]
+    assert scenario["payload"] is None  # the pinned contract value
+
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(1, "", "boom"))
+
+    assert zfs.zfs_storage_health(**scenario["config"]) is None
 
 
 def test_contract_health_code_mapping_matches_fixture():
@@ -186,7 +217,14 @@ def test_list_zfs_pools_ok(monkeypatch):
 
 
 def test_list_zfs_pools_failure(monkeypatch):
-    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(2, "", "no pools"))
+    """Command failure -> None (distinct from [] = zero pools)."""
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(2, "", "boom"))
+    assert zfs.list_zfs_pools() is None
+
+
+def test_list_zfs_pools_empty(monkeypatch):
+    """Command succeeded, zero pools -> [] (distinct from None = failure)."""
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, ""))
     assert zfs.list_zfs_pools() == []
 
 
@@ -276,6 +314,30 @@ def test_count_degraded_vdevs_ignores_spares_and_states():
         ]
     }
     assert zfs._count_degraded_vdevs(tree) == 1
+
+
+def test_count_degraded_vdevs_reaches_section_devices_via_parser():
+    """Pin the parser invariant _count_degraded_vdevs' docstring relies on: a
+    FAULTED device in a SECTION (logs) is reachable through 'children' by the
+    walk. Exercises the real parser, not a hand-built tree, and confirms the
+    device is counted exactly once despite also living in tree['logs']."""
+    text = (
+        "  pool: tank\n"
+        " state: DEGRADED\n"
+        "  scan: none requested\n"
+        "config:\n"
+        "\n"
+        "\tNAME        STATE     READ WRITE CKSUM\n"
+        "\ttank        DEGRADED     0     0     0\n"
+        "\t  sda       ONLINE       0     0     0\n"
+        "\tlogs\n"
+        "\t  sdb       FAULTED      0     0     0\n"
+        "\n"
+        "errors: No known data errors\n"
+    )
+    tree = zfs._parse_zpool_status(text)["tank"]["vdev_tree"]
+    assert [d["name"] for d in tree["logs"]] == ["sdb"]  # in the section list...
+    assert zfs._count_degraded_vdevs(tree) == 1  # ...and counted once via children
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +621,36 @@ def test_get_zfs_pool_info_exception_returns_none(monkeypatch):
     assert zfs.get_zfs_pool_info("rpool") is None
 
 
+def test_get_zfs_pool_info_status_timeout_degrades_to_list(monkeypatch):
+    """A hung `zpool status` (both -pPLv and -PLv) is caught in _run as a
+    failure, so the pool degrades to list-only health -- same outcome as
+    test_get_zfs_pool_info_status_fails_but_in_summary, reached via a real
+    timeout rather than a non-zero return code."""
+
+    def run(cmd, **kwargs):
+        if "status" in cmd:
+            raise zfs.subprocess.TimeoutExpired(cmd, zfs._SUBPROCESS_TIMEOUT)
+        return FakeProc(0, LIST_SUMMARY_OUT)  # `zpool list -Hp` still answers
+
+    monkeypatch.setattr(zfs.subprocess, "run", run)
+    info = zfs.get_zfs_pool_info("rpool")
+    assert info["health"] == "ONLINE"
+    assert info["degraded_vdevs"] is None
+    assert info["resilver_progress"] is None
+    assert info["vdev_tree"] is None
+
+
+def test_get_zfs_pool_info_all_timeout_returns_none(monkeypatch):
+    """Both `zpool status` and `zpool list` hang -> no health anywhere -> None,
+    and no exception escapes."""
+
+    def run(cmd, **kwargs):
+        raise zfs.subprocess.TimeoutExpired(cmd, zfs._SUBPROCESS_TIMEOUT)
+
+    monkeypatch.setattr(zfs.subprocess, "run", run)
+    assert zfs.get_zfs_pool_info("rpool") is None
+
+
 # ---------------------------------------------------------------------------
 # zfs_storage_health
 # ---------------------------------------------------------------------------
@@ -586,21 +678,46 @@ def test_storage_health_cache_hit(monkeypatch):
     assert zfs.zfs_storage_health(interval=60) is sentinel
 
 
-def test_storage_health_not_available(monkeypatch):
+def test_storage_health_not_available_returns_none(monkeypatch):
+    """zpool binary gone mid-run -> collection failure -> None (NOT [], which
+    the server would read as 'zero pools' and prune health rows on)."""
     monkeypatch.setattr(zfs.shutil, "which", lambda _: None)
-    assert zfs.zfs_storage_health() == []
+    assert zfs.zfs_storage_health() is None
 
 
-def test_storage_health_no_pools(monkeypatch):
+def test_storage_health_no_pools_returns_empty(monkeypatch):
+    """Listing succeeded with genuinely zero pools -> [] (safe to prune)."""
     monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
 
     def run(cmd):
         if "version" in cmd:
             return FakeProc(0, VERSION_OUT)
-        return FakeProc(0, "")  # no pools listed
+        return FakeProc(0, "")  # `zpool list` succeeds, reports zero pools
 
     monkeypatch.setattr(zfs, "_run", run)
     assert zfs.zfs_storage_health() == []
+
+
+def test_storage_health_list_failure_returns_none(monkeypatch):
+    """`zpool list` itself fails -> collection failure -> None, not []."""
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(1, "", "boom"))
+    assert zfs.zfs_storage_health() is None
+
+
+def test_storage_health_all_pools_timeout_returns_none(monkeypatch):
+    """Pool list answers, but every per-pool call hangs -> all reads None ->
+    collection failure -> None (we KNOW pools exist, we just couldn't read
+    them). A wedged host never hangs the tick and never falsely prunes."""
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+
+    def run(cmd, **kwargs):
+        if "-H" in cmd:  # `zpool list -H -o name` (pool names) answers
+            return FakeProc(0, POOL_NAMES_OUT)
+        raise zfs.subprocess.TimeoutExpired(cmd, zfs._SUBPROCESS_TIMEOUT)
+
+    monkeypatch.setattr(zfs.subprocess, "run", run)
+    assert zfs.zfs_storage_health() is None
 
 
 def test_storage_health_filters_none_pool_info(monkeypatch):

--- a/tests/test_zfs.py
+++ b/tests/test_zfs.py
@@ -1,0 +1,640 @@
+"""Tests for the ZFS pool health collector."""
+
+import json
+import os
+
+import pytest
+
+from fivenines_agent import zfs
+
+# ---------------------------------------------------------------------------
+# Canned `zpool` CLI output for the shared contract scenario. These strings are
+# the source the fixture was generated from; the round-trip test re-derives the
+# payload and asserts equality with tests/fixtures/zfs_contract_payload.json.
+# ---------------------------------------------------------------------------
+
+VERSION_OUT = "zfs-2.2.2-1\nzfs-kmod-2.2.2-1\n"
+
+POOL_NAMES_OUT = "rpool\ntank\n"
+
+LIST_SUMMARY_OUT = (
+    "rpool\tONLINE\t1000204886016\t500102443008\t500102443008\t5\t50\t1.00\n"
+    "tank\tDEGRADED\t4000787030016\t1200236109004\t2800550921012\t12\t30\t1.00\n"
+)
+
+STATUS_RPOOL = (
+    "  pool: rpool\n"
+    " state: ONLINE\n"
+    "  scan: scrub repaired 0B in 00:12:34 with 0 errors on Sun Jul  7 03:12:34 2026\n"
+    "config:\n"
+    "\n"
+    "\tNAME        STATE     READ WRITE CKSUM\n"
+    "\trpool       ONLINE       0     0     0\n"
+    "\t  mirror-0  ONLINE       0     0     0\n"
+    "\t    sda     ONLINE       0     0     0\n"
+    "\t    sdb     ONLINE       0     0     0\n"
+    "\n"
+    "errors: No known data errors\n"
+)
+
+STATUS_TANK = (
+    "  pool: tank\n"
+    " state: DEGRADED\n"
+    "status: One or more devices is currently being resilvered.\n"
+    "action: Wait for the resilver to complete.\n"
+    "  scan: resilver in progress since Mon Jul 13 01:00:00 2026\n"
+    "\t1234567890 scanned at 12345678/s, 987654321 issued at 9876543/s, 4000787030016 total\n"
+    "\t500000000 resilvered, 42.13% done, 00:34:56 to go\n"
+    "config:\n"
+    "\n"
+    "\tNAME        STATE     READ WRITE CKSUM\n"
+    "\ttank        DEGRADED     0     0     0\n"
+    "\t  mirror-0  DEGRADED     0     0     0\n"
+    "\t    sdc     ONLINE       0     0     0\n"
+    "\t    sdd     FAULTED      3     0     0  too many errors\n"
+    "\n"
+    "errors: No known data errors\n"
+)
+
+
+class FakeProc:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_run_passes_through_to_subprocess(monkeypatch):
+    """_run is a thin wrapper: clean env, no raise, pipes captured."""
+    captured = {}
+
+    def fake(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc(0, "ok")
+
+    monkeypatch.setattr(zfs.subprocess, "run", fake)
+    proc = zfs._run(["zpool", "version"])
+    assert proc.stdout == "ok"
+    assert captured["cmd"] == ["zpool", "version"]
+    assert captured["kwargs"]["check"] is False
+
+
+def _contract_run(cmd):
+    """Dispatcher matching the contract scenario (all commands succeed)."""
+    if "version" in cmd:
+        return FakeProc(0, VERSION_OUT)
+    if "status" in cmd:
+        pool = cmd[-1]
+        return FakeProc(0, STATUS_RPOOL if pool == "rpool" else STATUS_TANK)
+    if "-Hp" in cmd:
+        return FakeProc(0, LIST_SUMMARY_OUT)
+    if "list" in cmd:
+        return FakeProc(0, POOL_NAMES_OUT)
+    raise AssertionError("unexpected cmd: {}".format(cmd))
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test starts with a cold cache."""
+    zfs._zfs_cache["timestamp"] = 0
+    zfs._zfs_cache["data"] = []
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Shared contract round-trip
+# ---------------------------------------------------------------------------
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "zfs_contract_payload.json"
+)
+
+
+def test_contract_fixture_round_trip(monkeypatch):
+    """SHARED FIXTURE (cross-repo contract): fixtures/zfs_contract_payload.json.
+
+    The same file is asserted on both sides:
+    - here: zfs_storage_health(**fixture["config"]) must equal fixture["payload"]
+      with only zfs._run and shutil.which mocked (canned CLI above), pinning the
+      whole probe -> parse -> payload pipeline;
+    - fivenines-server: its ZFS ingester posts fixture["payload"] under data["zfs"].
+
+    Change the payload shape only in lockstep with the server spec and its copy.
+    """
+    with open(_FIXTURE_PATH) as f:
+        fixture = json.load(f)
+
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", _contract_run)
+
+    out = zfs.zfs_storage_health(**fixture["config"])
+
+    assert out == fixture["payload"]
+
+
+def test_contract_health_code_mapping_matches_fixture():
+    """The numeric health codes are a stable contract; guard against renumbering."""
+    with open(_FIXTURE_PATH) as f:
+        fixture = json.load(f)
+    for code_str, state in fixture["health_code_contract"].items():
+        if code_str == "_note" or code_str == "null":
+            continue
+        assert zfs._HEALTH_CODES[state] == int(code_str)
+    # Every code in the module is documented in the fixture, and vice versa.
+    documented = {
+        v
+        for k, v in fixture["health_code_contract"].items()
+        if k not in ("_note", "null")
+    }
+    assert documented == set(zfs._HEALTH_CODES)
+
+
+# ---------------------------------------------------------------------------
+# zfs_available / get_zfs_version / list_zfs_pools
+# ---------------------------------------------------------------------------
+
+
+def test_zfs_available_true(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    assert zfs.zfs_available() is True
+
+
+def test_zfs_available_false(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: None)
+    assert zfs.zfs_available() is False
+
+
+def test_get_zfs_version_ok(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, VERSION_OUT))
+    assert zfs.get_zfs_version() == "zfs-2.2.2-1"
+
+
+def test_get_zfs_version_failure(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(1, "", "boom"))
+    assert zfs.get_zfs_version() is None
+
+
+def test_get_zfs_version_empty(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, "\n"))
+    assert zfs.get_zfs_version() is None
+
+
+def test_list_zfs_pools_ok(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, POOL_NAMES_OUT))
+    assert zfs.list_zfs_pools() == ["rpool", "tank"]
+
+
+def test_list_zfs_pools_failure(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(2, "", "no pools"))
+    assert zfs.list_zfs_pools() == []
+
+
+# ---------------------------------------------------------------------------
+# _safe_int
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("42", 42),
+        ("3.9", 3),  # float string -> truncated int
+        (7, 7),
+        ("-", None),  # invalid -> default
+        (None, None),
+    ],
+)
+def test_safe_int(value, expected):
+    assert zfs._safe_int(value) == expected
+
+
+def test_safe_int_custom_default():
+    assert zfs._safe_int("nope", 60) == 60
+
+
+# ---------------------------------------------------------------------------
+# _health_code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "health,code",
+    [
+        ("ONLINE", 0),
+        ("DEGRADED", 1),
+        ("FAULTED", 2),
+        ("OFFLINE", 3),
+        ("REMOVED", 4),
+        ("UNAVAIL", 5),
+        ("SUSPENDED", 6),  # missing from the original issue, added here
+        ("online", 0),  # case-insensitive
+        (" DEGRADED ", 1),  # whitespace tolerant
+    ],
+)
+def test_health_code_known(health, code):
+    assert zfs._health_code(health) == code
+
+
+@pytest.mark.parametrize("health", [None, "", "WEIRD_STATE"])
+def test_health_code_unknown(health):
+    assert zfs._health_code(health) is None
+
+
+# ---------------------------------------------------------------------------
+# _count_degraded_vdevs
+# ---------------------------------------------------------------------------
+
+
+def test_count_degraded_vdevs_none_tree():
+    assert zfs._count_degraded_vdevs(None) is None
+
+
+def test_count_degraded_vdevs_healthy():
+    tree = zfs._parse_zpool_status(STATUS_RPOOL)["rpool"]["vdev_tree"]
+    assert zfs._count_degraded_vdevs(tree) == 0
+
+
+def test_count_degraded_vdevs_degraded():
+    tree = zfs._parse_zpool_status(STATUS_TANK)["tank"]["vdev_tree"]
+    # mirror-0 (DEGRADED) + sdd (FAULTED)
+    assert zfs._count_degraded_vdevs(tree) == 2
+
+
+def test_count_degraded_vdevs_ignores_spares_and_states():
+    tree = {
+        "children": [
+            {
+                "state": "ONLINE",
+                "children": [
+                    {"state": "AVAIL"},  # spare, healthy -> not counted
+                    {"state": "INUSE"},  # spare, healthy -> not counted
+                    {"state": "REMOVED"},  # counted
+                ],
+            },
+            {"state": None},  # missing state -> not counted
+        ]
+    }
+    assert zfs._count_degraded_vdevs(tree) == 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_resilver_progress
+# ---------------------------------------------------------------------------
+
+
+def test_resilver_progress_none():
+    assert zfs._parse_resilver_progress(None) is None
+
+
+def test_resilver_progress_not_resilvering():
+    assert zfs._parse_resilver_progress("scrub repaired 0B with 0 errors") == 0.0
+
+
+def test_resilver_progress_in_progress():
+    text = "resilver in progress since ... 42.13% done, 00:34:56 to go"
+    assert zfs._parse_resilver_progress(text) == 42.13
+
+
+def test_resilver_progress_in_progress_no_percent():
+    # Resilvering but the percent is not (yet) present -> best-effort 0.0
+    assert zfs._parse_resilver_progress("resilver in progress since ...") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_scrub_errors
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_errors_none_text():
+    assert zfs._parse_scrub_errors(None) is None
+
+
+def test_scrub_errors_none_requested():
+    assert zfs._parse_scrub_errors("none requested") is None
+
+
+def test_scrub_errors_in_progress():
+    # A scrub in progress is not a completed scrub -> unknown
+    assert zfs._parse_scrub_errors("scrub in progress since ... 10% done") is None
+
+
+def test_scrub_errors_completed_clean():
+    text = "scrub repaired 0B in 00:12:34 with 0 errors on Sun ..."
+    assert zfs._parse_scrub_errors(text) == 0
+
+
+def test_scrub_errors_completed_with_errors():
+    text = "scrub repaired 1.5M in 01:02:03 with 7 errors on Sun ..."
+    assert zfs._parse_scrub_errors(text) == 7
+
+
+def test_scrub_errors_completed_but_unparseable_count():
+    # Defensive: "scrub repaired" present but no "with N errors" token.
+    assert zfs._parse_scrub_errors("scrub repaired 0B on Sun ...") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_zpool_status
+# ---------------------------------------------------------------------------
+
+
+def test_parse_status_simple_tree():
+    pools = zfs._parse_zpool_status(STATUS_RPOOL)
+    assert set(pools) == {"rpool"}
+    tree = pools["rpool"]["vdev_tree"]
+    assert tree["name"] == "rpool"
+    assert tree["state"] == "ONLINE"
+    assert [c["name"] for c in tree["children"]] == ["mirror-0"]
+    leaves = tree["children"][0]["children"]
+    assert [(d["name"], d["state"]) for d in leaves] == [
+        ("sda", "ONLINE"),
+        ("sdb", "ONLINE"),
+    ]
+    assert pools["rpool"]["errors"] == "No known data errors"
+    assert "with 0 errors" in pools["rpool"]["scan_full"]
+
+
+def test_parse_status_multiline_scan_captured():
+    """The resilver continuation lines (with the percent) must be captured."""
+    pools = zfs._parse_zpool_status(STATUS_TANK)
+    scan_full = pools["tank"]["scan_full"]
+    assert "resilver in progress" in scan_full
+    assert "42.13% done" in scan_full
+    assert pools["tank"]["vdev_tree"]["children"][0]["children"][1] == {
+        "name": "sdd",
+        "state": "FAULTED",
+        "read": 3,
+        "write": 0,
+        "cksum": 0,
+    }
+
+
+def test_parse_status_multiple_pools():
+    pools = zfs._parse_zpool_status(STATUS_RPOOL + STATUS_TANK)
+    assert set(pools) == {"rpool", "tank"}
+
+
+def test_parse_status_ignores_preamble_before_first_pool():
+    """Lines before the first 'pool:' header (no current pool) are skipped."""
+    pools = zfs._parse_zpool_status("no pools available\n" + STATUS_RPOOL)
+    assert set(pools) == {"rpool"}
+
+
+# A crafted status covering: both section-header forms (colon + bare), a spare
+# with only 2 columns (_num IndexError), a device with a scaled count (_num
+# ValueError), all four section lists, and a device shallower than the root
+# (the _push_by_indent root-fallback branch).
+STATUS_SECTIONS = (
+    "  pool: mix\n"
+    " state: ONLINE\n"
+    "  scan: none requested\n"
+    "config:\n"
+    "\n"
+    "\tNAME        STATE     READ WRITE CKSUM\n"
+    "\tmix         ONLINE       0     0     0\n"
+    "\t  raidz1-0  ONLINE       0     0     0\n"
+    "\t    sda     ONLINE     1.2K    0     0\n"
+    "\t    sdb     ONLINE       0     0     0\n"
+    "\tlogs\n"
+    "\t  sdc       ONLINE       0     0     0\n"
+    "\tcache\n"
+    "\t  nvme0     ONLINE       0     0     0\n"
+    "\tspecial:\n"
+    "\t  sdd       ONLINE       0     0     0\n"
+    "\tspares\n"
+    "\t  sde       AVAIL\n"
+    "\n"
+    "errors: No known data errors\n"
+)
+
+
+def test_parse_status_sections_and_edge_columns():
+    pools = zfs._parse_zpool_status(STATUS_SECTIONS)
+    tree = pools["mix"]["vdev_tree"]
+    # Section lists populated.
+    assert [d["name"] for d in tree["logs"]] == ["sdc"]
+    assert [d["name"] for d in tree["cache"]] == ["nvme0"]
+    assert [d["name"] for d in tree["special"]] == ["sdd"]
+    assert [d["name"] for d in tree["spares"]] == ["sde"]
+    # Scaled count "1.2K" is not an int -> None (no crash).
+    sda = tree["children"][0]["children"][0]
+    assert sda["name"] == "sda" and sda["read"] is None
+    # Spare row had only 2 columns -> numeric fields None.
+    sde = tree["spares"][0]
+    assert sde == {
+        "name": "sde",
+        "state": "AVAIL",
+        "read": None,
+        "write": None,
+        "cksum": None,
+    }
+
+
+def test_parse_status_device_shallower_than_root():
+    """A device indented at/above the root pops the stack empty (root fallback)."""
+    text = (
+        "  pool: weird\n"
+        " state: ONLINE\n"
+        "config:\n"
+        "\n"
+        "\tNAME     STATE\n"
+        "\t    weird   ONLINE 0 0 0\n"  # root, deeply indented
+        "\t  shallow ONLINE 0 0 0\n"  # shallower than root -> attaches to root
+    )
+    tree = zfs._parse_zpool_status(text)["weird"]["vdev_tree"]
+    assert tree["name"] == "weird"
+    assert [c["name"] for c in tree["children"]] == ["shallow"]
+
+
+# ---------------------------------------------------------------------------
+# _zpool_list_summary
+# ---------------------------------------------------------------------------
+
+
+def test_zpool_list_summary_ok(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, LIST_SUMMARY_OUT))
+    summary = zfs._zpool_list_summary()
+    assert summary["rpool"]["health"] == "ONLINE"
+    assert summary["rpool"]["summary"]["size_bytes"] == 1000204886016
+    assert summary["rpool"]["summary"]["dedup_ratio"] == 1.0
+
+
+def test_zpool_list_summary_dedup_dash_and_short_lines(monkeypatch):
+    out = (
+        "z\tONLINE\t100\t50\t50\t0\t50\t-\n"  # dedup '-' -> None
+        "\n"  # blank -> filtered
+        "short\tONLINE\t1\t2\n"  # <8 cols -> skipped
+    )
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(0, out))
+    summary = zfs._zpool_list_summary()
+    assert set(summary) == {"z"}
+    assert summary["z"]["summary"]["dedup_ratio"] is None
+
+
+def test_zpool_list_summary_command_failure(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", lambda cmd: FakeProc(1, "", "boom"))
+    assert zfs._zpool_list_summary() == {}
+
+
+# ---------------------------------------------------------------------------
+# get_zfs_pool_info
+# ---------------------------------------------------------------------------
+
+
+def test_get_zfs_pool_info_normal(monkeypatch):
+    monkeypatch.setattr(zfs, "_run", _contract_run)
+    info = zfs.get_zfs_pool_info("tank")
+    assert info["health"] == "DEGRADED"
+    assert info["health_code"] == 1
+    assert info["degraded_vdevs"] == 2
+    assert info["resilver_progress"] == 42.13
+    assert info["scrub_errors"] is None
+    assert info["fragmentation"] == 12
+    assert "zfs_version" not in info  # added by the caller, not here
+
+
+def test_get_zfs_pool_info_status_p_fallback(monkeypatch):
+    """`zpool status -pPLv` unsupported (old ZFS) -> retry `-PLv`."""
+    calls = []
+
+    def run(cmd):
+        calls.append(list(cmd))
+        if "version" in cmd:
+            return FakeProc(0, VERSION_OUT)
+        if "status" in cmd:
+            if "-pPLv" in cmd:
+                return FakeProc(2, "", "invalid option 'p'")
+            return FakeProc(0, STATUS_RPOOL)
+        if "-Hp" in cmd:
+            return FakeProc(0, LIST_SUMMARY_OUT)
+        return FakeProc(0, POOL_NAMES_OUT)
+
+    monkeypatch.setattr(zfs, "_run", run)
+    info = zfs.get_zfs_pool_info("rpool")
+    assert info["health"] == "ONLINE"
+    assert info["degraded_vdevs"] == 0  # parsed from the -PLv fallback output
+    assert ["zpool", "status", "-pPLv", "rpool"] in calls
+    assert ["zpool", "status", "-PLv", "rpool"] in calls
+
+
+def test_get_zfs_pool_info_status_fails_but_in_summary(monkeypatch):
+    """Both status calls fail; health still comes from `zpool list`."""
+
+    def run(cmd):
+        if "status" in cmd:
+            return FakeProc(1, "", "status failed")
+        if "-Hp" in cmd:
+            return FakeProc(0, LIST_SUMMARY_OUT)
+        return FakeProc(0, POOL_NAMES_OUT)
+
+    monkeypatch.setattr(zfs, "_run", run)
+    info = zfs.get_zfs_pool_info("rpool")
+    assert info["health"] == "ONLINE"
+    assert info["health_code"] == 0
+    assert info["degraded_vdevs"] is None  # no vdev tree available
+    assert info["resilver_progress"] is None
+    assert info["scrub_errors"] is None
+    assert info["vdev_tree"] is None
+    assert info["fragmentation"] == 5  # still from list summary
+
+
+def test_get_zfs_pool_info_unavailable_returns_none(monkeypatch):
+    """Status fails AND pool absent from list summary -> None."""
+
+    def run(cmd):
+        if "status" in cmd:
+            return FakeProc(1, "", "no such pool")
+        return FakeProc(0, "")  # empty list summary
+
+    monkeypatch.setattr(zfs, "_run", run)
+    assert zfs.get_zfs_pool_info("ghost") is None
+
+
+def test_get_zfs_pool_info_exception_returns_none(monkeypatch):
+    def boom():
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(zfs, "_zpool_list_summary", boom)
+    assert zfs.get_zfs_pool_info("rpool") is None
+
+
+# ---------------------------------------------------------------------------
+# zfs_storage_health
+# ---------------------------------------------------------------------------
+
+
+def test_storage_health_full(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", _contract_run)
+    data = zfs.zfs_storage_health()
+    assert [p["name"] for p in data] == ["rpool", "tank"]
+    assert all("zfs_version" in p for p in data)
+    # Cache populated.
+    assert zfs._zfs_cache["data"] == data
+
+
+def test_storage_health_cache_hit(monkeypatch):
+    sentinel = [{"name": "cached"}]
+    zfs._zfs_cache["timestamp"] = zfs.time.time()
+    zfs._zfs_cache["data"] = sentinel
+
+    def explode(_):
+        raise AssertionError("_run must not be called on a cache hit")
+
+    monkeypatch.setattr(zfs, "_run", explode)
+    assert zfs.zfs_storage_health(interval=60) is sentinel
+
+
+def test_storage_health_not_available(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: None)
+    assert zfs.zfs_storage_health() == []
+
+
+def test_storage_health_no_pools(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+
+    def run(cmd):
+        if "version" in cmd:
+            return FakeProc(0, VERSION_OUT)
+        return FakeProc(0, "")  # no pools listed
+
+    monkeypatch.setattr(zfs, "_run", run)
+    assert zfs.zfs_storage_health() == []
+
+
+def test_storage_health_filters_none_pool_info(monkeypatch):
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "get_zfs_version", lambda: "zfs-2.2.2")
+    monkeypatch.setattr(zfs, "list_zfs_pools", lambda: ["good", "bad"])
+    monkeypatch.setattr(
+        zfs,
+        "get_zfs_pool_info",
+        lambda name: None if name == "bad" else {"name": name},
+    )
+    data = zfs.zfs_storage_health()
+    assert data == [{"name": "good", "zfs_version": "zfs-2.2.2"}]
+
+
+def test_storage_health_custom_interval_is_ttl(monkeypatch):
+    """A custom interval becomes the cache TTL."""
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", _contract_run)
+    # Warm the cache 30s ago; interval=60 -> still fresh (no re-probe).
+    zfs.zfs_storage_health(interval=1)  # populate
+    warmed = zfs._zfs_cache["data"]
+    zfs._zfs_cache["timestamp"] = zfs.time.time() - 30
+
+    def explode(_):
+        raise AssertionError("should be a cache hit within interval")
+
+    monkeypatch.setattr(zfs, "_run", explode)
+    assert zfs.zfs_storage_health(interval=60) is warmed
+
+
+def test_storage_health_negative_interval_uses_default(monkeypatch):
+    """A negative interval falls back to the default TTL rather than never caching."""
+    monkeypatch.setattr(zfs.shutil, "which", lambda _: "/usr/sbin/zpool")
+    monkeypatch.setattr(zfs, "_run", _contract_run)
+    data = zfs.zfs_storage_health(interval=-5)
+    assert [p["name"] for p in data] == ["rpool", "tank"]


### PR DESCRIPTION
## What

Adds a native **ZFS pool health** collector (issue #49, SE Networks — ZFS-on-Proxmox). The agent reported storage *capacity* but never pool *health* (DEGRADED, resilvering, scrub errors, faulted vdevs). That state comes from the local `zpool` CLI, not the Proxmox API.

Release: **v1.11.3** (rebased onto main; #84/#76/#85 = 1.11.0/1.11.1/1.11.2 are merged).

## Approach

`zfs.py` existed since v1.3.3 but was **orphaned** — never in `COLLECTORS`, zero tests. This adopts it rather than rewriting:

- **Wired** into `COLLECTORS`, capability-gated on the existing `zfs` capability; also in `_DRY_RUN_CONFIG` so `--dry-run` exercises it.
- **Generic, not Proxmox-scoped.** Host-local `zpool`; each pool is a **host-scoped** entity keyed (host, pool name). (See "Contract" for the correction to the earlier Proxmox-join framing.)
- **Numeric health contract**: `health_code` enum (0..6, incl. **SUSPENDED**; unknown → `null`, raw `health` kept), `degraded_vdevs`, `resilver_progress`, `scrub_errors` (last completed scrub only; `null` vs `0` = unknown vs clean), `fragmentation`.
- **Bounded subprocess calls**: every `zpool` call has a 10s timeout (`_SUBPROCESS_TIMEOUT`, mirroring `ceph.py`). A wedged `zpool` — SUSPENDED pool, dying controller — is caught in `_run` as a synthetic failure, so it can never hang the collect tick (the exact moment the ZFS alert matters most).
- `zpool status -pPLv` with a `-PLv` fallback for old ZFS. Configurable poll interval (cache TTL, default 60s).

## Contract + lockstep ⚠️

`tests/fixtures/zfs_contract_payload.json` is pinned as the cross-repo contract (Ceph/Proxmox discipline). **The paired fivenines-server ZFS ingester + a byte-identical fixture copy are still pending** (server #336) — change the payload shape only in lockstep.

Two contract points the server ingester depends on:

- **`null` vs `[]`** (like the docker contract): `data["zfs"] = null` means **collection failure** (`zpool list` failed/timed out, `zpool` vanished, or every per-pool read failed) — the server **must not prune** `zfs_pools` / auto-resolve incidents. `[]` means the listing succeeded with **zero pools** (safe to prune). A non-empty array is the live set.
- **Host-scoped, not a Proxmox join.** Correcting the earlier framing: pools are **not** joinable to `proxmox_storages` on `name` — that column is the PVE *storage ID* (e.g. `local-zfs`), not the zpool name (`rpool`). Proxmox correlation is deferred as later enrichment (would need the PVE storage's `pool` property, collected nowhere today).

## How to test

On a ZFS host: `fivenines-agent --dry-run | jq '.zfs'` (no server/config needed). Without hardware: a file-backed pool (`truncate` + `zpool create ... mirror`), then `zpool offline`/`scrub`/`online` to exercise DEGRADED / scrub / resilver.

## Tests

- `tests/test_zfs.py` — 71 tests: parser, every derivation, contract round-trip + null scenario, subprocess-timeout paths (list/status/all), null-vs-empty outcomes, section-reachability real-parse, caching.
- **100% coverage** on `zfs.py` and `collectors.py`; full suite **1336 passed, 2 skipped**.
- flake8 / black / isort clean on the changed files.

## Review items (from server-side review)

All addressed: (1) subprocess timeouts, (2) rebase onto main, (3) Proxmox-join correction, (4) three field_contract sharp edges, (5) section-reachability test, (6) null-vs-empty collection-failure semantics.

Refs #49. Inert until the server emits the `zfs` config key (same lockstep as ceph/logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)