### PR TITLE
v1.13.1 feat: PHP-FPM collector: per-pool status polling + saturation counters (#97)

### DIFF
--- a/fivenines_agent/collectors.py
+++ b/fivenines_agent/collectors.py
@@ -19,6 +19,7 @@ from fivenines_agent.mysql import mysql_metrics
 from fivenines_agent.network import network
 from fivenines_agent.nginx import nginx_metrics
 from fivenines_agent.partitions import partitions_metadata, partitions_usage
+from fivenines_agent.php_fpm import php_fpm_metrics
 from fivenines_agent.ports import listening_ports
 from fivenines_agent.postgresql import postgresql_metrics
 from fivenines_agent.processes import processes
@@ -91,6 +92,11 @@ COLLECTORS = [
     ("redis", [("redis", redis_metrics, True)]),
     ("nginx", [("nginx", nginx_metrics, True)]),
     ("apache", [("apache", apache_metrics, True)]),
+    # PHP-FPM: config-driven per-pool status scrape (nginx/apache posture, no
+    # capability gate). config["php_fpm"] == {"status_page_url": ...} is unpacked
+    # (pass_kwargs) into php_fpm_metrics(status_page_url=...). Emits an array of
+    # per-pool objects, [] (zero pools), or None (collection failure).
+    ("php_fpm", [("php_fpm", php_fpm_metrics, True)]),
     ("docker", [("docker", docker_metrics, True)]),
     ("qemu", [("qemu", qemu_metrics, True)]),
     ("fail2ban", [("fail2ban", fail2ban_metrics, False)]),

--- a/fivenines_agent/php_fpm.py
+++ b/fivenines_agent/php_fpm.py
@@ -1,0 +1,545 @@
+"""PHP-FPM per-pool status collector (server issue #490).
+
+PHP-FPM is the PHP runtime behind every LEMP/LAMP stack, and per-pool
+saturation -- ``max children reached`` climbing, a growing ``listen queue`` --
+is the single most common "my WordPress site is slow/down" root cause. This
+collector polls the FPM status page for every pool it can reach and ships an
+array of per-pool status objects under ``data["php_fpm"]``; the server turns
+that into per-pool rows, VictoriaMetrics series, and the ``php_fpm_saturation``
+trigger.
+
+Three transports, selected by the configured ``status_page_url``:
+
+* ``http(s)://`` -- scrape the status page exposed through the web server,
+  exactly like ``nginx.py`` / ``apache.py`` (Phase A). One URL == one pool.
+* ``unix://`` / ``tcp://`` -- talk FastCGI directly to an FPM socket via the
+  tiny pure-Python client below, no web-server exposure of ``/status`` needed
+  (Phase B, the security-friendlier setup). A ``unix://`` value points at the
+  socket file (conventionally ``*.sock``) with the ``pm.status_path`` appended:
+  ``unix:///run/php/php8.2-fpm.sock/status``; ``tcp://127.0.0.1:9000/status``
+  gives host, port and status path directly.
+* the sentinel ``"auto"`` -- discover every pool from the FPM pool.d configs and
+  poll each over its own socket (Phase B multi-pool). This is where the array
+  payload earns its shape: N pools ride free.
+
+The payload is one of THREE outcomes, mirroring the zfs null-vs-empty contract
+(the server's dispatch gate is ``is_a?(Array)``):
+
+* a non-empty array -- the trustworthy tick, every known pool responded;
+* ``[]`` -- the scrape succeeded and there are genuinely zero pollable pools
+  (auto-discovery found none), so the server prunes all rows;
+* ``None`` -- COLLECTION FAILURE (endpoint unreachable / timeout / non-200 /
+  malformed JSON, OR ANY single known pool's fetch failed). The server skips
+  ingestion entirely so rows are never pruned and open saturation incidents
+  cannot falsely resolve.
+
+The partial-failure -> ``None`` rule is the sharp edge: a pool silently missing
+from the array reads as "the operator deleted that pool" and resolves its open
+incident, so ANY known pool failing sinks the whole tick to ``None`` (unknown !=
+recovered). A pool the operator genuinely removed simply stops being discovered
+and drops out of a fully-successful array -- the server prunes it, which is
+correct.
+"""
+
+import glob
+import json
+import socket
+import struct
+from urllib.parse import parse_qs, urlsplit
+
+import requests
+
+from fivenines_agent.debug import debug, log
+
+# Shared transport timeout (seconds), matching apache.py / nginx.py. A wedged
+# pool must never hang the whole collect tick.
+_TIMEOUT = 5
+
+# Sentinel status_page_url that switches the collector into pool.d
+# auto-discovery mode (case-insensitive).
+_AUTO = "auto"
+
+# FPM's status JSON uses space-separated keys; normalise to the snake_case wire
+# contract. Insertion order is the JSON key order and must match the payload
+# fixture. Cumulative counters (max_children_reached, slow_requests,
+# accepted_connections) are shipped RAW -- the server rate()s them and derives
+# the durable saturation signal; never reset or diff them here. Every other FPM
+# key (start time / start since / listen queue len / max active processes / the
+# "full" per-process array) is dropped: not ingested, keep the payload exact.
+_FIELD_MAP = {
+    "pool": "name",
+    "process manager": "process_manager",
+    "active processes": "active_processes",
+    "idle processes": "idle_processes",
+    "total processes": "total_processes",
+    "listen queue": "listen_queue",
+    "max listen queue": "max_listen_queue",
+    "max children reached": "max_children_reached",
+    "slow requests": "slow_requests",
+    "accepted conn": "accepted_connections",
+}
+
+# Where FPM pool definitions live across distributions. Module-level so tests can
+# point discovery at a fixture directory.
+_POOL_CONFIG_GLOBS = [
+    "/etc/php/*/fpm/pool.d/*.conf",
+    "/etc/php-fpm.d/*.conf",
+    "/usr/local/etc/php-fpm.d/*.conf",
+]
+
+
+@debug("php_fpm_metrics")
+def php_fpm_metrics(status_page_url="http://127.0.0.1/status?json"):
+    """Poll every reachable FPM pool; return the per-pool array | ``[]`` | ``None``.
+
+    See the module docstring for the null-vs-empty contract. The single-endpoint
+    forms (http/unix/tcp) degenerate to: success -> ``[pool]``, failure ->
+    ``None``; only auto-discovery ever yields ``[]``.
+    """
+    try:
+        endpoints = _resolve_endpoints(status_page_url)
+    except Exception as e:  # defensive: resolution must never raise upward
+        log(f"Error resolving PHP-FPM endpoints: {e}", "error")
+        return None
+
+    if endpoints is None:
+        # The configuration could not be turned into a pollable endpoint
+        # (unknown scheme / unparsable) -- a collection failure, not "no pools".
+        return None
+    if not endpoints:
+        # Auto-discovery ran and found genuinely zero pollable pools.
+        return []
+
+    pools = []
+    for endpoint in endpoints:
+        status = _fetch_pool_status(endpoint)
+        if status is None:
+            # ANY known pool's fetch failed -> sink the whole tick to null so
+            # the server never prunes a pool that is merely unreachable.
+            log(f"PHP-FPM pool fetch failed for {_endpoint_label(endpoint)}", "error")
+            return None
+        pools.append(_normalize_pool(status))
+    return pools
+
+
+# --- endpoint resolution ---------------------------------------------------
+
+
+def _resolve_endpoints(status_page_url):
+    """Turn the configured status_page_url into the list of endpoints to poll.
+
+    Returns a (possibly empty) list of endpoints, or ``None`` when the value
+    could not be resolved to anything pollable (unknown scheme / unparsable),
+    which the caller reports as a collection failure.
+    """
+    target = (status_page_url or "").strip()
+    if target.lower() == _AUTO:
+        return _discover_pools()
+    endpoint = _endpoint_from_url(target)
+    if endpoint is None:
+        return None
+    return [endpoint]
+
+
+def _endpoint_from_url(url):
+    """Parse a single explicit status_page_url into an endpoint dict, or None."""
+    scheme = urlsplit(url).scheme.lower()
+    if scheme in ("http", "https"):
+        return {"kind": "http", "url": _ensure_json_query(url)}
+    if scheme == "unix":
+        return _unix_endpoint_from_url(url)
+    if scheme == "tcp":
+        return _tcp_endpoint_from_url(url)
+    log(f"Unsupported PHP-FPM status_page_url scheme: {scheme or '(none)'}", "error")
+    return None
+
+
+def _ensure_json_query(url):
+    """Append ``json`` to the query string when absent (defensively).
+
+    FPM only emits JSON when the status request carries the ``json`` flag. Scope
+    the check to the parsed query string so a host or path that merely contains
+    the substring "json" (e.g. /jsonstatus) is not mistaken for the flag already
+    being present -- the apache ?auto lesson.
+    """
+    query = urlsplit(url).query
+    if "json" in parse_qs(query, keep_blank_values=True):
+        return url
+    sep = "&" if query else "?"
+    return f"{url}{sep}json"
+
+
+def _unix_endpoint_from_url(url):
+    """Split ``unix:///socket/path/status`` into socket file + SCRIPT_NAME.
+
+    The documented form has an empty authority (``unix:///path``). If a caller
+    writes ``unix://path`` (two slashes), urlsplit parses the first path segment
+    as the authority; fold it back so the (always absolute) socket path keeps its
+    leading component instead of silently losing it.
+    """
+    parts = urlsplit(url)
+    path = parts.path
+    if parts.netloc:
+        path = "/" + parts.netloc + path
+    return _split_unix_path(path)
+
+
+def _split_unix_path(path):
+    """Separate the FPM socket file from the trailing status path.
+
+    FPM sockets conventionally end in ``.sock``; everything after that marker is
+    the FastCGI SCRIPT_NAME (the ``pm.status_path``). Without a ``.sock`` marker
+    the split is inherently ambiguous, so fall back to treating the last path
+    segment as the status path -- prefer the ``.sock`` naming or auto-discovery,
+    which avoids the ambiguity entirely.
+    """
+    marker = ".sock"
+    idx = path.find(marker)
+    if idx != -1:
+        end = idx + len(marker)
+        return {"kind": "unix", "address": path[:end], "script_name": path[end:] or "/status"}
+    parent, sep, last = path.rpartition("/")
+    if sep and parent and last:
+        return {"kind": "unix", "address": parent, "script_name": "/" + last}
+    return None
+
+
+def _tcp_endpoint_from_url(url):
+    """Parse ``tcp://host:port/status`` into a TCP FastCGI endpoint, or None."""
+    parts = urlsplit(url)
+    try:
+        host = parts.hostname
+        port = parts.port
+    except ValueError:
+        return None
+    if not host or not port:
+        return None
+    return {"kind": "tcp", "host": host, "port": port, "script_name": parts.path or "/status"}
+
+
+# --- pool.d auto-discovery -------------------------------------------------
+
+
+def _discover_pools():
+    """Discover pollable pools from the FPM pool.d configs.
+
+    Returns a list of endpoints (possibly empty -- genuinely zero pollable
+    pools, which the server prunes), or ``None`` if ANY matched config file
+    could not be read. An unreadable config means the discovered set may be
+    incomplete, and a pollable pool silently dropping out reads as "the operator
+    removed it" so its open saturation incident false-resolves. A read failure
+    therefore sinks the whole tick to a collection failure (None) -- the same
+    unknown-!=-recovered discipline as a per-pool fetch failure, never a silently
+    short array. Only pools declaring BOTH a ``listen`` socket and a
+    ``pm.status_path`` are pollable (FPM 404s otherwise); duplicate endpoints
+    across files are polled once.
+    """
+    endpoints = []
+    seen = set()
+    for path in _pool_config_files():
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError as e:
+            # A matched-but-unreadable config makes discovery untrustworthy:
+            # fail the tick to None rather than under-report and false-prune.
+            log(f"PHP-FPM pool config unreadable ({path}): {e}", "error")
+            return None
+        for pool in _parse_pool_file(text):
+            endpoint = _endpoint_from_listen(pool.get("listen"), pool.get("status_path"))
+            if endpoint is None:
+                continue
+            key = _endpoint_key(endpoint)
+            if key in seen:
+                continue
+            seen.add(key)
+            endpoints.append(endpoint)
+    return endpoints
+
+
+def _pool_config_files():
+    """Glob the pool.d config paths, de-duplicated and sorted for determinism."""
+    files = []
+    for pattern in _POOL_CONFIG_GLOBS:
+        files.extend(glob.glob(pattern))
+    return sorted(set(files))
+
+
+def _parse_pool_file(text):
+    """Parse an FPM pool config into ``[{name, listen, status_path}, ...]``.
+
+    A minimal INI reader tolerant of FPM's quirks (``;`` comments, inline
+    comments, quoted values, the ``[global]`` pseudo-section, options repeated
+    across pools) -- configparser is too strict for real-world pool files.
+    """
+    pools = []
+    current = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(";"):
+            continue
+        if line.startswith("[") and "]" in line:
+            end = line.index("]")
+            current = {"name": line[1:end].strip(), "listen": None, "status_path": None}
+            pools.append(current)
+            continue
+        if current is None or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip().lower()
+        value = _clean_value(value)
+        if key == "listen":
+            current["listen"] = value
+        elif key == "pm.status_path":
+            current["status_path"] = value
+    return pools
+
+
+def _clean_value(value):
+    """Strip an inline ``;`` comment, surrounding whitespace, then a quote pair."""
+    value = value.split(";", 1)[0].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        value = value[1:-1]
+    return value
+
+
+def _endpoint_from_listen(listen, status_path):
+    """Build a FastCGI endpoint from a pool's ``listen`` + ``pm.status_path``."""
+    if not listen or not status_path:
+        return None
+    script = status_path if status_path.startswith("/") else "/" + status_path
+    if "/" in listen:
+        # An absolute path -> unix domain socket.
+        return {"kind": "unix", "address": listen, "script_name": script}
+    hostport = _split_host_port(listen)
+    if hostport is None:
+        return None
+    host, port = hostport
+    return {"kind": "tcp", "host": host, "port": port, "script_name": script}
+
+
+def _split_host_port(listen):
+    """Parse an FPM ``listen`` address into (host, port), defaulting host.
+
+    Accepts ``host:port``, ``:port``, a bare ``port`` (FPM binds 127.0.0.1), and
+    ``[ipv6]:port``. Returns None when no valid port can be read.
+    """
+    listen = listen.strip()
+    if listen.startswith("["):  # [ipv6]:port
+        host, sep, rest = listen.partition("]")
+        if not sep or not rest.startswith(":"):
+            return None
+        port = _safe_port(rest[1:])
+        host = host[1:]
+        return (host, port) if host and port else None
+    if ":" in listen:  # host:port or :port
+        host, _, port = listen.rpartition(":")
+        port = _safe_port(port)
+        return (host or "127.0.0.1", port) if port else None
+    port = _safe_port(listen)  # bare port
+    return ("127.0.0.1", port) if port else None
+
+
+def _safe_port(value):
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        return None
+    return port if 0 < port < 65536 else None
+
+
+def _endpoint_key(endpoint):
+    """Hashable identity for de-duplicating discovered endpoints."""
+    kind = endpoint["kind"]
+    if kind == "http":
+        return ("http", endpoint["url"])
+    if kind == "unix":
+        return ("unix", endpoint["address"], endpoint["script_name"])
+    return ("tcp", endpoint["host"], endpoint["port"], endpoint["script_name"])
+
+
+def _endpoint_label(endpoint):
+    """Human-readable endpoint id for logs and test transport keying."""
+    kind = endpoint["kind"]
+    if kind == "http":
+        return endpoint["url"]
+    if kind == "unix":
+        return f"unix:{endpoint['address']}{endpoint['script_name']}"
+    return f"tcp:{endpoint['host']}:{endpoint['port']}{endpoint['script_name']}"
+
+
+# --- fetch + normalise -----------------------------------------------------
+
+
+def _fetch_pool_status(endpoint):
+    """Fetch one pool's raw FPM status dict, or None on any failure."""
+    body = _fetch_status_body(endpoint)
+    if body is None:
+        return None
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _fetch_status_body(endpoint):
+    """Transport seam: return the raw status body text, or None on failure."""
+    if endpoint["kind"] == "http":
+        return _http_status_body(endpoint["url"])
+    return _fcgi_status_body(endpoint)
+
+
+def _http_status_body(url):
+    try:
+        response = requests.get(url, timeout=_TIMEOUT)
+    except Exception as e:
+        log(f"PHP-FPM HTTP error for {url}: {e}", "error")
+        return None
+    if response.status_code != 200:
+        return None
+    return response.text
+
+
+def _normalize_pool(status):
+    """Map the space-separated FPM keys to the snake_case wire contract.
+
+    Unmapped FPM fields are dropped; a missing mapped field yields None (real
+    FPM always emits the full set, so a healthy scrape has no None values).
+    """
+    return {payload_key: status.get(fpm_key) for fpm_key, payload_key in _FIELD_MAP.items()}
+
+
+# --- FastCGI client --------------------------------------------------------
+#
+# A tiny pure-Python FastCGI responder client (no new dependency). It sends one
+# BEGIN_REQUEST + PARAMS + empty STDIN GET for the status path and reads STDOUT
+# until END_REQUEST. See https://fastcgi-archives.github.io/FastCGI_Specification.html
+
+_FCGI_VERSION = 1
+_FCGI_BEGIN_REQUEST = 1
+_FCGI_END_REQUEST = 3
+_FCGI_PARAMS = 4
+_FCGI_STDIN = 5
+_FCGI_STDOUT = 6
+_FCGI_RESPONDER = 1
+_FCGI_REQUEST_ID = 1
+# Safety cap on accumulated STDOUT (status JSON is < 1 KiB; this only guards a
+# misbehaving backend from unbounded growth -- the socket timeout bounds time).
+_FCGI_MAX_BODY = 1 << 20
+
+
+def _fcgi_status_body(endpoint):
+    """Fetch the status page over FastCGI; return body text or None on failure."""
+    script = endpoint.get("script_name") or "/status"
+    params = {
+        "GATEWAY_INTERFACE": "FastCGI/1.0",
+        "REQUEST_METHOD": "GET",
+        "SCRIPT_NAME": script,
+        "SCRIPT_FILENAME": script,
+        "DOCUMENT_URI": script,
+        "REQUEST_URI": f"{script}?json",
+        "QUERY_STRING": "json",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "SERVER_SOFTWARE": "fivenines-agent",
+        "REMOTE_ADDR": "127.0.0.1",
+    }
+    sock = None
+    try:
+        sock = _fcgi_connect(endpoint)
+        raw = _fcgi_exchange(sock, params)
+    except OSError as e:
+        log(f"PHP-FPM FastCGI error for {_endpoint_label(endpoint)}: {e}", "error")
+        return None
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+    return _fcgi_body(raw)
+
+
+def _fcgi_connect(endpoint):
+    if endpoint["kind"] == "unix":
+        family = getattr(socket, "AF_UNIX", None)
+        if family is None:  # non-POSIX platform; FPM is Linux-only anyway
+            raise OSError("AF_UNIX unavailable on this platform")
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        sock.settimeout(_TIMEOUT)
+        sock.connect(endpoint["address"])
+        return sock
+    sock = socket.create_connection((endpoint["host"], endpoint["port"]), _TIMEOUT)
+    sock.settimeout(_TIMEOUT)
+    return sock
+
+
+def _fcgi_exchange(sock, params):
+    begin = struct.pack("!HB5x", _FCGI_RESPONDER, 0)  # role, flags=0 (no keep-conn)
+    sock.sendall(_fcgi_record(_FCGI_BEGIN_REQUEST, begin))
+    payload = b"".join(_fcgi_pair(k, v) for k, v in params.items())
+    sock.sendall(_fcgi_record(_FCGI_PARAMS, payload))
+    sock.sendall(_fcgi_record(_FCGI_PARAMS, b""))  # empty PARAMS terminates the stream
+    sock.sendall(_fcgi_record(_FCGI_STDIN, b""))  # empty STDIN: a GET with no body
+    return _fcgi_read_stdout(sock)
+
+
+def _fcgi_record(rec_type, content):
+    # Params/status bodies are tiny, so a single record (content < 65536) is
+    # always sufficient; no multi-record chunking needed on the send side.
+    header = struct.pack("!BBHHBB", _FCGI_VERSION, rec_type, _FCGI_REQUEST_ID, len(content), 0, 0)
+    return header + content
+
+
+def _fcgi_pair(name, value):
+    nb = name.encode("utf-8")
+    vb = value.encode("utf-8")
+    out = bytearray()
+    for length in (len(nb), len(vb)):
+        if length < 128:
+            out += struct.pack("!B", length)
+        else:
+            out += struct.pack("!I", length | 0x80000000)
+    out += nb
+    out += vb
+    return bytes(out)
+
+
+def _fcgi_read_stdout(sock):
+    """Read records until END_REQUEST, accumulating STDOUT (STDERR ignored)."""
+    stdout = bytearray()
+    while True:
+        header = _recv_exact(sock, 8)
+        if len(header) < 8:
+            break  # connection closed early / truncated
+        _, rec_type, _, content_len, pad_len, _ = struct.unpack("!BBHHBB", header)
+        content = _recv_exact(sock, content_len) if content_len else b""
+        if pad_len:
+            _recv_exact(sock, pad_len)
+        if rec_type == _FCGI_STDOUT:
+            stdout += content
+            if len(stdout) > _FCGI_MAX_BODY:
+                break
+        elif rec_type == _FCGI_END_REQUEST:
+            break
+    return bytes(stdout)
+
+
+def _recv_exact(sock, n):
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            break
+        buf += chunk
+    return bytes(buf)
+
+
+def _fcgi_body(raw):
+    """Strip the CGI headers FPM prepends, returning the JSON body text."""
+    for sep in (b"\r\n\r\n", b"\n\n"):
+        idx = raw.find(sep)
+        if idx != -1:
+            start = idx + len(sep)
+            return raw[start:].decode("utf-8", "replace")
+    return raw.decode("utf-8", "replace")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.12.0"
+version = "1.13.1"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/php_fpm_contract_payload.json
+++ b/tests/fixtures/php_fpm_contract_payload.json
@@ -1,0 +1,125 @@
+{
+  "description": "Shared PHP-FPM contract fixture between fivenines-agent and fivenines-server. Source of truth: fivenines-agent tests/fixtures/php_fpm_contract_payload.json, asserted end-to-end by tests/test_php_fpm.py::test_contract_fixture_round_trip (only the HTTP/FastCGI transport is mocked -- each scenario's 'raw_status' bodies are fed back per endpoint, and for 'auto' scenarios the 'pool_configs' are written to a temp dir that discovery is pointed at). php_fpm_metrics(**scenario['config']) must equal scenario['payload']. The server's spec/requests/api_collect_php_fpm_spec.rb posts scenario['payload'] under data['php_fpm'] through /collect and asserts Ingesters::Agent ingests each shape (array / [] / null). 'config', 'pool_configs' and 'raw_status' are agent-side inputs the server ignores. Change the payload shape only in lockstep across both repos, keeping the two copies byte-identical.",
+  "agent_min_version": "1.13.1",
+  "_agent_min_version_note": "1.12.0 was taken by the MQTT collector (server #608). PHP-FPM has NO server version gate (no FEATURES_SUPPORTED_VERSIONS entry -- it is purely config-driven, php_fpm_enabled defaults false), so this number is free. Ships as 1.13.1, a PATCH that cedes the 1.13.0 minor slot to Ceph v2 (#94), which is hard-gated on ceph_extended == '1.13.0'. Nothing gates on this number.",
+  "null_contract": "data['php_fpm'] is one of THREE outcomes and the server MUST branch on them (dispatch gate: is_a?(Array)): (a) null (JSON null / Python None) = COLLECTION FAILURE -- the endpoint was unreachable / timed out / returned non-200 / returned malformed JSON, OR (the multi-pool sharp edge) ANY single known pool's fetch failed. The server MUST NOT prune php_fpm_pools rows or auto-resolve php_fpm_saturation incidents on null: a pool that is merely unreachable is not 'deleted', and treating it as recovery is a false-resolve bug. (b) [] (empty array) = auto-discovery ran and the host genuinely has ZERO pollable pools -- safe to prune. (c) a non-empty array of per-pool objects = the live set; a pool the operator genuinely removed simply stops being discovered and drops out, which the server prunes. Single-endpoint http/unix/tcp mode degenerates to success -> [pool], failure -> null (it never emits []). Same null-vs-empty discipline as the zfs and docker contracts.",
+  "field_contract": {
+    "name": "FPM 'pool' -- the pool name, the per-pool entity key.",
+    "process_manager": "FPM 'process manager' (dynamic / static / ondemand).",
+    "active_processes": "FPM 'active processes' -- gauge.",
+    "idle_processes": "FPM 'idle processes' -- gauge.",
+    "total_processes": "FPM 'total processes' -- gauge.",
+    "listen_queue": "FPM 'listen queue' -- requests waiting for a free worker RIGHT NOW; > 0 is the live saturation signal.",
+    "max_listen_queue": "FPM 'max listen queue' -- high-water mark of the listen queue since FPM start.",
+    "max_children_reached": "FPM 'max children reached' -- RAW cumulative counter of times pm.max_children was hit; the server rate()s it into the durable saturation trigger. Never reset or diff agent-side.",
+    "slow_requests": "FPM 'slow requests' -- RAW cumulative counter (needs request_slowlog_timeout). Shipped raw.",
+    "accepted_connections": "FPM 'accepted conn' -- RAW cumulative counter of accepted connections. Shipped raw.",
+    "_dropped": "FPM's 'start time', 'start since', 'listen queue len' and 'max active processes' are NOT ingested and are dropped from the payload; the 'full' per-process array is never requested."
+  },
+  "scenarios": {
+    "healthy_multi_pool": {
+      "description": "Auto-discovery finds two pools in one pool.d file: 'www' healthy over a unix socket, 'api' SATURATED over a TCP socket (listen_queue 12 + max_children_reached 7 + slow_requests 3). Pins the multi-entity array payload, the snake_case normalization, the drop of start time/start since/listen queue len/max active processes, and raw counter passthrough. Discovery order follows the file, so the array is [www, api].",
+      "config": { "status_page_url": "auto" },
+      "pool_configs": {
+        "fivenines-pools.conf": "[global]\npid = /run/php-fpm.pid\n\n[www]\nuser = www-data\nlisten = /run/php/php8.2-fpm-www.sock  ; the WordPress pool\npm = dynamic\npm.status_path = \"/status\"\n\n[api]\nuser = api\nlisten = 127.0.0.1:9000\npm = static\npm.status_path = /status\n"
+      },
+      "raw_status": {
+        "unix:/run/php/php8.2-fpm-www.sock/status": {
+          "pool": "www",
+          "process manager": "dynamic",
+          "start time": 1721815200,
+          "start since": 3600,
+          "accepted conn": 154823,
+          "listen queue": 0,
+          "max listen queue": 5,
+          "listen queue len": 128,
+          "idle processes": 8,
+          "active processes": 2,
+          "total processes": 10,
+          "max active processes": 3,
+          "max children reached": 0,
+          "slow requests": 0
+        },
+        "tcp:127.0.0.1:9000/status": {
+          "pool": "api",
+          "process manager": "dynamic",
+          "start time": 1721815200,
+          "start since": 3600,
+          "accepted conn": 98211,
+          "listen queue": 12,
+          "max listen queue": 34,
+          "listen queue len": 128,
+          "idle processes": 0,
+          "active processes": 20,
+          "total processes": 20,
+          "max active processes": 20,
+          "max children reached": 7,
+          "slow requests": 3
+        }
+      },
+      "payload": [
+        {
+          "name": "www",
+          "process_manager": "dynamic",
+          "active_processes": 2,
+          "idle_processes": 8,
+          "total_processes": 10,
+          "listen_queue": 0,
+          "max_listen_queue": 5,
+          "max_children_reached": 0,
+          "slow_requests": 0,
+          "accepted_connections": 154823
+        },
+        {
+          "name": "api",
+          "process_manager": "dynamic",
+          "active_processes": 20,
+          "idle_processes": 0,
+          "total_processes": 20,
+          "listen_queue": 12,
+          "max_listen_queue": 34,
+          "max_children_reached": 7,
+          "slow_requests": 3,
+          "accepted_connections": 98211
+        }
+      ]
+    },
+    "zero_pools": {
+      "description": "Auto-discovery succeeds but no pool declares BOTH a listen socket and a pm.status_path (the [global] pseudo-section and a status-less pool are both skipped). Emits [] so the server prunes all rows. Distinct from null: the scrape genuinely succeeded with zero pollable pools.",
+      "config": { "status_page_url": "auto" },
+      "pool_configs": {
+        "no-status.conf": "[global]\npid = /run/php-fpm.pid\n\n[www]\nlisten = /run/php/php8.2-fpm.sock\npm = dynamic\n; pm.status_path intentionally unset -> this pool is not pollable\n"
+      },
+      "payload": []
+    },
+    "collection_failure": {
+      "description": "Single HTTP endpoint that is unreachable / times out / returns non-200 or malformed JSON -- the transport yields None. Emits null (collection failure); the server must NOT prune rows or resolve incidents.",
+      "config": { "status_page_url": "http://127.0.0.1/status?json" },
+      "raw_status": { "http://127.0.0.1/status?json": null },
+      "payload": null
+    },
+    "partial_failure": {
+      "description": "THE FALSE-RESOLVE GUARD. Auto-discovery finds two pools; 'www' responds but 'api' is unreachable (its fetch yields None). Because a pool silently missing from the array reads as 'operator deleted it' and resolves its open incident, ANY known pool failing sinks the WHOLE tick to null -- never a partial array. unknown != recovered.",
+      "config": { "status_page_url": "auto" },
+      "pool_configs": {
+        "two-pools.conf": "[www]\nlisten = /run/php/php8.2-fpm-www.sock\npm.status_path = /status\n\n[api]\nlisten = 127.0.0.1:9000\npm.status_path = /status\n"
+      },
+      "raw_status": {
+        "unix:/run/php/php8.2-fpm-www.sock/status": {
+          "pool": "www",
+          "process manager": "dynamic",
+          "accepted conn": 154823,
+          "listen queue": 0,
+          "max listen queue": 5,
+          "idle processes": 8,
+          "active processes": 2,
+          "total processes": 10,
+          "max children reached": 0,
+          "slow requests": 0
+        },
+        "tcp:127.0.0.1:9000/status": null
+      },
+      "payload": null
+    }
+  }
+}

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -32,6 +32,7 @@ def test_registry_has_expected_config_keys():
         "redis",
         "nginx",
         "apache",
+        "php_fpm",
         "docker",
         "qemu",
         "fail2ban",

--- a/tests/test_php_fpm.py
+++ b/tests/test_php_fpm.py
@@ -1,0 +1,697 @@
+"""Tests for the PHP-FPM per-pool status collector (server issue #490).
+
+Only the transport is mocked. The HTTP path mocks requests.get; the FastCGI
+path drives a FakeSocket through the real BEGIN_REQUEST/PARAMS/STDIN encode and
+STDOUT/END_REQUEST decode; the contract round-trip mocks the _fetch_status_body
+seam and, for auto-discovery scenarios, points discovery at a temp dir of real
+pool.d configs. Mirrors test_apache.py's cross-repo fixture assertion.
+"""
+
+import json
+import os
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from fivenines_agent import php_fpm
+
+
+# --- FastCGI test doubles --------------------------------------------------
+
+
+class FakeSocket:
+    """A minimal stand-in for a connected stream socket.
+
+    ``recv`` drains a preloaded byte buffer (returning b"" at EOF); ``sendall``
+    accumulates what the client wrote so request framing can be asserted.
+    """
+
+    def __init__(self, to_read=b""):
+        self._buf = bytearray(to_read)
+        self.sent = bytearray()
+        self.closed = False
+        self.timeout = None
+        self.connect_addr = None
+
+    def settimeout(self, timeout):
+        self.timeout = timeout
+
+    def sendall(self, data):
+        self.sent += data
+
+    def recv(self, n):
+        if not self._buf:
+            return b""
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    def connect(self, addr):
+        self.connect_addr = addr
+
+    def close(self):
+        self.closed = True
+
+
+def _fcgi_record(rec_type, content, pad=0, request_id=1):
+    header = struct.pack("!BBHHBB", 1, rec_type, request_id, len(content), pad, 0)
+    return header + content + (b"\x00" * pad)
+
+
+_END_REQUEST = _fcgi_record(3, struct.pack("!IB3x", 0, 0))
+
+
+def _fcgi_stream(body, header="Content-type: application/json\r\n\r\n", split=None):
+    """Build a well-formed FPM FastCGI STDOUT+END_REQUEST response byte stream."""
+    payload = (header + body).encode("utf-8")
+    if split:
+        records = b"".join(
+            _fcgi_record(6, payload[i:][:split]) for i in range(0, len(payload), split)
+        )
+    else:
+        records = _fcgi_record(6, payload)
+    return records + _END_REQUEST
+
+
+def _http_response(text="", status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+_RAW_WWW = {
+    "pool": "www",
+    "process manager": "dynamic",
+    "start time": 1721815200,
+    "start since": 3600,
+    "accepted conn": 100,
+    "listen queue": 0,
+    "max listen queue": 5,
+    "listen queue len": 128,
+    "idle processes": 8,
+    "active processes": 2,
+    "total processes": 10,
+    "max active processes": 3,
+    "max children reached": 0,
+    "slow requests": 0,
+}
+
+_NORM_WWW = {
+    "name": "www",
+    "process_manager": "dynamic",
+    "active_processes": 2,
+    "idle_processes": 8,
+    "total_processes": 10,
+    "listen_queue": 0,
+    "max_listen_queue": 5,
+    "max_children_reached": 0,
+    "slow_requests": 0,
+    "accepted_connections": 100,
+}
+
+
+# --- HTTP transport (Phase A) ----------------------------------------------
+
+
+def test_http_single_pool(monkeypatch):
+    monkeypatch.setattr(
+        php_fpm.requests, "get", lambda url, timeout: _http_response(json.dumps(_RAW_WWW))
+    )
+    assert php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status?json") == [_NORM_WWW]
+
+
+def test_http_non_200_returns_null(monkeypatch):
+    monkeypatch.setattr(
+        php_fpm.requests, "get", lambda url, timeout: _http_response("x", status=500)
+    )
+    assert php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status?json") is None
+
+
+def test_http_exception_returns_null(monkeypatch):
+    def boom(url, timeout):
+        raise requests.exceptions.Timeout("timed out")
+
+    monkeypatch.setattr(php_fpm.requests, "get", boom)
+    assert php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status?json") is None
+
+
+def test_http_malformed_json_returns_null(monkeypatch):
+    monkeypatch.setattr(php_fpm.requests, "get", lambda url, timeout: _http_response("not json"))
+    assert php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status?json") is None
+
+
+def test_http_non_dict_json_returns_null(monkeypatch):
+    monkeypatch.setattr(php_fpm.requests, "get", lambda url, timeout: _http_response("[1, 2]"))
+    assert php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status?json") is None
+
+
+def test_default_url_used_when_unset(monkeypatch):
+    captured = {}
+
+    def cap(url, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _http_response(json.dumps(_RAW_WWW))
+
+    monkeypatch.setattr(php_fpm.requests, "get", cap)
+    php_fpm.php_fpm_metrics()
+    assert captured["url"] == "http://127.0.0.1/status?json"
+    assert captured["timeout"] == php_fpm._TIMEOUT
+
+
+def test_json_query_appended_through_metrics(monkeypatch):
+    captured = {}
+
+    def cap(url, timeout):
+        captured["url"] = url
+        return _http_response(json.dumps(_RAW_WWW))
+
+    monkeypatch.setattr(php_fpm.requests, "get", cap)
+    php_fpm.php_fpm_metrics(status_page_url="http://127.0.0.1/status")
+    assert captured["url"] == "http://127.0.0.1/status?json"
+
+
+# --- json query flag (parse-based, not substring) --------------------------
+
+
+def test_ensure_json_query_variants():
+    assert php_fpm._ensure_json_query("http://h/status") == "http://h/status?json"
+    assert php_fpm._ensure_json_query("http://h/status?refresh=5") == "http://h/status?refresh=5&json"
+    assert php_fpm._ensure_json_query("http://h/status?json") == "http://h/status?json"
+    assert php_fpm._ensure_json_query("http://h/status?json=1") == "http://h/status?json=1"
+    # A path that merely contains "json" must still get the flag appended.
+    assert php_fpm._ensure_json_query("http://h/jsonstatus") == "http://h/jsonstatus?json"
+
+
+# --- scheme dispatch -------------------------------------------------------
+
+
+def test_unknown_scheme_returns_null():
+    assert php_fpm.php_fpm_metrics(status_page_url="ftp://h/status") is None
+
+
+def test_no_scheme_returns_null():
+    assert php_fpm.php_fpm_metrics(status_page_url="127.0.0.1/status") is None
+
+
+def test_resolution_exception_returns_null(monkeypatch):
+    def boom(url):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(php_fpm, "_resolve_endpoints", boom)
+    assert php_fpm.php_fpm_metrics(status_page_url="http://h/status?json") is None
+
+
+# --- unix:// URL parsing ---------------------------------------------------
+
+
+def test_unix_url_sock_split():
+    assert php_fpm._endpoint_from_url("unix:///run/php/php8.2-fpm.sock/status") == {
+        "kind": "unix",
+        "address": "/run/php/php8.2-fpm.sock",
+        "script_name": "/status",
+    }
+
+
+def test_unix_url_sock_no_trailing_script():
+    assert php_fpm._endpoint_from_url("unix:///run/php.sock") == {
+        "kind": "unix",
+        "address": "/run/php.sock",
+        "script_name": "/status",
+    }
+
+
+def test_unix_url_fallback_without_sock_marker():
+    assert php_fpm._endpoint_from_url("unix:///run/php/fpm/status") == {
+        "kind": "unix",
+        "address": "/run/php/fpm",
+        "script_name": "/status",
+    }
+
+
+def test_unix_url_two_slash_authority_folded():
+    # Malformed two-slash form: the socket path's first segment lands in the URL
+    # authority; it must be folded back into the (absolute) path, not dropped.
+    assert php_fpm._endpoint_from_url("unix://run/php/fpm.sock/status") == {
+        "kind": "unix",
+        "address": "/run/php/fpm.sock",
+        "script_name": "/status",
+    }
+
+
+def test_unix_url_unparseable_returns_none():
+    assert php_fpm._endpoint_from_url("unix://") is None
+    assert php_fpm._endpoint_from_url("unix:///") is None
+
+
+# --- tcp:// URL parsing ----------------------------------------------------
+
+
+def test_tcp_url():
+    assert php_fpm._endpoint_from_url("tcp://127.0.0.1:9000/status") == {
+        "kind": "tcp",
+        "host": "127.0.0.1",
+        "port": 9000,
+        "script_name": "/status",
+    }
+
+
+def test_tcp_url_default_script():
+    assert php_fpm._endpoint_from_url("tcp://127.0.0.1:9000") == {
+        "kind": "tcp",
+        "host": "127.0.0.1",
+        "port": 9000,
+        "script_name": "/status",
+    }
+
+
+def test_tcp_url_ipv6():
+    assert php_fpm._endpoint_from_url("tcp://[::1]:9000/status") == {
+        "kind": "tcp",
+        "host": "::1",
+        "port": 9000,
+        "script_name": "/status",
+    }
+
+
+def test_tcp_url_bad_port_returns_none():
+    assert php_fpm._endpoint_from_url("tcp://127.0.0.1:notaport/status") is None
+
+
+def test_tcp_url_missing_port_returns_none():
+    assert php_fpm._endpoint_from_url("tcp://127.0.0.1/status") is None
+
+
+# --- listen address parsing ------------------------------------------------
+
+
+def test_split_host_port_variants():
+    assert php_fpm._split_host_port("127.0.0.1:9000") == ("127.0.0.1", 9000)
+    assert php_fpm._split_host_port(":9000") == ("127.0.0.1", 9000)
+    assert php_fpm._split_host_port("9000") == ("127.0.0.1", 9000)
+    assert php_fpm._split_host_port("[::1]:9000") == ("::1", 9000)
+    assert php_fpm._split_host_port("localhost:9000") == ("localhost", 9000)
+
+
+def test_split_host_port_invalid():
+    assert php_fpm._split_host_port("notaport") is None
+    assert php_fpm._split_host_port("host:notaport") is None
+    assert php_fpm._split_host_port("[::1]") is None
+    assert php_fpm._split_host_port("[::1]nocolon") is None
+    assert php_fpm._split_host_port(":0") is None
+    assert php_fpm._split_host_port("host:70000") is None
+
+
+def test_safe_port_type_error():
+    assert php_fpm._safe_port(None) is None
+
+
+def test_endpoint_from_listen():
+    assert php_fpm._endpoint_from_listen("/run/php.sock", "/status") == {
+        "kind": "unix",
+        "address": "/run/php.sock",
+        "script_name": "/status",
+    }
+    # status_path without a leading slash is normalised.
+    assert php_fpm._endpoint_from_listen("127.0.0.1:9000", "status") == {
+        "kind": "tcp",
+        "host": "127.0.0.1",
+        "port": 9000,
+        "script_name": "/status",
+    }
+
+
+def test_endpoint_from_listen_missing_parts():
+    assert php_fpm._endpoint_from_listen(None, "/status") is None
+    assert php_fpm._endpoint_from_listen("/run/php.sock", None) is None
+
+
+def test_endpoint_from_listen_bad_tcp():
+    assert php_fpm._endpoint_from_listen("host:bad", "/status") is None
+
+
+# --- pool.d config parsing -------------------------------------------------
+
+
+def test_parse_pool_file():
+    text = (
+        "; a comment\n"
+        "orphan = 1\n"  # before any [section]: no current pool
+        "\n"
+        "[global]\n"
+        "pid = /run/php-fpm.pid\n"
+        "[www]\n"
+        "listen = /run/php/www.sock  ; inline comment\n"
+        'pm.status_path = "/status"\n'
+        "no_equals_line\n"
+        "[api]\n"
+        "listen = '127.0.0.1:9000'\n"
+        "pm.status_path = /api\n"
+    )
+    assert php_fpm._parse_pool_file(text) == [
+        {"name": "global", "listen": None, "status_path": None},
+        {"name": "www", "listen": "/run/php/www.sock", "status_path": "/status"},
+        {"name": "api", "listen": "127.0.0.1:9000", "status_path": "/api"},
+    ]
+
+
+def test_clean_value():
+    assert php_fpm._clean_value(" /run/x.sock ; a comment ") == "/run/x.sock"
+    assert php_fpm._clean_value(' "/status" ') == "/status"
+    assert php_fpm._clean_value(" '/status' ") == "/status"
+    assert php_fpm._clean_value('"') == '"'  # single char: nothing to strip
+    assert php_fpm._clean_value('"mismatch') == '"mismatch'  # unmatched quote
+
+
+# --- discovery -------------------------------------------------------------
+
+
+def _write(tmp_path, name, content):
+    (tmp_path / name).write_text(content)
+
+
+def test_discover_multi_file(tmp_path, monkeypatch):
+    _write(tmp_path, "a.conf", "[www]\nlisten = /run/www.sock\npm.status_path = /status\n")
+    _write(tmp_path, "b.conf", "[api]\nlisten = 127.0.0.1:9000\npm.status_path = /status\n")
+    monkeypatch.setattr(php_fpm, "_POOL_CONFIG_GLOBS", [str(tmp_path / "*.conf")])
+    eps = php_fpm._discover_pools()
+    assert eps is not None
+    assert len(eps) == 2
+    assert {e["kind"] for e in eps} == {"unix", "tcp"}
+
+
+def test_endpoint_key_and_label_all_kinds():
+    http = {"kind": "http", "url": "http://h/status?json"}
+    unix = {"kind": "unix", "address": "/run/x.sock", "script_name": "/status"}
+    tcp = {"kind": "tcp", "host": "127.0.0.1", "port": 9000, "script_name": "/status"}
+    assert php_fpm._endpoint_key(http) == ("http", "http://h/status?json")
+    assert php_fpm._endpoint_key(unix) == ("unix", "/run/x.sock", "/status")
+    assert php_fpm._endpoint_key(tcp) == ("tcp", "127.0.0.1", 9000, "/status")
+    assert php_fpm._endpoint_label(http) == "http://h/status?json"
+    assert php_fpm._endpoint_label(unix) == "unix:/run/x.sock/status"
+    assert php_fpm._endpoint_label(tcp) == "tcp:127.0.0.1:9000/status"
+
+
+def test_discover_dedups_identical_endpoints(tmp_path, monkeypatch):
+    _write(tmp_path, "a.conf", "[www]\nlisten = /run/www.sock\npm.status_path = /status\n")
+    _write(tmp_path, "b.conf", "[dup]\nlisten = /run/www.sock\npm.status_path = /status\n")
+    monkeypatch.setattr(php_fpm, "_POOL_CONFIG_GLOBS", [str(tmp_path / "*.conf")])
+    eps = php_fpm._discover_pools()
+    assert eps is not None
+    assert len(eps) == 1
+
+
+def test_discover_skips_incomplete_pools(tmp_path, monkeypatch):
+    _write(
+        tmp_path,
+        "a.conf",
+        "[nolisten]\npm.status_path = /status\n[nostatus]\nlisten = /run/x.sock\n",
+    )
+    monkeypatch.setattr(php_fpm, "_POOL_CONFIG_GLOBS", [str(tmp_path / "*.conf")])
+    assert php_fpm._discover_pools() == []
+
+
+def test_discover_zero_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(php_fpm, "_POOL_CONFIG_GLOBS", [str(tmp_path / "*.conf")])
+    assert php_fpm._discover_pools() == []
+
+
+def test_discover_unreadable_file_returns_none(monkeypatch):
+    # An unreadable matched config sinks discovery to None (collection failure),
+    # NOT [] -- otherwise a pool that merely can't be read would false-resolve
+    # as "operator removed it" and the server would prune its rows.
+    monkeypatch.setattr(php_fpm, "_pool_config_files", lambda: ["/no/such/path.conf"])
+    assert php_fpm._discover_pools() is None
+
+
+def test_discover_partial_unreadable_returns_none(tmp_path, monkeypatch):
+    # One readable pollable pool + one unreadable file -> None, never a short
+    # [www] array that would drop (and prune) whatever the unreadable file held.
+    good = tmp_path / "www.conf"
+    good.write_text("[www]\nlisten = /run/www.sock\npm.status_path = /status\n")
+    monkeypatch.setattr(
+        php_fpm, "_pool_config_files", lambda: [str(good), "/no/such/path.conf"]
+    )
+    assert php_fpm._discover_pools() is None
+
+
+# --- top-level auto-discovery outcomes -------------------------------------
+
+
+def test_auto_zero_pools_returns_empty_list(monkeypatch):
+    monkeypatch.setattr(php_fpm, "_discover_pools", lambda: [])
+    assert php_fpm.php_fpm_metrics(status_page_url="auto") == []
+
+
+def test_auto_all_success_returns_array(monkeypatch):
+    eps = [
+        {"kind": "unix", "address": "/a.sock", "script_name": "/status"},
+        {"kind": "tcp", "host": "h", "port": 9000, "script_name": "/status"},
+    ]
+    monkeypatch.setattr(php_fpm, "_discover_pools", lambda: eps)
+    monkeypatch.setattr(
+        php_fpm,
+        "_fetch_status_body",
+        lambda ep: json.dumps({"pool": ep.get("address") or ep.get("host")}),
+    )
+    out = php_fpm.php_fpm_metrics(status_page_url="AUTO")  # case-insensitive sentinel
+    assert [p["name"] for p in out] == ["/a.sock", "h"]
+
+
+def test_auto_partial_failure_returns_null(monkeypatch):
+    eps = [
+        {"kind": "unix", "address": "/a.sock", "script_name": "/status"},
+        {"kind": "tcp", "host": "h", "port": 9000, "script_name": "/status"},
+    ]
+    monkeypatch.setattr(php_fpm, "_discover_pools", lambda: eps)
+
+    def fetch(ep):
+        return json.dumps({"pool": "a"}) if ep["kind"] == "unix" else None
+
+    monkeypatch.setattr(php_fpm, "_fetch_status_body", fetch)
+    assert php_fpm.php_fpm_metrics(status_page_url="auto") is None
+
+
+# --- normalisation ---------------------------------------------------------
+
+
+def test_normalize_drops_extra_and_fills_missing():
+    raw = {"pool": "w", "process manager": "dynamic", "active processes": 2, "junk": "x"}
+    out = php_fpm._normalize_pool(raw)
+    assert out["name"] == "w"
+    assert out["active_processes"] == 2
+    assert "junk" not in out
+    assert out["accepted_connections"] is None  # absent FPM key -> None
+    assert list(out.keys()) == list(php_fpm._FIELD_MAP.values())
+
+
+# --- FastCGI wire protocol -------------------------------------------------
+
+
+def test_fcgi_roundtrip_and_request_framing(monkeypatch):
+    body = json.dumps(_RAW_WWW)
+    sock = FakeSocket(_fcgi_stream(body))
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    out = php_fpm._fcgi_status_body({"kind": "unix", "address": "/x.sock", "script_name": "/status"})
+    assert out == body
+    assert sock.closed
+    # First record is a BEGIN_REQUEST (version=1, type=1).
+    assert sock.sent[0] == 1 and sock.sent[1] == 1
+    # The status request carries QUERY_STRING=json.
+    assert b"QUERY_STRING" in sock.sent
+    assert b"json" in sock.sent
+
+
+def test_fcgi_default_script_name(monkeypatch):
+    sock = FakeSocket(_fcgi_stream(json.dumps(_RAW_WWW)))
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    php_fpm._fcgi_status_body({"kind": "unix", "address": "/x.sock"})  # no script_name
+    assert b"/status" in sock.sent
+
+
+def test_fcgi_multi_record_stdout(monkeypatch):
+    body = json.dumps(_RAW_WWW)
+    sock = FakeSocket(_fcgi_stream(body, split=7))
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) == body
+
+
+def test_fcgi_ignores_stderr_and_reads_padding(monkeypatch):
+    body = json.dumps(_RAW_WWW)
+    payload = ("Content-type: application/json\r\n\r\n" + body).encode()
+    stream = _fcgi_record(7, b"a warning") + _fcgi_record(6, payload, pad=5) + _END_REQUEST
+    sock = FakeSocket(stream)
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) == body
+
+
+def test_fcgi_empty_stdout_record(monkeypatch):
+    body = json.dumps(_RAW_WWW)
+    payload = ("H: 1\r\n\r\n" + body).encode()
+    stream = _fcgi_record(6, payload) + _fcgi_record(6, b"") + _END_REQUEST
+    sock = FakeSocket(stream)
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) == body
+
+
+def test_fcgi_truncated_header_returns_empty(monkeypatch):
+    sock = FakeSocket(b"\x01\x06")  # 2 bytes, short of an 8-byte header
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) == ""
+
+
+def test_fcgi_max_body_cap(monkeypatch):
+    monkeypatch.setattr(php_fpm, "_FCGI_MAX_BODY", 4)
+    payload = ("H: 1\r\n\r\n" + "0123456789").encode()
+    sock = FakeSocket(_fcgi_record(6, payload))  # no END_REQUEST: cap must break the loop
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    out = php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"})
+    assert out == "0123456789"
+
+
+def test_fcgi_connect_error_returns_none(monkeypatch):
+    def boom(ep):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", boom)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) is None
+
+
+def test_fcgi_close_error_is_swallowed(monkeypatch):
+    class BadClose(FakeSocket):
+        def close(self):
+            raise OSError("close failed")
+
+    sock = BadClose(_fcgi_stream(json.dumps(_RAW_WWW)))
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) is not None
+
+
+def test_fcgi_body_separators():
+    assert php_fpm._fcgi_body(b"H: 1\r\n\r\nBODY") == "BODY"
+    assert php_fpm._fcgi_body(b"H: 1\n\nBODY") == "BODY"
+    assert php_fpm._fcgi_body(b"rawbody") == "rawbody"
+
+
+def test_fcgi_pair_length_encoding():
+    out = php_fpm._fcgi_pair("N" * 200, "V" * 5)
+    assert out[0] & 0x80  # 200 >= 128 -> 4-byte length, high bit set
+    assert struct.unpack("!I", out[0:4])[0] & 0x7FFFFFFF == 200
+    assert out[4] == 5  # 5 < 128 -> single byte
+
+
+def test_recv_exact_eof():
+    assert php_fpm._recv_exact(FakeSocket(b"abc"), 5) == b"abc"
+
+
+def test_fcgi_connect_unix(monkeypatch):
+    made = {}
+
+    def fake_socket(family, kind):
+        made["family"] = family
+        made["kind"] = kind
+        return FakeSocket()
+
+    monkeypatch.setattr(php_fpm.socket, "socket", fake_socket)
+    sock = php_fpm._fcgi_connect({"kind": "unix", "address": "/run/x.sock", "script_name": "/s"})
+    assert made["family"] == php_fpm.socket.AF_UNIX
+    assert made["kind"] == php_fpm.socket.SOCK_STREAM
+    assert sock.connect_addr == "/run/x.sock"
+    assert sock.timeout == php_fpm._TIMEOUT
+
+
+def test_fcgi_connect_unix_without_af_unix(monkeypatch):
+    monkeypatch.delattr(php_fpm.socket, "AF_UNIX", raising=False)
+    assert php_fpm._fcgi_status_body({"kind": "unix", "address": "/x", "script_name": "/s"}) is None
+
+
+def test_fcgi_connect_tcp(monkeypatch):
+    captured = {}
+    fake = FakeSocket()
+
+    def fake_create(addr, timeout):
+        captured["addr"] = addr
+        captured["timeout"] = timeout
+        return fake
+
+    monkeypatch.setattr(php_fpm.socket, "create_connection", fake_create)
+    sock = php_fpm._fcgi_connect({"kind": "tcp", "host": "127.0.0.1", "port": 9000, "script_name": "/s"})
+    assert captured["addr"] == ("127.0.0.1", 9000)
+    assert captured["timeout"] == php_fpm._TIMEOUT
+    assert sock.timeout == php_fpm._TIMEOUT
+
+
+def test_fcgi_transport_end_to_end_via_metrics(monkeypatch):
+    """A unix:// URL flows through the real FastCGI encode/decode to a payload."""
+    sock = FakeSocket(_fcgi_stream(json.dumps(_RAW_WWW)))
+    monkeypatch.setattr(php_fpm, "_fcgi_connect", lambda ep: sock)
+    out = php_fpm.php_fpm_metrics(status_page_url="unix:///run/php/php8.2-fpm.sock/status")
+    assert out == [_NORM_WWW]
+
+
+# --- cross-repo contract (fivenines-server) --------------------------------
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "php_fpm_contract_payload.json"
+)
+
+
+def _load_fixture():
+    with open(_FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+def _run_scenario(scenario, tmp_path, monkeypatch):
+    raw = scenario.get("raw_status", {})
+
+    def fake_fetch(endpoint):
+        body = raw.get(php_fpm._endpoint_label(endpoint))
+        return None if body is None else json.dumps(body)
+
+    monkeypatch.setattr(php_fpm, "_fetch_status_body", fake_fetch)
+    if "pool_configs" in scenario:
+        for fname, content in scenario["pool_configs"].items():
+            (tmp_path / fname).write_text(content)
+        monkeypatch.setattr(php_fpm, "_POOL_CONFIG_GLOBS", [str(tmp_path / "*.conf")])
+    return php_fpm.php_fpm_metrics(**scenario["config"])
+
+
+@pytest.mark.parametrize(
+    "name", ["healthy_multi_pool", "zero_pools", "collection_failure", "partial_failure"]
+)
+def test_contract_fixture_round_trip(name, tmp_path, monkeypatch):
+    """SHARED FIXTURE (cross-repo contract): fixtures/php_fpm_contract_payload.json.
+
+    Asserted on both sides:
+    - here: php_fpm_metrics(**scenario["config"]) must equal scenario["payload"]
+      with only the transport mocked (raw_status fed per endpoint, pool.d configs
+      written to a temp dir for auto-discovery);
+    - fivenines-server: spec/requests/api_collect_php_fpm_spec.rb posts
+      scenario["payload"] under data["php_fpm"] and asserts Ingesters::Agent
+      handles the array / [] / null shapes.
+
+    Change the payload shape only in lockstep with the server spec and its
+    byte-identical fixture copy.
+    """
+    fixture = _load_fixture()
+    scenario = fixture["scenarios"][name]
+    assert _run_scenario(scenario, tmp_path, monkeypatch) == scenario["payload"]
+
+
+def test_fixture_agent_min_version():
+    assert _load_fixture()["agent_min_version"] == "1.13.1"
+
+
+def test_fixture_payload_keys_match_field_map():
+    payload = _load_fixture()["scenarios"]["healthy_multi_pool"]["payload"]
+    for pool in payload:
+        assert list(pool.keys()) == list(php_fpm._FIELD_MAP.values())
+
+
+def test_fixture_config_is_documented_shape():
+    fixture = _load_fixture()
+    for scenario in fixture["scenarios"].values():
+        assert set(scenario["config"]) == {"status_page_url"}


### PR DESCRIPTION
Agent half of Five-Nines-io/fivenines_server#490 (PHP-FPM monitoring: per-pool status + `php_fpm_saturation` trigger). Closes #97.

Polls the PHP-FPM status page per pool and ships an **array of per-pool status objects** under `data["php_fpm"]`. Pool saturation (`max_children_reached` climbing, a growing listen queue) is the #1 "my WordPress site is down" root cause; the server turns this payload into per-pool rows, VictoriaMetrics series, and the per-pool saturation trigger.

## Both phases, one release

Per the completeness bar, this ships Phase A **and** Phase B together rather than deferring the FastCGI work.

- **Phase A — HTTP(S):** `requests.get(status_page_url)` scrape, the nginx/apache posture. One URL = one pool.
- **Phase B — direct FastCGI + auto-discovery:** a tiny pure-Python FastCGI client (~120 lines, **no new dependency**) speaks to `unix:///run/php/php8.2-fpm.sock/status` and `tcp://127.0.0.1:9000/status`. The sentinel `status_page_url: "auto"` discovers every pool from the pool.d configs (`/etc/php/*/fpm/pool.d/*.conf` etc.) and polls each over its own socket — the true multi-pool payoff, no web-server exposure of `/status` required.

## Payload contract (`data["php_fpm"]`)

Three shapes, mirroring the zfs null-vs-empty discipline (server dispatch gate `is_a?(Array)`):

- **array** — the trustworthy tick, every known pool responded.
- **`[]`** — auto-discovery succeeded with genuinely zero pollable pools (server prunes all rows).
- **`null`** — collection failure: endpoint unreachable / timeout / non-200 / malformed JSON, **OR any single known pool's fetch or config-read failing**. This is the false-resolve guard: a pool silently missing from the array reads as "operator deleted it" and resolves its open incident, so any partial failure sinks the whole tick to `null` (unknown != recovered) — never a partial array. A pool the operator genuinely removed simply stops being discovered and drops out of a fully-successful array; the server prunes it, which is correct.

Space-separated FPM keys are normalized to snake_case per the locked field map; `max_children_reached` / `slow_requests` / `accepted_connections` are shipped **raw** (the server `rate()`s them). `json` is appended to the query string defensively (parse-based, not substring — the apache `?auto` lesson).

Registered in `collectors.py` with the nginx/apache posture: purely config-driven, **no capability gate, no server version gate** (`php_fpm_enabled` defaults false, so old servers are unaffected).

## Server-side lockstep (server-first deploy)

Pending on fivenines_server #490, and safe either way since the config key defaults off:
- Ingester for the array / `[]` / `null` shapes + `spec/requests/api_collect_php_fpm_spec.rb`.
- Byte-identical copy of `tests/fixtures/php_fpm_contract_payload.json` into `spec/fixtures/`.
- **URL-validation relax:** the server currently validates `php_fpm_status_page_url` as http(s)-only. Phase B needs it to also store `unix://` / `tcp://` values and the literal `"auto"` sentinel. Phase B is inert until that lands.

## Version

Ships as **1.13.1**, a PATCH that cedes the 1.13.0 minor slot to Ceph v2 (#94), which is hard-gated on `ceph_extended == "1.13.0"`. PHP-FPM has no server version gate, so its number is free.

## Tests & review

- `tests/test_php_fpm.py` — 63 tests, **100% coverage** of `php_fpm.py` (HTTP, FastCGI wire protocol, URL/listen parsing, pool.d discovery, normalization, the array/`[]`/`null` contract, and the cross-repo fixture round-trip). `flake8 --ignore=W503,E501` clean, ASCII-only.
- An adversarial review of the hand-rolled FastCGI client confirmed the framing and null/array/`[]` logic are correct, and surfaced two edge cases on the contract's sharpest edge, both now fixed and tested: an unreadable pool.d config now sinks the tick to `null` instead of `[]` (was a false-prune risk), and a malformed two-slash `unix://` URL now folds its authority back into the socket path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
