### PR TITLE
fix(tests): make the systemd host-detection tests host-independent

### DIFF
--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1141,7 +1141,12 @@ def test_collect_no_cgroup_skips_resource_read():
     """When hierarchy is None, skip cgroup reads and return units with null cgroup fields."""
     SystemdCollector._version = 252
     SystemdCollector._hierarchy = None
-    coll = SystemdCollector()
+    # __init__ re-detects a None hierarchy from the live machine, so pin the
+    # detection to None: without the patch this test only passes on hosts
+    # without cgroups (macOS) and fails on any Linux box, where
+    # /sys/fs/cgroup makes detect_hierarchy() return "v2".
+    with patch("fivenines_agent.systemd.detect_hierarchy", return_value=None):
+        coll = SystemdCollector()
     with patch.object(coll, "_list_units", return_value=(["nginx.service"], None)):
         with patch.object(
             coll,

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1374,7 +1374,12 @@ def test_reverse_deps_centos_7_returns_none():
 def test_reverse_deps_no_systemd_version():
     SystemdCollector._version = None
     SystemdCollector._hierarchy = None
-    coll = SystemdCollector()
+    # Same live-machine re-detection as above, but for both caches: on a Linux
+    # box `systemctl --version` reports >= 230, which would defeat the very
+    # version gate this test exercises and let _reverse_deps shell out for real.
+    with patch("fivenines_agent.systemd._systemd_version", return_value=None):
+        with patch("fivenines_agent.systemd.detect_hierarchy", return_value=None):
+            coll = SystemdCollector()
     assert coll._reverse_deps("nginx.service") is None
 
 

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1368,7 +1368,17 @@ def test_reverse_deps_centos_7_returns_none():
     SystemdCollector._version = 219
     SystemdCollector._hierarchy = "v1"
     coll = SystemdCollector()
-    assert coll._reverse_deps("nginx.service") is None
+    # Assert the GATE, not just the return value: _reverse_deps also returns
+    # None when the subprocess errors, so on a host without systemctl a
+    # regression that dropped the version check would still go green here.
+    # The return_value is a realistic failure tuple so that such a regression
+    # trips assert_not_called rather than an unpack error.
+    with patch(
+        "fivenines_agent.systemd._run_systemctl",
+        return_value=(None, {"type": "missing", "message": "x"}),
+    ) as mock_run:
+        assert coll._reverse_deps("nginx.service") is None
+    mock_run.assert_not_called()
 
 
 def test_reverse_deps_no_systemd_version():
@@ -1380,7 +1390,14 @@ def test_reverse_deps_no_systemd_version():
     with patch("fivenines_agent.systemd._systemd_version", return_value=None):
         with patch("fivenines_agent.systemd.detect_hierarchy", return_value=None):
             coll = SystemdCollector()
-    assert coll._reverse_deps("nginx.service") is None
+    # Same gate assertion as the centos-7 case above: prove no shellout, not
+    # just a None return (which subprocess failure would also produce).
+    with patch(
+        "fivenines_agent.systemd._run_systemctl",
+        return_value=(None, {"type": "missing", "message": "x"}),
+    ) as mock_run:
+        assert coll._reverse_deps("nginx.service") is None
+    mock_run.assert_not_called()
 
 
 def test_reverse_deps_subprocess_error():


### PR DESCRIPTION
## Summary

Two systemd tests passed only because the dev host was macOS, and both
reverse-deps gate tests were additionally asserting the wrong thing. Runtime
code is untouched -- `fivenines_agent/` has zero changes. Tests only.

**1. Host-dependent setup (the original bug)**

`SystemdCollector.__init__` treats a `None` class-level cache as "not detected
yet" and re-detects from the live machine, silently overwriting what a test
pinned. Two tests were affected:

- `test_collect_no_cgroup_skips_resource_read` (c10de02) -- sets
  `_hierarchy = None`, but on Linux `/sys/fs/cgroup/cgroup.controllers` makes
  `detect_hierarchy()` return `"v2"`, so `collect()` called
  `read_unit_resources` and `assert_not_called()` blew up.

- `test_reverse_deps_no_systemd_version` (d95626a, found by this run's
  pre-landing review) -- sets `_version = None`, but on Linux
  `systemctl --version` reports >= 230, so the gate at
  `fivenines_agent/systemd.py:1054` never tripped and `_reverse_deps` shelled
  out to the real `systemctl`. Passed on macOS only because `systemctl` is
  absent and `_run_subprocess` bails with `{"type": "missing"}`.

**2. Vacuous gate assertions (found by the Codex adversarial pass)**

Both reverse-deps gate tests asserted only that `_reverse_deps` returns `None`.
That is ambiguous: `_reverse_deps` also returns `None` when the subprocess
errors (`systemd.py:1073`), so on any host without `systemctl` the assertion
held **even if the version gate itself were deleted**. Confirmed by mutation --
with the `version is None or version < MIN_SYSTEMD_VERSION_REVERSE_DEPS` guard
removed from the source, both tests still passed.

89b7477 patches `_run_systemctl` and asserts `assert_not_called()`, so the tests
now prove the gate short-circuits *before* any shellout. The mock returns a
realistic failure tuple so a regression trips `assert_not_called` with a legible
message instead of an unpack error. The same mutation now fails both tests.

## Test Coverage

Test-only diff, so there are no new application code paths to audit. Test count
is unchanged (2040 passed, 2 skipped) -- this repairs four existing assertions
rather than adding cases.

Verified two-sided. Linux was simulated with a pytest plugin that seeds the
`fivenines_agent.cgroup` hierarchy cache and stubs `_systemd_version`, leaving
everything inside `SystemdCollector` real:

| Check | Before | After |
|---|---|---|
| `test_collect_no_cgroup_skips_resource_read`, simulated cgroup v2 | FAIL -- `read_unit_resources` called with `'v2'` | PASS |
| `test_reverse_deps_no_systemd_version`, simulated systemd 252 | FAIL -- returned the real dependency list | PASS |
| Mutation: delete the version gate from `systemd.py` | both gate tests still PASSED (vacuous) | both FAIL with `Expected '_run_systemctl' to not have been called` |

Full-suite sweeps, all green (2040 passed, 2 skipped each):

- real macOS host
- simulated Linux, cgroup v2
- simulated Linux, cgroup v1
- simulated Linux + systemd 252 + working `systemctl`

The Linux sweep was also used to confirm these were the only tests in the suite
carrying this host-dependence.

## Pre-Landing Review

1 issue found, 1 auto-fixed.

- `[INFORMATIONAL] (confidence: 10/10) tests/test_systemd.py:1374` --
  `test_reverse_deps_no_systemd_version` carried the identical latent defect as
  the first commit. Auto-fixed in d95626a; verified failing-before /
  passing-after under simulation.

Checked and clean: class-state leakage (the autouse `_reset_systemd` fixture
resets between tests), the other `_hierarchy = None` sites (line ~2048 already
patches `detect_hierarchy`; `_make_collector()` pins both caches truthy so
`__init__` never re-detects), and ASCII compliance (0 non-ASCII lines, the one
hard CI gate).

Specialists skipped: diff was 7 lines at review time, under the 50-line threshold.

## Adversarial Review

Claude + Codex, both run. Codex structured review skipped (diff is 35 lines,
threshold is 200).

- **Codex, Medium, `tests/test_systemd.py:1374` and `:1366`** -- the reverse-deps
  gate tests can still pass after a regression that shells out to `systemctl`,
  masking the exact production bug they exist to prevent. **Confirmed by
  mutation testing and fixed in 89b7477.** Codex's verdict was "request changes";
  the requested change was made.
- **Codex, Low** -- no other `SystemdCollector()` construction in the file is
  still host-dependent, and the `test_collect_no_cgroup_skips_resource_read`
  change is not tautological. Matches this run's independent finding.

## Design Review

No frontend files changed -- design review skipped.

## Eval Results

No prompt-related files changed -- evals skipped.

## Greptile Review

No Greptile comments.

## Scope Drift

Scope Check: CLEAN.

Intent: make the systemd tests pass on Linux, not just on a cgroup-less macOS host.
Delivered: that, plus the assertion strengthening needed for the gate tests to
actually be host-independent in what they can catch. No runtime code touched.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Versioning

No version bump. `pyproject.toml` stays at 1.15.1, matching this repo's
convention that non-shipping changes ship unversioned -- see `perf(ci)` (#117),
`build(deps-dev)` (#119), and (#95) on main, none of which bumped. The CI version
gate only fires when a `v*` tag disagrees with `pyproject.toml`, so an
unversioned test fix does not trip it.

## Test plan

- [x] Full pytest suite on macOS: 2040 passed, 2 skipped
- [x] Full pytest suite, simulated Linux cgroup v2: 2040 passed, 2 skipped
- [x] Full pytest suite, simulated Linux cgroup v1: 2040 passed, 2 skipped
- [x] Target tests under a simulated Linux systemd-252 host: 18 passed
- [x] Two-sided proof: each fixed test verified failing before, passing after
- [x] Mutation test: deleting the production version gate now fails both gate tests
- [x] ASCII gate: clean

Note: this branch is named `fix-systemd-cgroup-test`, which does not match the
`fix/**` push filter in `build-release.yml` / `windows.yml`, so neither workflow
runs on it. All verification above is local.

Generated with [Claude Code](https://claude.com/claude-code)
