### PR TITLE
fix(ci): release version guard checks pyproject only (cli.py derives from metadata)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -890,16 +890,19 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Verify tag matches pyproject.toml and cli.py versions
+      - name: Verify tag matches pyproject.toml version
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           FILE_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
-          CLI_VERSION=$(grep "^VERSION = " fivenines_agent/cli.py | head -1 | cut -d"'" -f2)
-          echo "Tag version:        $TAG_VERSION"
-          echo "pyproject.toml:     $FILE_VERSION"
-          echo "fivenines_agent/cli.py: $CLI_VERSION"
-          if [ "$TAG_VERSION" != "$FILE_VERSION" ] || [ "$TAG_VERSION" != "$CLI_VERSION" ]; then
-            echo "::error::Tag v$TAG_VERSION disagrees with pyproject.toml ($FILE_VERSION) or fivenines_agent/cli.py ($CLI_VERSION). Bump the version stamps before tagging."
+          echo "Tag version:    $TAG_VERSION"
+          echo "pyproject.toml: $FILE_VERSION"
+          # pyproject.toml is the single source of truth for the version.
+          # fivenines_agent/cli.py derives VERSION from the installed package
+          # metadata (built from pyproject.toml), so it cannot drift and is no
+          # longer grepped here; the py2exe.sh build smoke check separately
+          # confirms the frozen binary reports a real (non-fallback) version.
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION disagrees with pyproject.toml ($FILE_VERSION). Bump the version in pyproject.toml before tagging."
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up to #86, which is why the `v1.11.2` release build failed. PR #86 made `fivenines_agent/cli.py` derive `VERSION` from the installed package metadata instead of a hardcoded literal, but the release job's guard still grepped `^VERSION = ` out of `cli.py` -- which now returns empty, so the tag push failed with `cli.py ()` even though the tag and `pyproject.toml` agreed. This verifies the tag against `pyproject.toml` only (the single source of truth `cli.py` now derives from, so it cannot drift), while the `py2exe.sh` build smoke check still confirms the frozen binary reports a real, non-fallback version. No published artifacts were affected -- the guard runs before the "Create GitHub Release" and R2 sync steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)