### PR TITLE
v1.11.7 feat: emit Proxmox storage pool identifier for ZFS<->storage join (#49)

### DIFF
--- a/fivenines_agent/proxmox.py
+++ b/fivenines_agent/proxmox.py
@@ -405,11 +405,39 @@ class ProxmoxCollector:
 
         return containers
 
+    def _storage_config_map(self):
+        """Map storage id -> its datacenter /storage config entry.
+
+        The per-node /nodes/<n>/storage endpoint returns runtime status only
+        (total/used/avail/active); the 'pool' property -- a zfspool's ZFS
+        dataset (e.g. 'rpool/data'), an rbd/cephfs's Ceph pool -- lives in the
+        cluster-wide datacenter storage config (/storage). One call per collect,
+        used to enrich each per-node storage row with the ZFS<->Proxmox join key
+        (issue #49). Best-effort: a restricted token that cannot read /storage,
+        or an older PVE, yields {} and no 'pool' enrichment rather than failing
+        the storage section -- deliberately NOT threaded through the `collection`
+        flags block, so it never flips storage_ok.
+        """
+        config = {}
+        try:
+            for entry in self.proxmox.storage.get():
+                storage_id = entry.get('storage')
+                if storage_id:
+                    config[storage_id] = entry
+        except Exception as e:
+            log(f"Error listing datacenter storage config: {e}", 'debug')
+        return config
+
     def _collect_storage(self, collection=None):
         """Collect metrics for all storage pools."""
         storage_pools = []
         try:
             node_list = self.proxmox.nodes.get()
+
+            # Datacenter storage config (/storage), one cluster-wide call, maps
+            # storage id -> its config entry so each per-node storage row can be
+            # enriched with 'pool' (the ZFS<->Proxmox join key, issue #49).
+            config_map = self._storage_config_map()
 
             for node_info in node_list:
                 node_name = node_info.get('node')
@@ -433,6 +461,15 @@ class ProxmoxCollector:
                             'available': storage.get('avail') or 0,
                             'active': storage.get('active', 0) == 1
                         }
+
+                        # Additive 'pool' enrichment: present only for storage
+                        # types that carry one (zfspool/rbd/cephfs), omitted
+                        # (never null) otherwise, so a host with only dir/lvmthin
+                        # stays byte-identical to the pre-field payload.
+                        pool = config_map.get(storage_name, {}).get('pool')
+                        if pool is not None:
+                            storage_data['pool'] = pool
+
                         storage_pools.append(storage_data)
 
                 except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.11.6"
+version = "1.11.7"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/proxmox_contract_payload.json
+++ b/tests/fixtures/proxmox_contract_payload.json
@@ -24,6 +24,13 @@
     "api_unreachable_after_construction": "The realistic auth-failure / host-down case: token-auth ProxmoxAPI constructs lazily (no None), then every request raises. version.get() raises AND the node-listing probe raises => collect() returns None (see scenario 'unreachable'). BEFORE 1.9.0 this returned {\"version\": null, \"cluster\": null, \"nodes\": [], \"vms\": [], \"lxc\": [], \"storage\": []}, indistinguishable-by-value from an idle node; normalized to None in 1.9.0.",
     "single_node_timeout": "One node's per-node calls raise mid-loop while the cluster-wide /cluster/status still counts it online. Exceptions are swallowed per-node in _collect_nodes/_collect_vms/_collect_lxc/_collect_storage, so that node silently drops from payload.nodes/vms/lxc/storage while payload.cluster.nodes_online still includes it (see scenario 'partial_node_timeout')."
   },
