### PR TITLE
fix(ci): decouple docker image-inventory version assert from later version bumps

### DIFF
--- a/tests/test_docker_image_inventory.py
+++ b/tests/test_docker_image_inventory.py
@@ -165,14 +165,18 @@ def test_contract_hash_matches_packages(name):
 
 
 def test_contract_agent_min_version_matches_pyproject():
-    """agent_min_version must equal the SHIPPED version, not a hand-typed twin.
+    """agent_min_version must be a REAL shipped version -- at or below the
+    current pyproject version, not a hand-typed twin.
 
     The server gates FEATURES_SUPPORTED_VERSIONS["docker_image_inventory"] on
-    this exact string. Asserting it against a literal cannot catch the failure it
-    looks like it prevents -- if the release slot moves (this repo has repeated
-    contention: Ceph took 1.13.0, PHP-FPM ceded to 1.13.1, ZFS rebased to
-    1.11.7), a literal-vs-literal assert stays green while the server gates on a
-    version no agent reports. Read the real version instead."""
+    this exact string, so it must be a version some released agent actually
+    reports. A hand-typed literal can drift ABOVE any shipped version (the
+    server would then gate on a version no agent reports); reading the real
+    version catches that. The relation is <=, not ==: this contract's floor is
+    frozen at the version the feature shipped in (1.14.0), but once it merges a
+    LATER, unrelated feature bumps pyproject above it (TSDB #103 took 1.14.1),
+    and an agent at 1.14.1 still supports docker_image_inventory. Only a floor
+    GREATER than the shipped version is the bug."""
     pyproject = os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
     with open(pyproject) as f:
         for line in f:
@@ -181,7 +185,11 @@ def test_contract_agent_min_version_matches_pyproject():
                 break
         else:  # pragma: no cover - pyproject always has a version
             raise AssertionError("no version in pyproject.toml")
-    assert _CONTRACT["agent_min_version"] == shipped
+
+    def _parts(v):
+        return tuple(int(p) for p in v.split("."))
+
+    assert _parts(_CONTRACT["agent_min_version"]) <= _parts(shipped)
 
 
 def test_packages_are_sorted_by_name_regardless_of_db_order():


### PR DESCRIPTION
## What broke

`main` is currently red on the Windows pytest job:

```
tests/test_docker_image_inventory.py::test_contract_agent_min_version_matches_pyproject
AssertionError: assert '1.14.0' == '1.14.1'
```

`test_contract_agent_min_version_matches_pyproject` (added with the Docker image-inventory feature, #111) reads the **live** `pyproject.toml` version and asserts the docker contract fixture's `agent_min_version` **equals** it. That invariant only holds while docker image inventory is the version tip. Once TSDB (#103 / #112) shipped **1.14.1** on top of docker's **1.14.0**, the assert flipped red -- and because #112 is already merged, it's red on `main` proper, not just a PR branch.

Every other contract test in the repo (`test_apache`, `test_network`, `test_mqtt`, `test_php_fpm`, `test_tsdb`) asserts `agent_min_version` against a frozen literal; docker was the lone outlier coupling to the live version, so it's the only one that broke.

## The fix

The docker fixture is **correct as-is** -- docker image inventory's floor is legitimately **1.14.0** (an agent `>= 1.14.0` supports it, and the server gates `FEATURES_SUPPORTED_VERSIONS["docker_image_inventory"]` on that exact string). Bumping the fixture to 1.14.1 would be wrong (it would falsely claim docker needs 1.14.1) and would just re-break on the next feature's bump.

So this fixes the **relation, not the fixture**: `agent_min_version` must be `<=` the shipped version, not `==`.

- Still catches the real bug the test guards: a floor typed **above** any shipped version (which the server would gate on but no released agent reports) -- that now fails the `<=`.
- Survives every later, unrelated version bump: `(1,14,0) <= (1,14,1)` holds.
- Uses an int-tuple compare so `1.14.10 <= 1.14.9` can't lex-sort wrong.

Fixture unchanged, so the server contract / `FEATURES_SUPPORTED_VERSIONS` value is untouched.

## Verification

`tests/test_docker_image_inventory.py`: **103 passed** locally (was 1 failed on `main`). ASCII-clean. Branch is `fix/**` so CI runs on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)