### PR TITLE
fix(ci): make PHP-FPM unix-socket test AF_UNIX-agnostic for Windows (#97)

### DIFF
--- a/tests/test_php_fpm.py
+++ b/tests/test_php_fpm.py
@@ -595,6 +595,11 @@ def test_fcgi_connect_unix(monkeypatch):
         made["kind"] = kind
         return FakeSocket()
 
+    # Windows lacks socket.AF_UNIX, so inject it to exercise the unix-connect
+    # path on every platform (the real "no AF_UNIX" behaviour is pinned by
+    # test_fcgi_connect_unix_without_af_unix). raising=False permits the set
+    # where the attribute is absent.
+    monkeypatch.setattr(php_fpm.socket, "AF_UNIX", 1, raising=False)
     monkeypatch.setattr(php_fpm.socket, "socket", fake_socket)
     sock = php_fpm._fcgi_connect({"kind": "unix", "address": "/run/x.sock", "script_name": "/s"})
     assert made["family"] == php_fpm.socket.AF_UNIX


### PR DESCRIPTION
Follow-up to #99. main went red on **Windows Build** after the PHP-FPM merge:

```
FAILED tests/test_php_fpm.py::test_fcgi_connect_unix - OSError: AF_UNIX unavailable on this platform
=========== 1 failed, 1601 passed, 18 skipped ===========
```

`test_fcgi_connect_unix` built a real `AF_UNIX` socket, which `windows-latest` lacks, so `_fcgi_connect` hit its guard and raised before reaching the mock. **The production code is correct** -- PHP-FPM is a Linux-only POSIX SAPI, so raising `OSError` on Windows is the intended safe behaviour (pinned by `test_fcgi_connect_unix_without_af_unix`). Only the happy-path test was platform-fragile.

Fix: inject `socket.AF_UNIX` via `monkeypatch` (`raising=False`) so the unix-connect path runs on every platform. Restores Windows CI to green and lifts `php_fpm.py` to 100% coverage on Windows too.

Test-only, **no functional change and no version bump** -- 1.13.1 stands (same posture as #98). Verified locally with `AF_UNIX` deleted to simulate Windows; `fix/**` triggers the Windows job so it is verified on real CI here before merge.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)