+  "storage_pool_contract": {
+    "_note": "Agent-side prerequisite for the deferred ZFS<->Proxmox join (issue #49, ZFS pool health shipped in agent 1.11.3). Each storage entry OPTIONALLY carries 'pool', read from the datacenter storage config (/storage -> self.proxmox.storage.get(), one cluster-wide call), which is DISTINCT from the per-node /nodes/<n>/storage runtime status the total/used/available/active fields come from. See scenario 'standalone' for the pinned shape (local-zfs carries pool, local/local-lvm do not).",
+    "field": "pool",
+    "present_for": "Pool-backed storage types only: zfspool (the ZFS dataset, e.g. 'rpool/data'), rbd/cephfs (the Ceph pool). OMITTED (key absent, never null) for dir/lvmthin/nfs/etc, so a host with no pool-backed storage stays byte-identical to the pre-field payload -- the contract is purely additive and the field is the single allowed optional key beyond the base 7.",
+    "server_join": "For a zfspool storage the zpool ROOT is pool.split('/')[0] (e.g. 'rpool/data' -> 'rpool'); the server joins that to host-local ZfsPool.name per (host, pool root). This is the join key proxmox_storages.name could never provide -- that column is the PVE storage ID (e.g. 'local-zfs'), not the zpool name. rbd/cephfs 'pool' is the Ceph pool; the server filters by type when joining. OUT OF SCOPE for the agent: the server adds proxmox_storages.pool and performs the join in a paired lockstep PR.",
+    "best_effort": "Enrichment is best-effort. A restricted token that cannot read /storage, or an older PVE, degrades to no 'pool' on any entry and NEVER fails or flips storage_ok -- _storage_config_map swallows its own error and is deliberately not threaded through the 'collection' flags block. Deploy order is not sensitive: an old server ignores the extra 'pool' key; a new server reads it with .get('pool')."
+  },
   "scenarios": {
     "quorate_cluster": {
       "description": "3-node quorate cluster 'production'. Guests spread across nodes (pve1: vm 100 + ct 200; pve2: vm 101; pve3: stopped ct 201). Shared storage 'ceph-pool' visible on all three nodes (reported 3x, once per node -- server must dedupe) plus a per-node 'local-lvm'. cluster.nodes_online (3) == len(nodes) (3) => nodes_ok. This is the fully-healthy reference shape.",
@@ -171,9 +178,15 @@
         "storage_by_node": {
           "standalone-pve": [
             {"storage": "local", "type": "dir", "total": 100000000000, "used": 30000000000, "avail": 70000000000, "active": 1},
-            {"storage": "local-lvm", "type": "lvmthin", "total": 200000000000, "used": 50000000000, "avail": 150000000000, "active": 1}
+            {"storage": "local-lvm", "type": "lvmthin", "total": 200000000000, "used": 50000000000, "avail": 150000000000, "active": 1},
+            {"storage": "local-zfs", "type": "zfspool", "total": 500000000000, "used": 100000000000, "avail": 400000000000, "active": 1}
           ]
-        }
+        },
+        "storage_config": [
+          {"storage": "local", "type": "dir"},
+          {"storage": "local-lvm", "type": "lvmthin"},
+          {"storage": "local-zfs", "type": "zfspool", "pool": "rpool/data"}
+        ]
       },
       "payload": {
         "version": "8.2.4",
@@ -187,7 +200,8 @@
         "lxc": [],
         "storage": [
           {"name": "local", "node": "standalone-pve", "type": "dir", "total": 100000000000, "used": 30000000000, "available": 70000000000, "active": true},
-          {"name": "local-lvm", "node": "standalone-pve", "type": "lvmthin", "total": 200000000000, "used": 50000000000, "available": 150000000000, "active": true}
+          {"name": "local-lvm", "node": "standalone-pve", "type": "lvmthin", "total": 200000000000, "used": 50000000000, "available": 150000000000, "active": true},
+          {"name": "local-zfs", "node": "standalone-pve", "type": "zfspool", "total": 500000000000, "used": 100000000000, "available": 400000000000, "active": true, "pool": "rpool/data"}
         ],
         "collection": {"reachable": true, "cluster_ok": true, "nodes_ok": true, "guests_ok": true, "storage_ok": true, "error": null}
       }

--- a/tests/test_proxmox.py
+++ b/tests/test_proxmox.py
@@ -23,12 +23,17 @@ def make_proxmox_mock(
     lxc_raises_for=None,
     storage_by_node=None,
     storage_raises_for=None,
+    storage_config=None,
+    storage_config_raises=False,
     version_raises=False,
 ):
     """Build a MagicMock simulating proxmoxer.ProxmoxAPI chained-call API.
 
     Each kwarg controls one endpoint. The `_raises_for` variants take a set
-    of node names that should raise instead of returning data.
+    of node names that should raise instead of returning data. `storage_config`
+    wires the datacenter /storage endpoint (self.proxmox.storage.get(), distinct
+    from the per-node storage below); it defaults to [] so absent-config tests
+    get a clean empty datacenter config rather than a bare MagicMock.
     """
     mock = MagicMock()
 
