### PR TITLE
fix(ci): normalize sysfs path separators in Windows network tests

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -315,8 +315,15 @@ def test_network_enriches_bridge_physical_virtual_and_tags_members():
 
 
 def _split(path):
-    """Split /sys/class/net/<iface>/<rest...> into (iface, rest)."""
-    rel = path[len(SYS_CLASS_NET):].strip("/")
+    """Split /sys/class/net/<iface>/<rest...> into (iface, rest).
+
+    network() builds these paths with os.path.join, which uses the host's
+    separator. On the Windows CI runner (where the tests force the linux branch)
+    that is '\\', so normalise to '/' before splitting -- otherwise the mock
+    would model sysfs differently per platform and the enrichment would silently
+    misparse.
+    """
+    rel = path[len(SYS_CLASS_NET):].replace("\\", "/").strip("/")
     parts = rel.split("/", 1)
     return parts[0], (parts[1] if len(parts) > 1 else "")
 


### PR DESCRIPTION
## Problem

The `main` Windows Build workflow is failing on the **Tests (windows-latest)** job ([run 30022485190](https://github.com/Five-Nines-io/fivenines_agent/actions/runs/30022485190)) with 2 failures in `tests/test_network.py`:

- `test_network_enriches_bridge_physical_virtual_and_tags_members`
- `test_contract_fixture_round_trip`

## Root cause

Both tests force `os_family()` to `"linux"` so the bridge/link-speed sysfs enrichment (issue #50, v1.11.6) is exercised on the runner. But `network.py` builds sysfs paths with `os.path.join`, which on `windows-latest` emits **backslashes** (`/sys/class/net\vmbr0\bridge`). The test's `_split()` mock helper — which parses those paths inside the `os.path.isdir`/`exists`/`listdir` side-effects — only split on `/`, so it returned `iface='\vmbr0\bridge', rest=''`. That made `_is_bridge`/`_interface_type` misparse: `interface_type` came out `"virtual"` and `bridge_member_count` went missing, so the enriched payload didn't match.

This is a **test-harness portability bug, not a product bug**. On real targets there is no issue: Linux uses `/`, and real Windows hosts never enter the enrichment branch (`enrich = os_family() == 'linux'`).

## Fix

One helper, test-only — normalize `\` to `/` before splitting in `_split()`.

## Verification

- Simulated the Windows condition locally (forced `network.py`'s `os.path.join` to `ntpath.join` for sysfs paths) -> both previously-failing tests **pass**.
- Full `tests/test_network.py` on posix: **29/29 pass** (unchanged).
- ASCII-only gate: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)