### PR TITLE
v1.11.0 feat: deepen Redis/Valkey INFO collector (server #491)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,16 +355,24 @@ Collects metrics via a direct connection (pure-Python `pg8000` driver, no `psql`
 
 Requires appropriate database credentials.
 
-### Redis
+### Redis / Valkey
 
-Collects metrics via Redis protocol:
-- Version and uptime
-- Connected/blocked clients
-- Commands processed
-- Evicted/expired keys
-- Per-database key counts
+Collects metrics from a single `INFO` call over the Redis protocol. Works with
+Redis and [Valkey](https://valkey.io) (the collector also reports
+`valkey_version` when present). Deepened in agent version **1.11.0+**:
 
-Connects to `localhost:6379` by default.
+- Version and uptime (`valkey_version` on Valkey)
+- Connected/blocked clients, commands processed, ops/sec
+- Memory: used memory, `maxmemory` limit, fragmentation ratio
+- Keyspace hits/misses (the dashboard derives the hit ratio)
+- Evicted/expired keys, per-database key counts
+- Replication: role, connected replicas, replication offset, per-replica
+  state/offset/lag (master) and link status/lag (replica)
+- Persistence: last RDB save time, last background-save status, AOF enabled
+
+Connects to `localhost:6379` by default; an optional password is supported. All
+derived values (memory usage %, hit ratio, RDB age, replication lag) are
+computed server-side from these raw fields.
 
 ## Contribute
 

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -82,6 +82,7 @@ _DRY_RUN_CONFIG = {
     "smart_storage_health": True,
     "raid_storage_health": True,
     "ceph": {"clusters": [{"name": "ceph"}]},
+    "redis": {"port": 6379},
     "fail2ban": True,
     "disk_health": True,
     # Dict (not bare True) because systemd_metrics takes **kwargs; scan=False

--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-VERSION = '1.10.0'
+VERSION = '1.11.0'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/fivenines_agent/redis.py
+++ b/fivenines_agent/redis.py
@@ -1,79 +1,151 @@
-import os
-import sys
 import re
 import socket
-import traceback
 
 from fivenines_agent.debug import debug, log
 
-METRICS_REGEX = '|'.join([
-  'redis_version',
-  'uptime_in_seconds',
-  'blocked_clients',
-  'connected_clients',
-  'evicted_clients',
-  'maxclients',
-  'total_connections_received',
-  'total_commands_processed',
-  'evicted_keys',
-  'expired_keys',
-  '^db[0-9]'
-])
 
-@debug('redis_metrics')
-def redis_metrics(port=6379, password=None):
-    auth_prefix = ''
-    if password:
-      auth_prefix = f'AUTH {password}\n'
+# Exact INFO keys shipped as strings. Anything the server encodes into a gauge
+# (role master=1, master_link_status up=1, rdb_last_bgsave_status ok=1) stays a
+# raw string here -- that mapping is the server's job, not the agent's.
+STRING_KEYS = frozenset(
+    {
+        "redis_version",
+        "valkey_version",
+        "role",
+        "master_link_status",
+        "rdb_last_bgsave_status",
+    }
+)
 
+# Exact INFO keys shipped as floats (existing convention: numeric values go
+# through float()). Cumulative counters (keyspace_hits/misses, *_repl_offset,
+# total_*) ship raw -- the server derives rates/ratios/ages, not the agent.
+NUMERIC_KEYS = frozenset(
+    {
+        # Currently-shipped fields -- kept byte-compatible.
+        "uptime_in_seconds",
+        "blocked_clients",
+        "connected_clients",
+        "evicted_clients",
+        "maxclients",
+        "total_connections_received",
+        "total_commands_processed",
+        "evicted_keys",
+        "expired_keys",
+        # Memory (#491).
+        "used_memory",
+        "maxmemory",
+        "mem_fragmentation_ratio",
+        # Stats / perf (#491).
+        "instantaneous_ops_per_sec",
+        "keyspace_hits",
+        "keyspace_misses",
+        # Replication (#491).
+        "connected_slaves",
+        "master_repl_offset",
+        "slave_repl_offset",
+        "master_last_io_seconds_ago",
+        # Persistence (#491).
+        "rdb_last_save_time",
+        "aof_enabled",
+    }
+)
+
+# Nested "k=v,k=v" INFO lines: db<N> keyspace stats (all-numeric) and slave<N>
+# per-replica lines (mixed -- ip/state are strings). Both parse through the
+# same per-value try-float()-fallback-to-string helper.
+NESTED_KEY_REGEX = re.compile(r"^(?:db\d+|slave\d+)$")
+
+
+def _as_float(value):
+    """float(value), or None if it is not numeric.
+
+    Returning None (rather than raising) keeps a single malformed line from
+    sinking the whole tick's payload: the caller simply drops that one key,
+    and a missing key stays missing (the server treats absent as not zero).
+    """
     try:
+        return float(value)
+    except ValueError:
+        return None
 
-      # Use create_connection for better address handling (IPv4/IPv6)
-      s = socket.create_connection(('localhost', int(port)), timeout=5)
 
-      commands = []
-      if password:
-          commands.append(f'AUTH {password}')
-      commands.append('INFO')
-      commands.append('QUIT')
+def _parse_nested(value):
+    """Parse a comma-separated k=v INFO value into a dict.
 
-      # Use CRLF for Redis protocol
-      full_command = '\r\n'.join(commands) + '\r\n'
-      s.sendall(full_command.encode())
+    Numeric sub-values become floats (db<N> keyspace counters, slaveN
+    port/offset/lag); non-numeric ones (slaveN ip/state) stay strings. A
+    segment without '=' is skipped rather than fatal.
+    """
+    result = {}
+    for pair in value.split(","):
+        if "=" not in pair:
+            continue
+        k, _, v = pair.partition("=")
+        num = _as_float(v.strip())
+        result[k.strip()] = num if num is not None else v.strip()
+    return result
 
-      data = b""
-      while True:
-          chunk = s.recv(4096)
-          if not chunk:
-              break
-          data += chunk
-      s.close()
 
-      results = []
-      for line in data.decode('utf-8', errors='ignore').split('\n'):
-          line = line.strip()
-          if not line:
-              continue
-          if re.search(METRICS_REGEX, line):
-              results.append(line)
+def _parse_info(text):
+    """Parse a raw INFO reply into the outgoing metrics dict.
 
-      metrics = {}
+    Cherry-picks exact keys (STRING_KEYS / NUMERIC_KEYS / nested db*/slave*)
+    out of the full response. Blank lines, section headers ('# ...'), the RESP
+    bulk-length line ('$<n>'), and simple-string / error replies ('+OK',
+    '-WRONGPASS ...') carry no ':' key we know, so they are skipped. A single
+    unparseable line drops only its own key, never the whole payload.
+    """
+    metrics = {}
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        # split(':', 1) via partition: slaveN values carry extra ':' (and IPv6
+        # ip=::1), so a naive 2-tuple unpack would crash the moment a slaveN
+        # line becomes collectable.
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if key in STRING_KEYS:
+            metrics[key] = value
+        elif key in NUMERIC_KEYS:
+            num = _as_float(value)
+            if num is not None:
+                metrics[key] = num
+        elif NESTED_KEY_REGEX.match(key):
+            metrics[key] = _parse_nested(value)
+    return metrics
 
-      if len(results) > 0:
-        for result in results:
-          key, value = result.split(':')
-          if key == 'redis_version':
-            metrics[key] = value.strip()
-          elif key.startswith('db'):
-            metrics[key] = {}
-            values = value.split(',')
-            for v in values:
-              k, raw_val = v.split('=')
-              metrics[key][k.strip()] = float(raw_val.strip())
-          else:
-            metrics[key] = float(value.strip())
 
-      return metrics
+@debug("redis_metrics")
+def redis_metrics(port=6379, password=None):
+    try:
+        # create_connection handles IPv4/IPv6 address selection.
+        s = socket.create_connection(("localhost", int(port)), timeout=5)
+
+        commands = []
+        if password:
+            commands.append(f"AUTH {password}")
+        commands.append("INFO")
+        commands.append("QUIT")
+
+        # CRLF-terminated inline commands (RESP inline protocol).
+        s.sendall(("\r\n".join(commands) + "\r\n").encode())
+
+        data = b""
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        s.close()
+
+        # A denied/unparseable reply (-WRONGPASS, -NOAUTH) or an empty response
+        # yields {} here (no exact key matched); the server's presence gate
+        # skips an empty block. A socket/connection error raises and returns
+        # None via the except path below.
+        return _parse_info(data.decode("utf-8", errors="ignore"))
 
     except Exception as e:
-      log(f"Error collecting Redis metrics: {e}", 'error')
+        log(f"Error collecting Redis metrics: {e}", "error")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.10.0"
+version = "1.11.0"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/redis_contract_payload.json
+++ b/tests/fixtures/redis_contract_payload.json
@@ -1,0 +1,177 @@
+{
+  "description": "Shared Redis contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/redis_contract_payload.json, asserted end-to-end by tests/test_redis.py::test_contract_fixture_round_trip (only socket.create_connection is mocked -- each scenario's raw 'info' is fed back as the socket reply and redis_metrics(**config) must equal 'payload'). The server's spec/requests/api_collect_redis_spec.rb posts each 'payload' under data['redis'] through /collect and asserts Ingesters::Agent ingests it (an empty payload is skipped by the presence gate). 'config' is the shape config['redis'] takes. The '$<n>' RESP bulk-length line is illustrative -- the agent skips it without validating the byte count. Change only in lockstep across both repos.",
+  "agent_min_version": "1.11.0",
+  "config": {
+    "port": 6379
+  },
+  "scenarios": {
+    "master": {
+      "info": "$882\r\n# Server\r\nredis_version:7.2.4\r\nuptime_in_seconds:123456\r\n# Clients\r\nconnected_clients:10\r\nblocked_clients:0\r\nmaxclients:10000\r\n# Memory\r\nused_memory:1048576\r\nused_memory_rss:2097152\r\nused_memory_peak:1572864\r\nmaxmemory:2147483648\r\nmaxmemory_policy:noeviction\r\nmem_fragmentation_ratio:1.23\r\n# Persistence\r\nrdb_last_save_time:1699564800\r\nrdb_last_bgsave_status:ok\r\naof_enabled:0\r\n# Stats\r\ntotal_connections_received:1000\r\ntotal_commands_processed:50000\r\ninstantaneous_ops_per_sec:12\r\nexpired_keys:42\r\nexpired_stale_perc:0.00\r\nevicted_keys:0\r\nevicted_clients:0\r\nkeyspace_hits:900\r\nkeyspace_misses:100\r\n# Replication\r\nrole:master\r\nconnected_slaves:2\r\nslave0:ip=10.0.0.2,port=6379,state=online,offset=123400,lag=0\r\nslave1:ip=10.0.0.3,port=6379,state=online,offset=123390,lag=1\r\nmaster_repl_offset:123456\r\n# Keyspace\r\ndb0:keys=1000,expires=50,avg_ttl=0\r\ndb1:keys=200,expires=0,avg_ttl=0\r\n+OK\r\n",
+      "payload": {
+        "redis_version": "7.2.4",
+        "uptime_in_seconds": 123456.0,
+        "connected_clients": 10.0,
+        "blocked_clients": 0.0,
+        "maxclients": 10000.0,
+        "used_memory": 1048576.0,
+        "maxmemory": 2147483648.0,
+        "mem_fragmentation_ratio": 1.23,
+        "rdb_last_save_time": 1699564800.0,
+        "rdb_last_bgsave_status": "ok",
+        "aof_enabled": 0.0,
+        "total_connections_received": 1000.0,
+        "total_commands_processed": 50000.0,
+        "instantaneous_ops_per_sec": 12.0,
+        "expired_keys": 42.0,
+        "evicted_keys": 0.0,
+        "evicted_clients": 0.0,
+        "keyspace_hits": 900.0,
+        "keyspace_misses": 100.0,
+        "role": "master",
+        "connected_slaves": 2.0,
+        "slave0": {
+          "ip": "10.0.0.2",
+          "port": 6379.0,
+          "state": "online",
+          "offset": 123400.0,
+          "lag": 0.0
+        },
+        "slave1": {
+          "ip": "10.0.0.3",
+          "port": 6379.0,
+          "state": "online",
+          "offset": 123390.0,
+          "lag": 1.0
+        },
+        "master_repl_offset": 123456.0,
+        "db0": {
+          "keys": 1000.0,
+          "expires": 50.0,
+          "avg_ttl": 0.0
+        },
+        "db1": {
+          "keys": 200.0,
+          "expires": 0.0,
+          "avg_ttl": 0.0
+        }
+      }
+    },
+    "replica": {
+      "info": "$677\r\n# Server\r\nredis_version:7.2.4\r\nuptime_in_seconds:9999\r\n# Clients\r\nconnected_clients:5\r\nblocked_clients:0\r\nmaxclients:10000\r\n# Memory\r\nused_memory:524288\r\nmaxmemory:0\r\nmem_fragmentation_ratio:1.07\r\n# Persistence\r\nrdb_last_save_time:1699564900\r\nrdb_last_bgsave_status:ok\r\naof_enabled:1\r\n# Stats\r\ntotal_connections_received:200\r\ntotal_commands_processed:10000\r\ninstantaneous_ops_per_sec:3\r\nexpired_keys:5\r\nevicted_keys:0\r\nevicted_clients:0\r\nkeyspace_hits:400\r\nkeyspace_misses:50\r\n# Replication\r\nrole:slave\r\nmaster_link_status:up\r\nmaster_last_io_seconds_ago:1\r\nslave_repl_offset:120000\r\nmaster_repl_offset:120000\r\nconnected_slaves:0\r\n# Keyspace\r\ndb0:keys=500,expires=10,avg_ttl=0\r\n+OK\r\n",
+      "payload": {
+        "redis_version": "7.2.4",
+        "uptime_in_seconds": 9999.0,
+        "connected_clients": 5.0,
+        "blocked_clients": 0.0,
+        "maxclients": 10000.0,
+        "used_memory": 524288.0,
+        "maxmemory": 0.0,
+        "mem_fragmentation_ratio": 1.07,
+        "rdb_last_save_time": 1699564900.0,
+        "rdb_last_bgsave_status": "ok",
+        "aof_enabled": 1.0,
+        "total_connections_received": 200.0,
+        "total_commands_processed": 10000.0,
+        "instantaneous_ops_per_sec": 3.0,
+        "expired_keys": 5.0,
+        "evicted_keys": 0.0,
+        "evicted_clients": 0.0,
+        "keyspace_hits": 400.0,
+        "keyspace_misses": 50.0,
+        "role": "slave",
+        "master_link_status": "up",
+        "master_last_io_seconds_ago": 1.0,
+        "slave_repl_offset": 120000.0,
+        "master_repl_offset": 120000.0,
+        "connected_slaves": 0.0,
+        "db0": {
+          "keys": 500.0,
+          "expires": 10.0,
+          "avg_ttl": 0.0
+        }
+      }
+    },
+    "standalone": {
+      "info": "$586\r\n# Server\r\nredis_version:7.0.11\r\nuptime_in_seconds:3600\r\n# Clients\r\nconnected_clients:1\r\nblocked_clients:0\r\nmaxclients:10000\r\n# Memory\r\nused_memory:262144\r\nmaxmemory:0\r\nmem_fragmentation_ratio:1.5\r\n# Persistence\r\nrdb_last_save_time:1699560000\r\nrdb_last_bgsave_status:ok\r\naof_enabled:0\r\n# Stats\r\ntotal_connections_received:10\r\ntotal_commands_processed:100\r\ninstantaneous_ops_per_sec:0\r\nexpired_keys:0\r\nevicted_keys:0\r\nevicted_clients:0\r\nkeyspace_hits:10\r\nkeyspace_misses:2\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_repl_offset:0\r\n# Keyspace\r\ndb0:keys=3,expires=0,avg_ttl=0\r\n+OK\r\n",
+      "payload": {
+        "redis_version": "7.0.11",
+        "uptime_in_seconds": 3600.0,
+        "connected_clients": 1.0,
+        "blocked_clients": 0.0,
+        "maxclients": 10000.0,
+        "used_memory": 262144.0,
+        "maxmemory": 0.0,
+        "mem_fragmentation_ratio": 1.5,
+        "rdb_last_save_time": 1699560000.0,
+        "rdb_last_bgsave_status": "ok",
+        "aof_enabled": 0.0,
+        "total_connections_received": 10.0,
+        "total_commands_processed": 100.0,
+        "instantaneous_ops_per_sec": 0.0,
+        "expired_keys": 0.0,
+        "evicted_keys": 0.0,
+        "evicted_clients": 0.0,
+        "keyspace_hits": 10.0,
+        "keyspace_misses": 2.0,
+        "role": "master",
+        "connected_slaves": 0.0,
+        "master_repl_offset": 0.0,
+        "db0": {
+          "keys": 3.0,
+          "expires": 0.0,
+          "avg_ttl": 0.0
+        }
+      }
+    },
+    "valkey": {
+      "info": "$621\r\n# Server\r\nredis_version:7.2.4\r\nvalkey_version:8.0.1\r\nuptime_in_seconds:7200\r\n# Clients\r\nconnected_clients:3\r\nblocked_clients:0\r\nmaxclients:10000\r\n# Memory\r\nused_memory:393216\r\nmaxmemory:1073741824\r\nmem_fragmentation_ratio:1.34\r\n# Persistence\r\nrdb_last_save_time:1699565000\r\nrdb_last_bgsave_status:ok\r\naof_enabled:0\r\n# Stats\r\ntotal_connections_received:50\r\ntotal_commands_processed:2000\r\ninstantaneous_ops_per_sec:5\r\nexpired_keys:1\r\nevicted_keys:0\r\nevicted_clients:0\r\nkeyspace_hits:150\r\nkeyspace_misses:20\r\n# Replication\r\nrole:master\r\nconnected_slaves:0\r\nmaster_repl_offset:0\r\n# Keyspace\r\ndb0:keys=42,expires=0,avg_ttl=0\r\n+OK\r\n",
+      "payload": {
+        "redis_version": "7.2.4",
+        "valkey_version": "8.0.1",
+        "uptime_in_seconds": 7200.0,
+        "connected_clients": 3.0,
+        "blocked_clients": 0.0,
+        "maxclients": 10000.0,
+        "used_memory": 393216.0,
+        "maxmemory": 1073741824.0,
+        "mem_fragmentation_ratio": 1.34,
+        "rdb_last_save_time": 1699565000.0,
+        "rdb_last_bgsave_status": "ok",
+        "aof_enabled": 0.0,
+        "total_connections_received": 50.0,
+        "total_commands_processed": 2000.0,
+        "instantaneous_ops_per_sec": 5.0,
+        "expired_keys": 1.0,
+        "evicted_keys": 0.0,
+        "evicted_clients": 0.0,
+        "keyspace_hits": 150.0,
+        "keyspace_misses": 20.0,
+        "role": "master",
+        "connected_slaves": 0.0,
+        "master_repl_offset": 0.0,
+        "db0": {
+          "keys": 42.0,
+          "expires": 0.0,
+          "avg_ttl": 0.0
+        }
+      }
+    },
+    "legacy_minimal": {
+      "info": "$127\r\n# Server\r\nredis_version:6.2.6\r\n# Clients\r\nconnected_clients:2\r\nmaxclients:10000\r\n# Keyspace\r\ndb0:keys=100,expires=5,avg_ttl=0\r\n+OK\r\n",
+      "payload": {
+        "redis_version": "6.2.6",
+        "connected_clients": 2.0,
+        "maxclients": 10000.0,
+        "db0": {
+          "keys": 100.0,
+          "expires": 5.0,
+          "avg_ttl": 0.0
+        }
+      }
+    },
+    "auth_failure": {
+      "info": "-WRONGPASS invalid username-password pair or user is disabled.\r\n-NOAUTH Authentication required.\r\n",
+      "payload": {}
+    }
+  }
+}

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,240 @@
+"""Tests for the Redis/Valkey INFO collector (server issue #491).
+
+Only socket.create_connection is mocked; each scenario feeds a canned INFO
+reply back through the real read loop + parser, so the whole
+config-in -> parse -> payload-out pipeline is exercised.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from fivenines_agent import redis
+
+
+def _fake_socket(reply_bytes):
+    """A socket whose recv() returns the whole reply once, then b'' to end the
+    read loop (mirrors Redis closing the connection after QUIT)."""
+    sock = MagicMock()
+    sock.recv.side_effect = [reply_bytes, b""]
+    return sock
+
+
+# --- _parse_nested --------------------------------------------------------
+
+
+def test_parse_nested_mixed_numeric_and_string():
+    out = redis._parse_nested("ip=10.0.0.2,port=6379,state=online,offset=42,lag=0")
+    assert out == {
+        "ip": "10.0.0.2",
+        "port": 6379.0,
+        "state": "online",
+        "offset": 42.0,
+        "lag": 0.0,
+    }
+
+
+def test_parse_nested_skips_segment_without_equals():
+    # A malformed comma segment ('garbage') is dropped, not fatal; the float
+    # path (port) and the string fallback (ip/state) both still apply.
+    out = redis._parse_nested("ip=10.0.0.2,garbage,port=6379,state=online")
+    assert out == {"ip": "10.0.0.2", "port": 6379.0, "state": "online"}
+
+
+# --- redis_metrics: connection / auth / read loop -------------------------
+
+
+def test_no_password_omits_auth():
+    sent = []
+    sock = _fake_socket(b"$21\r\n# Server\r\nrole:master\r\n+OK\r\n")
+    sock.sendall.side_effect = sent.append
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        out = redis.redis_metrics(port=6379)
+    assert out == {"role": "master"}
+    assert b"AUTH" not in b"".join(sent)
+
+
+def test_password_sends_auth_before_info():
+    sent = []
+    sock = _fake_socket(b"$21\r\n# Server\r\nrole:master\r\n+OK\r\n")
+    sock.sendall.side_effect = sent.append
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        out = redis.redis_metrics(port=6379, password="s3cr3t")
+    assert out == {"role": "master"}
+    wire = b"".join(sent).decode()
+    # AUTH is issued, and before INFO/QUIT.
+    assert wire.index("AUTH s3cr3t") < wire.index("INFO") < wire.index("QUIT")
+
+
+def test_socket_error_returns_none():
+    # A connection/socket error returns None via the except path (server sees
+    # no 'redis' key and skips the block), distinct from a reachable-but-empty
+    # reply which returns {}.
+    with patch(
+        "fivenines_agent.redis.socket.create_connection",
+        side_effect=OSError("connection refused"),
+    ):
+        assert redis.redis_metrics(port=6379) is None
+
+
+def test_empty_reply_returns_empty_dict():
+    sock = MagicMock()
+    sock.recv.side_effect = [b""]  # closed immediately, no data
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        assert redis.redis_metrics(port=6379) == {}
+
+
+def test_auth_failure_reply_returns_empty_dict():
+    reply = b"-WRONGPASS invalid username-password pair or user is disabled.\r\n"
+    sock = _fake_socket(reply)
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        assert redis.redis_metrics(port=6379, password="wrong") == {}
+
+
+# --- parser resilience & traps --------------------------------------------
+
+
+def test_malformed_numeric_line_is_skipped_not_fatal():
+    # One bad line must not sink the whole payload (per-line resilience).
+    reply = b"# Memory\r\nused_memory:notanumber\r\nconnected_clients:7\r\n"
+    sock = _fake_socket(reply)
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        out = redis.redis_metrics(port=6379)
+    assert "used_memory" not in out
+    assert out["connected_clients"] == 7.0
+
+
+def test_ipv6_multicolon_slave_line_does_not_crash():
+    # The old split(':') 2-tuple unpack would crash here; partition(':', 1)
+    # keeps the slaveN value (including IPv6 ip=::) intact.
+    reply = (
+        b"# Replication\r\nrole:master\r\n"
+        b"slave0:ip=fe80::1,port=6379,state=online,offset=1,lag=0\r\n"
+    )
+    sock = _fake_socket(reply)
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        out = redis.redis_metrics(port=6379)
+    assert out["role"] == "master"
+    assert out["slave0"] == {
+        "ip": "fe80::1",
+        "port": 6379.0,
+        "state": "online",
+        "offset": 1.0,
+        "lag": 0.0,
+    }
+
+
+def test_substring_keys_are_not_captured():
+    # Exact-key matching: used_memory must not swallow used_memory_rss/peak,
+    # and maxmemory must not swallow maxmemory_policy.
+    reply = (
+        b"# Memory\r\n"
+        b"used_memory:100\r\nused_memory_rss:200\r\nused_memory_peak:300\r\n"
+        b"maxmemory:0\r\nmaxmemory_policy:noeviction\r\n"
+    )
+    sock = _fake_socket(reply)
+    with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+        out = redis.redis_metrics(port=6379)
+    assert out == {"used_memory": 100.0, "maxmemory": 0.0}
+
+
+# --- cross-repo contract (fivenines-server) -------------------------------
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "redis_contract_payload.json"
+)
+
+# Existing keys the pre-#491 server already read (or that shipped in the
+# payload) -- must stay byte-compatible in name and shape.
+_LEGACY_KEYS = {
+    "redis_version",
+    "connected_clients",
+    "maxclients",
+    "blocked_clients",
+    "evicted_keys",
+    "expired_keys",
+    "uptime_in_seconds",
+    "evicted_clients",
+    "total_connections_received",
+    "total_commands_processed",
+}
+
+# Fields #491 adds. A parser regression that drops one must fail loudly here.
+_NEW_KEYS = {
+    "used_memory",
+    "maxmemory",
+    "mem_fragmentation_ratio",
+    "instantaneous_ops_per_sec",
+    "keyspace_hits",
+    "keyspace_misses",
+    "role",
+    "connected_slaves",
+    "master_repl_offset",
+    "rdb_last_save_time",
+    "rdb_last_bgsave_status",
+    "aof_enabled",
+}
+
+
+def test_contract_fixture_round_trip():
+    """SHARED FIXTURE (cross-repo contract): fixtures/redis_contract_payload.json.
+
+    Asserted on both sides:
+    - here: redis_metrics(**fixture["config"]) must equal each scenario's
+      "payload" with only socket.create_connection mocked (the scenario's raw
+      "info" is fed back as the reply), pinning parse -> payload;
+    - fivenines-server: spec/requests/api_collect_redis_spec.rb posts each
+      "payload" under data["redis"] and asserts Ingesters::Agent ingests it.
+
+    Change the payload shape only in lockstep with the server spec and its
+    byte-identical fixture copy.
+    """
+    with open(_FIXTURE_PATH) as f:
+        fixture = json.load(f)
+    config = fixture["config"]
+
+    for name, scenario in fixture["scenarios"].items():
+        sock = _fake_socket(scenario["info"].encode())
+        with patch("fivenines_agent.redis.socket.create_connection", return_value=sock):
+            out = redis.redis_metrics(**config)
+        assert out == scenario["payload"], "scenario '{}' drifted".format(name)
+
+    scenarios = fixture["scenarios"]
+
+    # master carries every section: legacy keys stay, new keys arrive, nested
+    # db*/slave* shapes hold, and substring traps never leak in.
+    master = scenarios["master"]["payload"]
+    assert _LEGACY_KEYS <= set(master)
+    assert _NEW_KEYS <= set(master)
+    assert master["slave0"]["state"] == "online"
+    assert master["slave0"]["port"] == 6379.0
+    assert set(master["db0"]) == {"keys", "expires", "avg_ttl"}
+    for trap in ("used_memory_rss", "used_memory_peak", "maxmemory_policy"):
+        assert trap not in master
+
+    # replica exposes the replica-only link fields; a standalone/master must not.
+    replica = scenarios["replica"]["payload"]
+    assert replica["role"] == "slave"
+    assert {
+        "master_link_status",
+        "slave_repl_offset",
+        "master_last_io_seconds_ago",
+    } <= (set(replica))
+    assert "master_link_status" not in scenarios["standalone"]["payload"]
+
+    # Valkey ships its own version string alongside the compat redis_version.
+    valkey = scenarios["valkey"]["payload"]
+    assert valkey["valkey_version"] == "8.0.1"
+    assert valkey["redis_version"] == "7.2.4"
+
+    # A denied reply degrades to {} (server presence gate skips it).
+    assert scenarios["auth_failure"]["payload"] == {}
+
+
+def test_fixture_config_is_the_documented_shape():
+    """The agent receives config["redis"] == {port, password?}; the fixture's
+    'config' pins that contract shape (no host, no new keys)."""
+    with open(_FIXTURE_PATH) as f:
+        fixture = json.load(f)
+    assert set(fixture["config"]) <= {"port", "password"}
+    assert fixture["agent_min_version"] == "1.11.0"


### PR DESCRIPTION
Agent side of server issue **Five-Nines-io/fivenines_server#491** (Deepen Redis integration). Ships ~15 more raw fields from the existing single `INFO` call and adds first-class Valkey support. No agent-side derivation, no new config keys, no new capability, no new dependencies.

## What changed
`fivenines_agent/redis.py` reworked from a `re.search` whitelist to **parse the whole INFO reply, then cherry-pick exact keys**. The old substring approach could not survive the new fields (`used_memory` would swallow `used_memory_rss`; `maxmemory` would swallow `maxmemory_policy`), so matching is now exact via `STRING_KEYS` / `NUMERIC_KEYS` frozensets + a `^(db\d+|slave\d+)$` nested parser.

New raw fields shipped when `INFO` returns them:
- **Memory:** `used_memory`, `maxmemory` (raw `0` = no limit), `mem_fragmentation_ratio`
- **Stats/perf:** `instantaneous_ops_per_sec`, `keyspace_hits`, `keyspace_misses`
- **Replication:** `role`, `connected_slaves`, `master_repl_offset`, replica-only `master_link_status` / `slave_repl_offset` / `master_last_io_seconds_ago`, and master `slaveN:` lines parsed to nested dicts
- **Persistence:** `rdb_last_save_time`, `rdb_last_bgsave_status`, `aof_enabled`
- **Valkey:** `valkey_version` (shipped alongside the compat `redis_version`)

All rates/ratios/ages/lag stay server-side. Strings stay strings; numerics stay floats (existing convention).

## Backward compatibility
Every currently-shipped key keeps its exact name, type, and nesting (`redis_version` string; the flat float metrics; `db<N>` nested float dicts). An independent review diffed the old vs new parser across all fixture scenarios and found **zero divergences on the legacy keys**. Unknown keys are ignored by the current prod server, so either deploy order is safe.

Traps handled per the issue: `partition(':')` instead of `split(':')` (slaveN + IPv6 `ip=::1` carry extra colons and would crash the old 2-tuple unpack); per-line resilience so one malformed line drops only its own key, never the whole tick; dead `auth_prefix` + unused imports removed.

## Failure semantics (unchanged)
- socket/connection error -> `None` (server skips the block)
- denied/unparseable reply (`-WRONGPASS`, `-NOAUTH`) or empty response -> `{}` (server presence gate skips it)

## Tests
- New `tests/test_redis.py` (12 tests, **100% line coverage on `redis.py`**): contract round-trip, AUTH ordering, socket-error->None, empty->{}, malformed-line-skip, IPv6/multi-colon slave line, substring-trap exclusion.
- New shared contract fixture `tests/fixtures/redis_contract_payload.json` (**source of truth**; payloads generated from the real parser). 6 scenarios: master (2 replicas) / replica / standalone (`maxmemory:0`, AOF off) / valkey / legacy_minimal / auth_failure->{}.
- `isort` / `black` / `flake8` / `mypy` / `bandit` clean on the new files; ASCII-only (the repo's hard CI gate).
- `redis` added to `_DRY_RUN_CONFIG` so `--dry-run` exercises the collector.

Simulated dry-run `redis` block (master fixture through the real collector, socket mocked):
```json
"redis": { "redis_version": "7.2.4", "used_memory": 1048576.0, "maxmemory": 2147483648.0,
  "mem_fragmentation_ratio": 1.23, "keyspace_hits": 900.0, "keyspace_misses": 100.0,
  "role": "master", "connected_slaves": 2.0, "master_repl_offset": 123456.0,
  "slave0": {"ip": "10.0.0.2", "port": 6379.0, "state": "online", "offset": 123400.0, "lag": 0.0},
  "rdb_last_save_time": 1699564800.0, "rdb_last_bgsave_status": "ok", "aof_enabled": 0.0, "...": "..." }
```

## Before merge
- [ ] **Manual acceptance (needs a live env):** paste `--dry-run` `redis` blocks from a real Redis 7.x, a Valkey 8 (`docker run valkey/valkey:8`), and a master/replica pair, per the issue's "verified against Valkey" criterion.
- [ ] **Server lockstep (`fivenines_server` branch `issue-491`):** vendor a byte-identical copy of `redis_contract_payload.json` at `spec/fixtures/`, add the `/collect` spec + ingester + derived metrics. Do **not** add a `"redis" => "1.11.0"` `FEATURES_SUPPORTED_VERSIONS` entry (would wrongly mark basic Redis unsupported on older agents — the legacy 2-metric support predates the capability system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)