@@ -46,6 +51,16 @@ def make_proxmox_mock(
         mock.nodes.get.side_effect = RuntimeError("nodes boom")
     elif nodes is not None:
         mock.nodes.get.return_value = nodes
+
+    # Datacenter /storage config (self.proxmox.storage.get()), distinct from the
+    # per-node /nodes/<n>/storage runtime status wired in nodes_call below. This
+    # is where the 'pool' property lives, driving the #49 pool enrichment.
+    if storage_config_raises:
+        mock.storage.get.side_effect = RuntimeError("storage config boom")
+    else:
+        mock.storage.get.return_value = (
+            storage_config if storage_config is not None else []
+        )
 
     node_status_raises_for = node_status_raises_for or set()
     qemu_raises_for = qemu_raises_for or set()
@@ -1285,6 +1300,100 @@ def test_collection_reachable_true_when_version_denied_but_nodes_listed():
     assert _collection(result)["reachable"] is True
 
 
+# --- storage 'pool' enrichment (#49 ZFS<->Proxmox join key) ------------------
+#
+# Each storage entry OPTIONALLY carries 'pool', read from the datacenter
+# /storage config (self.proxmox.storage.get()), which the per-node runtime
+# status endpoint does not return. It is the join key the server uses to
+# correlate a PVE storage to host-local ZFS pool health: for a zfspool the zpool
+# root is pool.split('/')[0]. Enrichment is additive and best-effort -- absent
+# for non-pool types, and a /storage failure degrades to no 'pool' WITHOUT
+# flipping storage_ok.
+
+
+def test_collect_storage_pool_enrichment_sets_zfspool_omits_dir():
+    """T79 [#49]: a zfspool storage gets 'pool' from the datacenter /storage
+    config; a dir storage (no pool property) does not."""
+    pmock = make_proxmox_mock(
+        nodes=[{"node": "pve1"}],
+        storage_by_node={
+            "pve1": [
+                {"storage": "local", "type": "dir", "active": 1},
+                {"storage": "local-zfs", "type": "zfspool", "active": 1},
+            ]
+        },
+        storage_config=[
+            {"storage": "local", "type": "dir"},
+            {"storage": "local-zfs", "type": "zfspool", "pool": "rpool/data"},
+        ],
+    )
+    c = make_collector(proxmox_mock=pmock)
+    by_name = {p["name"]: p for p in c._collect_storage()}
+    assert by_name["local-zfs"]["pool"] == "rpool/data"
+    assert "pool" not in by_name["local"]
+
+
+def test_collect_storage_pool_omitted_when_absent_from_config():
+    """T80 [#49]: a storage present in per-node runtime status but absent from
+    the datacenter /storage config gets no 'pool' (omitted, never null)."""
+    pmock = make_proxmox_mock(
+        nodes=[{"node": "pve1"}],
+        storage_by_node={
+            "pve1": [{"storage": "local-zfs", "type": "zfspool", "active": 1}]
+        },
+        storage_config=[],
+    )
+    c = make_collector(proxmox_mock=pmock)
+    pools = c._collect_storage()
+    assert "pool" not in pools[0]
+
+
+def test_collect_storage_degrades_when_storage_config_fails():
+    """T81 [#49]: /storage (datacenter config) raising degrades to no 'pool' on
+    any entry but still collects storage and does NOT flip storage_ok -- pool
+    enrichment is best-effort and off the collection flags block."""
+    pmock = make_proxmox_mock(
+        version={"version": "8"},
+        cluster_status=[],
+        nodes=[{"node": "pve1"}],
+        node_status_by_name={"pve1": {"uptime": 1}},
+        qemu_by_node={"pve1": []},
+        lxc_by_node={"pve1": []},
+        storage_by_node={
+            "pve1": [{"storage": "local-zfs", "type": "zfspool", "active": 1}]
+        },
+        storage_config_raises=True,
+    )
+    c = make_collector(proxmox_mock=pmock)
+    result = c.collect()
+    assert [p["name"] for p in result["storage"]] == ["local-zfs"]
+    assert "pool" not in result["storage"][0]
+    assert result["collection"]["storage_ok"] is True
+
+
+def test_storage_config_map_builds_and_skips_unnamed():
+    """T82 [#49]: _storage_config_map indexes /storage entries by storage id and
+    skips entries with no 'storage' key."""
+    pmock = make_proxmox_mock(
+        storage_config=[
+            {"storage": "local-zfs", "type": "zfspool", "pool": "rpool/data"},
+            {"type": "dir"},  # no storage id -> skipped
+        ],
+    )
+    c = make_collector(proxmox_mock=pmock)
+    config_map = c._storage_config_map()
+    assert set(config_map) == {"local-zfs"}
+    assert config_map["local-zfs"]["pool"] == "rpool/data"
+
+
+def test_storage_config_map_degrades_on_failure():
+    """T83 [#49]: _storage_config_map swallows a /storage failure and returns an
+    empty map (best-effort, never raises)."""
+    pmock = make_proxmox_mock(storage_config_raises=True)
+    c = make_collector(proxmox_mock=pmock)
+    assert c._storage_config_map() == {}
+
+
 # --- cross-repo contract (fivenines-server) ---------------------------------
 #
 # Shared fixture tests/fixtures/proxmox_contract_payload.json is asserted on
@@ -1345,6 +1454,9 @@ _GUEST_KEYS = {
     "uptime",
 }
 _STORAGE_KEYS = {"name", "node", "type", "total", "used", "available", "active"}
+# 'pool' (#49) is the only key a storage entry may carry beyond the base 7 --
+# present for pool-backed types (zfspool/rbd/cephfs), omitted otherwise.
+_STORAGE_OPTIONAL_KEYS = {"pool"}
 
 
 @pytest.mark.parametrize("scenario_name", sorted(_CONTRACT_SCENARIOS))
@@ -1375,7 +1487,9 @@ def test_contract_payload_key_sets(scenario_name):
     for guest in payload["vms"] + payload["lxc"]:
         assert set(guest) == _GUEST_KEYS
     for storage in payload["storage"]:
-        assert set(storage) == _STORAGE_KEYS
+        keys = set(storage)
+        assert _STORAGE_KEYS <= keys
+        assert keys - _STORAGE_KEYS <= _STORAGE_OPTIONAL_KEYS
 
 
 def test_contract_reachable_signal():
@@ -1441,3 +1555,17 @@ def test_contract_collection_storage_ok_independent():
     assert coll["guests_ok"] is True
     assert coll["cluster_ok"] is True
     assert coll["error"] == "node pve2: storage query failed"
+
+
+def test_contract_storage_pool_join_key():
+    """#49: the 'standalone' scenario pins the storage 'pool' join key -- a
+    zfspool storage carries pool='rpool/data' (its zpool root 'rpool' is what the
+    server joins to host-local ZFS pool health), while dir/lvmthin carry no pool.
+    This is the field proxmox_storages.name (the PVE storage ID 'local-zfs')
+    could never provide."""
+    storage = _CONTRACT_SCENARIOS["standalone"]["payload"]["storage"]
+    by_name = {s["name"]: s for s in storage}
+    assert by_name["local-zfs"]["pool"] == "rpool/data"
+    assert by_name["local-zfs"]["pool"].split("/")[0] == "rpool"
+    assert "pool" not in by_name["local"]
+    assert "pool" not in by_name["local-lvm"]


### PR DESCRIPTION
## What

Agent-side prerequisite for the deferred **"backend-joined to Proxmox storages"** half of #49. The ZFS pool health collector shipped in `1.11.3` (#83); what was missing is the **join key**.

`proxmox_storages.name` is the PVE *storage ID* (`local-zfs`), never the zpool name (`rpool`) — a stock PVE ZFS install maps storage `local-zfs` → dataset `rpool/data` while `zpool list` reports `rpool`, so the names never match and nothing keyed the join. The bridge is the PVE datacenter storage config's **`pool`** property, which the per-node `/nodes/<n>/storage` runtime-status endpoint does not return.

## Change

- **`proxmox.py`** — new `_storage_config_map()` makes one cluster-wide `self.proxmox.storage.get()` (`/storage`) call and maps `storage_id → config entry`. `_collect_storage` enriches each per-node storage row with `pool` when the config entry carries one.
- The server joins `pool.split('/')[0]` (the zpool root, e.g. `rpool/data` → `rpool`) to host-local `ZfsPool.name`, per host.

## Design guarantees

- **Additive.** `pool` is present only for pool-backed types (zfspool/rbd/cephfs), **omitted (never `null`)** otherwise. A host with only `dir`/`lvmthin` stays **byte-identical** to the pre-field payload — the 5 non-ZFS fixture scenarios are unchanged.
- **Best-effort.** A restricted token that cannot read `/storage`, or an older PVE, degrades to no `pool` and **never fails or flips `storage_ok`** — `_storage_config_map` swallows its own error and is deliberately not threaded through the `collection` flags block.
- **One cluster-wide call**, not per node (the config is datacenter-scoped and identical across nodes).

## Contract

- `tests/fixtures/proxmox_contract_payload.json` — the `standalone` scenario gains a `local-zfs` (zfspool) storage, a `storage_config` (`/storage`) mock, and `pool: "rpool/data"` in the payload; new top-level `storage_pool_contract` doc key describing the field + intended server join.
- **Lockstep:** the fixture is byte-identical shared with the server (`spec/fixtures/proxmox_contract_payload.json`). Paired `fivenines-server` PR (add `proxmox_storages.pool`, join zfspool → host-local `ZfsPool`, copy the fixture) lands together. Deploy order is not sensitive: an old server ignores the extra key; a new server reads it with `.get('pool')`.

## Tests

- +6 tests (5 unit: enrichment / omit-when-absent / degrade-when-`/storage`-fails / map build+skip-unnamed / map degrade; 1 contract-level pin of the join key).
- `proxmox.py` **100% coverage**; full suite **1451 passed, 2 skipped**. ASCII- and flake8-clean.

## Version

`1.11.7` — `1.11.6` was taken by #50 (bridge network) which landed while this was in flight. No overlap (that PR only touched `network.py`).

Refs #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)