### PR TITLE
fix: derive agent VERSION from package metadata (single source of truth)

### DIFF
--- a/fivenines_agent/cli.py
+++ b/fivenines_agent/cli.py
@@ -1,8 +1,18 @@
 """Command-line interface and argument parsing for fivenines agent."""
 
 import argparse
+from importlib.metadata import PackageNotFoundError, version
 
-VERSION = '1.11.1'
+# Single source of truth for the version is pyproject.toml; importlib.metadata
+# reads it back from the installed distribution's metadata so this stays in sync
+# automatically. The PyInstaller binary bundles that metadata via
+# `--copy-metadata fivenines_agent` in py2exe.sh (whose --version smoke check
+# aborts the build if it is missing). The fallback only applies when running
+# from a source tree with no installed distribution metadata.
+try:
+    VERSION = version('fivenines_agent')
+except PackageNotFoundError:  # pragma: no cover - only hit in uninstalled source trees
+    VERSION = '0.0.0+unknown'
 
 # Global args storage (set by parse_args)
 _args = None

--- a/py2exe.sh
+++ b/py2exe.sh
@@ -284,7 +284,7 @@ PYI_BASE=(
     --noconfirm --onedir --name "$BINARY_NAME"
     --workpath ./build/tmp --distpath ./build --clean
     --hidden-import=scramp --hidden-import=dateutil.parser
-    --copy-metadata pg8000 --copy-metadata scramp
+    --copy-metadata fivenines_agent --copy-metadata pg8000 --copy-metadata scramp
     --add-binary "$PYTHON_LIB:."
     --add-binary "/usr/local/lib/libcrypt.so.2:." --add-binary "/usr/local/lib/libcrypt.so.1:."
     --add-binary "/usr/lib64/libz.so.1:."
@@ -314,10 +314,20 @@ ldd ./build/$BINARY_NAME/$BINARY_NAME | head -10 || echo "ldd check failed (migh
 # collector graph (incl. pg8000, which reads its package metadata at import),
 # so this catches missing hidden imports or un-copied metadata before shipping.
 echo "=== Testing Built Binary ==="
-if ! ./build/$BINARY_NAME/$BINARY_NAME --version; then
+if ! VERSION_OUTPUT="$(./build/$BINARY_NAME/$BINARY_NAME --version)"; then
     echo "Smoke check FAILED: built binary cannot run --version (missing hidden import or bundled metadata). Aborting."
     exit 1
 fi
+echo "$VERSION_OUTPUT"
+# cli.py derives VERSION from the bundled fivenines_agent metadata; the
+# 0.0.0+unknown fallback means --copy-metadata fivenines_agent did not land, so
+# refuse to ship a binary that would report the wrong version.
+case "$VERSION_OUTPUT" in
+    *0.0.0+unknown*)
+        echo "Smoke check FAILED: --version reports the metadata-missing fallback (fivenines_agent metadata not bundled). Aborting."
+        exit 1
+        ;;
+esac
 
 # Move to final location
 if [ -n "${SYNOLOGY:-}" ]; then


### PR DESCRIPTION
`cli.py` hardcoded its `VERSION`, which was left at `1.11.1` when `pyproject.toml` bumped to `1.11.2` -- so `--version` and the `/collect` payload's `version` field under-reported the running release. This reads the version from `importlib.metadata` at runtime instead, making `pyproject.toml` the single source of truth so the two can no longer drift. The PyInstaller build now bundles the agent's own dist metadata via `--copy-metadata fivenines_agent`, and the build's `--version` smoke check rejects the `0.0.0+unknown` metadata-missing fallback so a binary that would report the wrong version can never ship. Verified end-to-end in a Python 3.13 venv: metadata path -> `1.11.2`, `--version` -> `fivenines-agent 1.11.2`, and the fallback path -> `0.0.0+unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)