### PR TITLE
v1.16.1 feat: report Ubuntu Pro attachment + enabled services (server #746)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The agent works without sudo, but these features will be unavailable (this is al
 | Log monitoring (journald capture + signals) | journal read access (`systemd-journal` group) |
 | WireGuard peer health | root or `CAP_NET_ADMIN` (the bundled systemd unit grants `AmbientCapabilities=CAP_NET_ADMIN`) |
 | Tailscale node state | `tailscale` CLI on `PATH` + a reachable `tailscaled` (no extra privilege) |
+| Ubuntu Pro entitlement | `pro` CLI on `PATH` (ubuntu-advantage-tools), or a readable `/var/lib/ubuntu-advantage/status.json` (no extra privilege) |
 | Per-unit cgroup metrics | cgroup v1 or v2 mounted at `/sys/fs/cgroup` |
 | Ceph cluster status | `ceph` CLI + read-only cephx keyring (no sudo) |
 
@@ -424,6 +425,39 @@ macOS. Only the tailnet-wide rollups are sent, never per-peer rows: every node
 sees every peer, so per-peer series would cost hosts x peers across a fleet.
 A node whose key expiry is disabled in the admin console reports "no expiry"
 rather than a fabricated countdown.
+
+## Ubuntu Pro Entitlement
+
+Requires agent version **1.16.1+**. On Linux hosts the agent reports whether the
+machine is attached to an Ubuntu Pro subscription and **which Pro services are
+actually enabled** on it. There is nothing to configure and nothing to turn on:
+collection is unconditional and a host without the `pro` client simply reports
+"could not determine".
+
+This exists for the vulnerability scanner. When the only published patch for a
+CVE lives in an Ubuntu Pro archive (ESM, FIPS), the finding is filed under
+"fixable only with a subscription" instead of in the work queue. That is correct
+for a machine that is not attached, and needlessly pessimistic for one that is --
+an attached host can `apt install` the fix today. This signal is what lets the
+dashboard tell the two apart.
+
+The service list is the load-bearing half, not the attachment flag. A machine
+can be attached with every service disabled (`pro disable esm-infra` is one
+command), and each Ubuntu Pro archive pocket is opened by one specific service --
+`esm-infra` does not unlock a FIPS-only fix. Only services reported as **enabled**
+are sent.
+
+Read from `pro api u.pro.status.is_attached.v1` and
+`pro api u.pro.status.enabled_services.v1`, falling back to
+`/var/lib/ubuntu-advantage/status.json` for clients too old to implement those
+endpoints. **No extra privilege is needed** -- the agent reads the world-readable
+machine token, not the root-only one. The reading is cached for 15 minutes, since
+it changes about once in a machine's lifetime.
+
+A `pro` that is missing, times out or errors reports "could not determine" and
+the dashboard keeps whatever it last knew. It is never reported as "not
+attached": a hiccup is not evidence that a machine detached, and treating it as
+one would bounce that host's findings between the two buckets on every miss.
 
 ## Ceph Cluster Monitoring
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,9 @@
 
 ## P1: Reconcile the server's copy of ubuntu_pro_contract_payload.json
 
+**Tracked server-side as fivenines_server#855** -- the work happens in that repo,
+this entry is the agent-side record of why.
+
 The Ubuntu Pro fixture (#125 / server #746) was authored server-first as the
 specification, with no `raw` block and its own description saying "copy the
 agent's over this file BYTE-FOR-BYTE when the agent PR lands". The agent PR added

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,33 @@
 # TODOS
 
+## P1: Reconcile the server's copy of ubuntu_pro_contract_payload.json
+
+The Ubuntu Pro fixture (#125 / server #746) was authored server-first as the
+specification, with no `raw` block and its own description saying "copy the
+agent's over this file BYTE-FOR-BYTE when the agent PR lands". The agent PR added
+the `raw` inputs (real `pro api` envelopes + status-cache content), a
+`raw_contract` and a `field_contract`, and reconciled two values that the server
+copy got wrong:
+
+- `agent_min_version` 1.15.1 (marked PROVISIONAL there) -> `1.16.1`.
+- `attached_full.payload.services` `["esm-infra","esm-apps"]` ->
+  `["esm-apps","esm-infra"]`. `u.pro.status.enabled_services.v1` returns
+  `sorted(enabled_services, key=lambda x: x.name)` and the collector sorts again
+  for stability, so the server draft's order is not one a real host can produce.
+
+Fix: copy `tests/fixtures/ubuntu_pro_contract_payload.json` over
+`fivenines-server/spec/fixtures/ubuntu_pro_contract_payload.json`, then flip the
+five hard-coded `%w[esm-infra esm-apps]` assertions in
+`spec/requests/api_collect_ubuntu_pro_spec.rb` to `%w[esm-apps esm-infra]`.
+Nothing is broken until then -- the server reads only `scenarios.*.payload` and
+its assertions are literals, not fixture-derived -- but the two copies have
+drifted and the lockstep discipline says they must not.
+
+- **Effort:** XS (human) / XS (CC)
+- **Depends on:** agent PR for #125 merged
+- **Files:** `fivenines-server/spec/fixtures/ubuntu_pro_contract_payload.json`,
+  `fivenines-server/spec/requests/api_collect_ubuntu_pro_spec.rb` (NOT this repo)
+
 ## P1: Reconcile the server's copy of vpn_contract_payload.json
 
 The VPN contract fixture (#127 / server #508) was authored server-first with the

--- a/fivenines_agent/agent.py
+++ b/fivenines_agent/agent.py
@@ -57,6 +57,7 @@ from fivenines_agent.systemd import (
     refresh_runtime_caches,
     systemd_inventory_sync,
 )
+from fivenines_agent.ubuntu_pro import ubuntu_pro_status
 
 CONFIG_DIR = config_dir()
 load_dotenv(dotenv_path=env_file())
@@ -339,6 +340,12 @@ class Agent:
         # than ship a value that's more misleading than informative.
         if not is_windows():
             data["load_average"] = self._collect("load_average", load_average)
+            # Ubuntu Pro entitlement (server #746). Unconditional: no config
+            # key, no capability gate, no version gate -- the server preserves
+            # its stored columns on the null every non-Ubuntu host reports, so
+            # there is nothing to switch on. Internally cached, so this costs a
+            # dict lookup on all but one tick in fifteen minutes.
+            data["ubuntu_pro"] = self._collect("ubuntu_pro", ubuntu_pro_status)
         self._collect_file_handles(data)
 
         # Conditional metrics via registry, gated by capability where available

--- a/fivenines_agent/ubuntu_pro.py
+++ b/fivenines_agent/ubuntu_pro.py
@@ -1,0 +1,354 @@
+"""Ubuntu Pro attachment + enabled-services collector (server #746).
+
+The vulnerability scanner files a CVE whose only patch is published under an
+`Ubuntu:Pro:*` OSV ecosystem in a separate "fixable only with a subscription"
+bucket rather than in the work queue. That is exact for an UNATTACHED host and
+merely pessimistic for an ATTACHED one, which can `apt install` the ESM fix
+today. The server cannot tell the two apart on its own; this collector is that
+signal.
+
+Contract rules (contract fixture: tests/fixtures/ubuntu_pro_contract_payload.json):
+
+1. ATTACHMENT ALONE IS NOT ENOUGH. A machine can be attached with every service
+   disabled (`pro disable esm-infra` is one command), and each Ubuntu Pro OSV
+   ecosystem maps to the archive pocket ONE SPECIFIC SERVICE opens -- esm-infra
+   does not unlock a FIPS-only fix. The server matches the service list against
+   its pocket table, so it needs the list, not a boolean.
+
+2. ``None`` MEANS "COULD NOT DETERMINE", AND ONLY THAT. The server preserves the
+   stored columns on null and never writes ``false`` from one. A timed-out `pro`
+   is not evidence a machine detached, and reporting it as one would bounce that
+   host's ESM findings between the work queue and the subscription bucket on
+   every hiccup -- each flip a findings rewrite and a rescan. So every ambiguous
+   outcome here resolves to ``None``, NEVER to ``{"attached": False}``.
+
+3. THE SERVICE NAMES TRAVEL VERBATIM (lowercased). There is deliberately no
+   allowlist: the server ignores tokens it does not recognise, which is exactly
+   what keeps a service Canonical adds next year from needing an agent release.
+
+4. CACHED. This rides /collect, which runs every 15-60s, and the value changes
+   about once in a machine's lifetime. Shelling out per tick is not acceptable;
+   the reading is recomputed at most once per _CACHE_TTL and the server reads
+   the stored columns at scan time, so minutes of staleness cost nothing.
+
+Non-Ubuntu hosts have no `pro` and no status cache, so they report ``None`` --
+never ``{"attached": False}``, which would claim a Debian box was checked and
+found detached.
+"""
+
+import json
+import shutil
+import subprocess
+
+from fivenines_agent.cache import TTLCache
+from fivenines_agent.debug import debug, log
+from fivenines_agent.subprocess_utils import get_clean_env
+
+# Hard per-call subprocess timeout (seconds). `pro api` on these two endpoints
+# does no network I/O (both are documented "network access required: no"); the
+# ceiling only keeps a wedged client out of the watchdog-bounded collect tick.
+# Worst case is two calls, and only on an ATTACHED host -- a detached one
+# answers in a single call (see _read_from_pro_api).
+_SUBPROCESS_TIMEOUT = 10
+
+# How long one reading is reused. Deliberately long: attachment changes about
+# once in a machine's lifetime, and the server reads the stored columns at scan
+# time rather than off the tick. FAILURES ARE CACHED TOO -- a `pro` that hangs
+# for the full timeout must not be re-run on the next tick 15 seconds later.
+_CACHE_TTL = 900
+_CACHE_KEY = "ubuntu_pro"
+
+# The two `pro api` endpoints. Both return the standard envelope:
+# {"_schema_version": .., "data": {"attributes": {..}, ..}, "result": "success",
+#  "errors": [], "warnings": [], "version": ".."}
+_IS_ATTACHED_ENDPOINT = "u.pro.status.is_attached.v1"
+_ENABLED_SERVICES_ENDPOINT = "u.pro.status.enabled_services.v1"
+
+# Fallback source: the on-disk status cache `pro` itself maintains. Plain file,
+# world-readable, no subprocess and no network. See _read_from_status_cache.
+_STATUS_CACHE_FILE = "/var/lib/ubuntu-advantage/status.json"
+
+# Cap on how much of the status cache is read. A real one is tens of KiB.
+_MAX_STATUS_CHARS = 4 * 1024 * 1024
+
+# The service-entry status that means "this pocket is actually open". `pro`
+# also emits "disabled", "n/a" and "warning"; none of those open a pocket.
+_ENABLED_STATUS = "enabled"
+
+# Mirrors the server's UBUNTU_PRO_MAX_SERVICES / _MAX_SERVICE_LENGTH so the two
+# sides agree on what a sane list looks like. Real hosts report under fifteen
+# services with names under twenty characters; these only bound a pathological
+# reading, they are not a filter (rule 3: no allowlist).
+_MAX_SERVICES = 32
+_MAX_SERVICE_CHARS = 64
+
+_cache = TTLCache()
+
+
+def _pro_api_attributes(binary, endpoint):
+    """Return the `data.attributes` object of a `pro api <endpoint>` call, or None.
+
+    Unlike the WireGuard collector, output on stderr is NOT a failure here. `pro`
+    warns on stderr about things that do not affect the answer (an unwritable
+    cache when running unprivileged, an APT news notice) while still printing a
+    complete envelope on stdout. The authority is the envelope's own `result`
+    field plus the exit code, which `pro api` sets to 1 for anything that is not
+    a successful call.
+    """
+    try:
+        result = subprocess.run(
+            [binary, "api", endpoint],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=_SUBPROCESS_TIMEOUT,
+            env=get_clean_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        log(f"Ubuntu Pro: `pro api {endpoint}` failed: {e}", "debug")
+        return None
+
+    if result.returncode != 0:
+        # The realistic trigger is an endpoint an older ubuntu-advantage-tools
+        # does not implement, which is why this is debug and not error: the
+        # status-cache fallback answers those hosts.
+        log(
+            f"Ubuntu Pro: `pro api {endpoint}` exited {result.returncode}: "
+            f"{(result.stderr or '').strip() or 'no error output'}",
+            "debug",
+        )
+        return None
+
+    try:
+        payload = json.loads(result.stdout or "")
+    except ValueError as e:
+        log(f"Ubuntu Pro: could not parse `pro api {endpoint}`: {e}", "debug")
+        return None
+
+    if not isinstance(payload, dict):
+        log(f"Ubuntu Pro: `pro api {endpoint}` was not an object", "debug")
+        return None
+
+    # `result` defaults to "success" and is absent from no released envelope,
+    # but tolerate its absence rather than blanking a future shape that only
+    # dropped a redundant field.
+    outcome = payload.get("result")
+    if outcome is not None and outcome != "success":
+        log(f"Ubuntu Pro: `pro api {endpoint}` reported result={outcome!r}", "debug")
+        return None
+
+    data = payload.get("data")
+    attributes = data.get("attributes") if isinstance(data, dict) else None
+    if not isinstance(attributes, dict):
+        log(f"Ubuntu Pro: `pro api {endpoint}` carried no attributes", "debug")
+        return None
+    return attributes
+
+
+def _service_names(raw):
+    """Normalize an enabled-services array into a sorted name list, or None.
+
+    Two entry shapes are real and both are accepted: current clients emit
+    ``{"name": "esm-infra", "variant_enabled": .., "variant_name": ..}`` while
+    older ones emit the plain string. The variant is deliberately ignored --
+    `realtime-kernel` opens the same pocket whichever variant is enabled, and
+    the server keys on the service name.
+
+    An entry whose name cannot be read fails the WHOLE list rather than being
+    skipped. A silently short list is a wrong answer in the shape the server
+    cannot detect: it would read as "that pocket is closed" and keep an
+    installable fix filed as unfixable, with nothing anywhere saying why.
+
+    Sorted and deduped so the payload is stable across `pro` versions and the
+    server's "did the entitlement actually change" comparison never fires on a
+    reordering.
+    """
+    if not isinstance(raw, list):
+        log(
+            f"Ubuntu Pro: enabled services were {type(raw).__name__}, not a list",
+            "error",
+        )
+        return None
+
+    names = set()
+    for entry in raw:
+        name = entry.get("name") if isinstance(entry, dict) else entry
+        if not isinstance(name, str):
+            log(
+                f"Ubuntu Pro: unreadable service entry {entry!r}; "
+                "reporting null rather than a short list",
+                "error",
+            )
+            return None
+        name = name.strip().lower()[:_MAX_SERVICE_CHARS]
+        if name:
+            names.add(name)
+
+    ordered = sorted(names)
+    if len(ordered) > _MAX_SERVICES:
+        log(
+            f"Ubuntu Pro: {len(ordered)} enabled services reported, "
+            f"capping at {_MAX_SERVICES}",
+            "error",
+        )
+    return ordered[:_MAX_SERVICES]
+
+
+def _read_from_pro_api(binary):
+    """Reading from the `pro api` endpoints, or None if either half is missing."""
+    attributes = _pro_api_attributes(binary, _IS_ATTACHED_ENDPOINT)
+    if attributes is None:
+        return None
+
+    attached = attributes.get("is_attached")
+    if attached is not True and attached is not False:
+        log(
+            f"Ubuntu Pro: is_attached was {attached!r}, not a boolean",
+            "error",
+        )
+        return None
+
+    if not attached:
+        # No second call: `_enabled_services` itself returns an empty list the
+        # moment it sees an unattached machine, so skipping the spawn is exactly
+        # equivalent -- and it keeps the common case (every non-Pro Ubuntu host
+        # in the fleet) at one subprocess per cache window.
+        return {"attached": False, "services": []}
+
+    attributes = _pro_api_attributes(binary, _ENABLED_SERVICES_ENDPOINT)
+    if attributes is None:
+        # BOTH HALVES OR NOTHING. `{"attached": true, "services": []}` is a real,
+        # meaningful state ("attached, every service disabled") and sending it
+        # because the service list could not be READ would tell the server we
+        # checked and found no open pocket. That is the pessimistic direction,
+        # so nothing breaks loudly -- a Pro customer's fixes just stay filed as
+        # unfixable forever with no signal anywhere. null preserves instead.
+        return None
+
+    services = _service_names(attributes.get("enabled_services"))
+    if services is None:
+        return None
+    return {"attached": True, "services": services}
+
+
+def _read_from_status_cache():
+    """Reading from /var/lib/ubuntu-advantage/status.json, or None.
+
+    The fallback for the hosts the `pro api` path cannot answer: an
+    ubuntu-advantage-tools too old to implement the endpoints, or a `pro` that
+    is installed but not on the agent's PATH. It is a world-readable file that
+    `pro` refreshes on every status run, on attach/detach and on its own timer,
+    so it is minutes-to-hours stale at worst against a value that changes about
+    once in a machine's lifetime -- strictly more useful than the null it
+    replaces.
+
+    Same schema as `pro status --format json`: a top-level `attached` boolean
+    and a `services` array whose entries carry a name and a status.
+    """
+    try:
+        with open(_STATUS_CACHE_FILE, "r", errors="replace") as handle:
+            raw = handle.read(_MAX_STATUS_CHARS)
+    except (OSError, ValueError):
+        # ValueError covers open()'s embedded-null-byte rejection. Absent is the
+        # normal case on every non-Ubuntu host, so this is not worth a log line.
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except ValueError as e:
+        log(f"Ubuntu Pro: could not parse {_STATUS_CACHE_FILE}: {e}", "error")
+        return None
+
+    if not isinstance(payload, dict):
+        log(f"Ubuntu Pro: {_STATUS_CACHE_FILE} was not an object", "error")
+        return None
+
+    attached = payload.get("attached")
+    if attached is not True and attached is not False:
+        log(
+            f"Ubuntu Pro: status cache attached was {attached!r}, not a boolean",
+            "error",
+        )
+        return None
+
+    if not attached:
+        return {"attached": False, "services": []}
+
+    services = payload.get("services")
+    if not isinstance(services, list):
+        log(
+            f"Ubuntu Pro: status cache services were {type(services).__name__}, "
+            "not a list",
+            "error",
+        )
+        return None
+
+    names = []
+    for entry in services:
+        if not isinstance(entry, dict):
+            log(
+                f"Ubuntu Pro: status cache service entry {entry!r} is not an object",
+                "error",
+            )
+            return None
+        # ONLY "enabled". An entitled-but-disabled service opens no pocket, and
+        # neither does one in "warning" -- the pessimistic reading is the safe
+        # one here, since over-reporting would move a genuinely unfixable
+        # finding into the work queue.
+        if entry.get("status") == _ENABLED_STATUS:
+            names.append(entry.get("name"))
+
+    normalized = _service_names(names)
+    if normalized is None:
+        return None
+    return {"attached": True, "services": normalized}
+
+
+def _read():
+    """Best available reading of this host's entitlement, or None.
+
+    `pro api` first (authoritative and always current), the on-disk status cache
+    second. Note that the fallback also covers a `pro` that TIMED OUT, not just
+    one that is absent or too old: a slightly stale reading of a value that
+    changes once in a machine's lifetime beats a null that teaches the server
+    nothing.
+    """
+    binary = shutil.which("pro")
+    reading = _read_from_pro_api(binary) if binary else None
+    if reading is None:
+        reading = _read_from_status_cache()
+    if reading is not None:
+        return reading
+
+    if binary is None:
+        # The overwhelmingly common case: not an Ubuntu host at all.
+        log("Ubuntu Pro: `pro` not found in PATH", "debug")
+    else:
+        log(
+            "Ubuntu Pro: `pro` is installed but neither `pro api` nor "
+            f"{_STATUS_CACHE_FILE} yielded a reading; reporting null",
+            "error",
+        )
+    return None
+
+
+@debug("ubuntu_pro")
+def ubuntu_pro_status():
+    """Collect Ubuntu Pro attachment and the services that are actually enabled.
+
+    Returns one of:
+
+    - ``None`` -- COULD NOT DETERMINE (`pro` absent, timed out, errored, or the
+      host is not Ubuntu at all). The server preserves whatever it has stored
+      and never writes ``false`` from this.
+    - ``{"attached": False, "services": []}`` -- `pro` answered and the machine
+      is not attached.
+    - ``{"attached": True, "services": [...]}`` -- attached, with the services
+      whose archive pockets are actually open. The list is empty when every
+      service is disabled, which unlocks nothing.
+
+    Cached for _CACHE_TTL, so the cost above is paid at most once per window
+    however short the collection interval is.
+    """
+    return _cache.get_or_compute(_CACHE_KEY, _CACHE_TTL, _read)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fivenines_agent"
-version = "1.16.0"
+version = "1.16.1"
 description = ""
 authors = ["Sebastien Puyet <sebastien@fivenines.io>"]
 license = "WTFPL"

--- a/tests/fixtures/ubuntu_pro_contract_payload.json
+++ b/tests/fixtures/ubuntu_pro_contract_payload.json
@@ -1,0 +1,326 @@
+{
+  "description": "Shared Ubuntu Pro attachment contract fixture between fivenines-agent and fivenines-server (server #746, the #736 follow-up). Authored SERVER-FIRST as the specification and reconciled with the agent PR (agent #125), which is now the SOURCE OF TRUTH: each scenario's 'raw' is fed back through the real collector with ONLY the subprocess / status-file boundary mocked, and must produce scenario['payload']. The server's spec/requests/api_collect_ubuntu_pro_spec.rb posts scenario['payload'] under data['ubuntu_pro'] through /collect and asserts the resulting hosts.ubuntu_pro_* columns. 'raw' is an agent-side input the server ignores. Keep the two copies byte-identical and change the payload shape only in lockstep.",
+  "agent_min_version": "1.16.1",
+  "_agent_min_version_note": "The agent release that FIRST ships the collector. Nothing gates on it: there is no FEATURES_SUPPORTED_VERSIONS entry and no config key, so an older agent simply never sends data['ubuntu_pro'] and the server preserves NULL (= 'never reported', which behaves exactly like pre-#746). The server could therefore ship first, in any order, and did.",
+  "_reconciliation_note": "Two deliberate divergences from the server-authored draft, both agent-verified against the real `pro` client. (1) agent_min_version 1.15.1 -> 1.16.1. (2) attached_full services ['esm-infra','esm-apps'] -> ['esm-apps','esm-infra']: u.pro.status.enabled_services.v1 returns `sorted(enabled_services, key=lambda x: x.name)` and the collector sorts again so the payload is stable across `pro` versions and across the two collection sources. api_collect_ubuntu_pro_spec.rb hard-codes %w[esm-infra esm-apps] in five examples and needs the same flip.",
+  "collection_contract": "The agent reads `pro api u.pro.status.is_attached.v1` and `pro api u.pro.status.enabled_services.v1` (falling back to /var/lib/ubuntu-advantage/status.json) and reports BOTH: attachment alone is not enough, because a machine can be attached with every service disabled and each OSV Ubuntu Pro ecosystem maps to a specific archive pocket that a specific SERVICE opens (esm-infra does not unlock a FIPS-only fix). Values are the `pro` service names verbatim, lowercase: esm-infra, esm-apps, fips, fips-updates, fips-preview, realtime-kernel, usg, livepatch, cis, ros, ros-updates, anbox-cloud, landscape, cc-eal. ONLY ENABLED services are listed - an entitled-but-disabled service opens no pocket, and neither does one in the 'warning' state. The server matches them against Osv::SubscriptionEcosystems and ignores anything it does not recognise, so the agent must never filter the list to a known set.",
+  "null_contract": "data['ubuntu_pro'] = null means COULD NOT DETERMINE (the `pro` CLI is absent, timed out, or errored) and the server PRESERVES the stored columns - it never writes false. The same is true of an absent key (a pre-#746 agent). Only an explicit boolean `attached` is written. This is the never-prune-on-null discipline applied to a boolean: a timed-out `pro status` is not evidence a machine detached, and treating it as one would bounce that host's ESM findings between the work queue and the subscription bucket on every hiccup - each flip a digest change, a findings rewrite, and a rescan. Agent-side the same rule runs one level deeper: a successful attachment read whose SERVICE LIST could not be read is also null, never {'attached': true, 'services': []} - that shape is a real state ('attached, everything disabled') and sending it for an unread list would silently keep a Pro customer's installable fixes filed as unfixable.",
+  "cadence_note": "This rides /collect (every interval), not /packages. The agent MUST cache the `pro` result and re-read it at most every few minutes rather than shelling out per tick - the value changes about once in a machine's lifetime, and /collect runs every 15-60s. The agent caches for 900s, FAILURES INCLUDED, so a wedged `pro` cannot be re-spawned every tick. The server reads the stored columns at scan time (Host#subscription_services), so a few minutes of staleness costs nothing.",
+  "raw_contract": "Agent-side inputs the server ignores (it reads only 'payload'). Each scenario is round-tripped TWICE, once per collection source, and both must produce the same payload. 'pro_api' maps an endpoint to the JSON envelope `pro api <endpoint>` prints on stdout (null for the whole object = `pro` is not on PATH); u.pro.status.enabled_services.v1 is ABSENT from a detached scenario on purpose, because the collector must not spawn a second process once is_attached says false - the endpoint itself short-circuits on the same check. 'status_json' is the content of /var/lib/ubuntu-advantage/status.json, the fallback source for a client too old to implement the endpoints or a `pro` off the agent's PATH (null = the file is absent). The two `pro api` envelopes are verbatim-shaped, including the fields the collector ignores (meta, warnings, contract_remaining_days, variant_enabled), so a future shape change shows up here.",
+  "field_contract": {
+    "ubuntu_pro": "The whole block, or null for COULD NOT DETERMINE. Never {'attached': false} on a collection failure, and never emitted at all by a Windows agent.",
+    "ubuntu_pro.attached": "A real JSON boolean - whether this machine is attached to an Ubuntu Pro subscription. The server refuses anything else and preserves instead of guessing, so a truthy STRING can never read as attached.",
+    "ubuntu_pro.services": "The `pro` names of the services that are ENABLED, lowercased, deduped and sorted. Empty for a detached machine, and empty for an attached one with every service disabled - the two are distinguished by `attached`, not by this list. Not filtered to a known set: an unrecognised token is inert server-side, which is what keeps a service Canonical adds later from needing an agent release."
+  },
+  "scenarios": {
+    "attached_full": {
+      "description": "The common shape: a machine attached to Ubuntu Pro with the two services `pro attach` enables by default. The server writes attached=true + both services; an Ubuntu:Pro:<release>:LTS fix then partitions as installable and its findings move into the work queue.",
+      "raw": {
+        "pro_api": {
+          "u.pro.status.is_attached.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "contract_remaining_days": 360,
+                "contract_status": "active",
+                "is_attached": true,
+                "is_attached_and_contract_valid": true
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "IsAttached"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          },
+          "u.pro.status.enabled_services.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "enabled_services": [
+                  {
+                    "name": "esm-apps",
+                    "variant_enabled": false,
+                    "variant_name": null
+                  },
+                  {
+                    "name": "esm-infra",
+                    "variant_enabled": false,
+                    "variant_name": null
+                  }
+                ]
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "EnabledServices"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          }
+        },
+        "status_json": {
+          "_schema_version": "0.1",
+          "attached": true,
+          "version": "35.1",
+          "execution_status": "inactive",
+          "services": [
+            {
+              "name": "anbox-cloud",
+              "available": "no",
+              "entitled": "no",
+              "status": "n/a"
+            },
+            {
+              "name": "esm-apps",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "enabled"
+            },
+            {
+              "name": "esm-infra",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "enabled"
+            },
+            {
+              "name": "fips-updates",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "livepatch",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "usg",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            }
+          ]
+        }
+      },
+      "payload": {
+        "attached": true,
+        "services": ["esm-apps", "esm-infra"]
+      }
+    },
+    "attached_fips_only": {
+      "description": "Attached with a FIPS service but WITHOUT esm-infra/esm-apps - the granularity case the issue calls out, in its harder direction. Ubuntu:Pro:FIPS-updates:<release> fixes become installable; plain Ubuntu:Pro:<release> ESM fixes stay gated.",
+      "raw": {
+        "pro_api": {
+          "u.pro.status.is_attached.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "contract_remaining_days": 712,
+                "contract_status": "active",
+                "is_attached": true,
+                "is_attached_and_contract_valid": true
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "IsAttached"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          },
+          "u.pro.status.enabled_services.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "enabled_services": [
+                  {
+                    "name": "fips-updates",
+                    "variant_enabled": false,
+                    "variant_name": null
+                  }
+                ]
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "EnabledServices"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          }
+        },
+        "status_json": {
+          "_schema_version": "0.1",
+          "attached": true,
+          "version": "35.1",
+          "execution_status": "inactive",
+          "services": [
+            {
+              "name": "esm-apps",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "esm-infra",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "fips",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "fips-updates",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "enabled"
+            }
+          ]
+        }
+      },
+      "payload": {
+        "attached": true,
+        "services": ["fips-updates"]
+      }
+    },
+    "attached_no_services": {
+      "description": "Attached but every service disabled (`pro disable esm-infra esm-apps`). Attachment alone unlocks NOTHING: no pocket is open, so every gated finding stays in the subscription bucket. This is why the server keys on the service list rather than on the boolean. Note this is the one payload an agent must NEVER fabricate: it is what an unread service list would look like.",
+      "raw": {
+        "pro_api": {
+          "u.pro.status.is_attached.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "contract_remaining_days": 88,
+                "contract_status": "active",
+                "is_attached": true,
+                "is_attached_and_contract_valid": true
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "IsAttached"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          },
+          "u.pro.status.enabled_services.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "enabled_services": []
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "EnabledServices"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          }
+        },
+        "status_json": {
+          "_schema_version": "0.1",
+          "attached": true,
+          "version": "35.1",
+          "execution_status": "inactive",
+          "services": [
+            {
+              "name": "esm-apps",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            },
+            {
+              "name": "esm-infra",
+              "available": "yes",
+              "entitled": "yes",
+              "status": "disabled"
+            }
+          ]
+        }
+      },
+      "payload": {
+        "attached": true,
+        "services": []
+      }
+    },
+    "detached": {
+      "description": "`pro` is installed and reports the machine is not attached. Written as false, which is distinct from NULL: the host card can say 'not attached' rather than stay silent, and the effect on findings is identical to pre-#746. The enabled_services endpoint is absent from 'raw' on purpose - the collector must answer from the attachment call alone.",
+      "raw": {
+        "pro_api": {
+          "u.pro.status.is_attached.v1": {
+            "_schema_version": "v1",
+            "data": {
+              "attributes": {
+                "contract_remaining_days": 0,
+                "contract_status": null,
+                "is_attached": false,
+                "is_attached_and_contract_valid": false
+              },
+              "meta": {
+                "environment_vars": []
+              },
+              "type": "IsAttached"
+            },
+            "errors": [],
+            "result": "success",
+            "version": "35.1",
+            "warnings": []
+          }
+        },
+        "status_json": {
+          "_schema_version": "0.1",
+          "attached": false,
+          "version": "35.1",
+          "execution_status": "inactive",
+          "services": [
+            {
+              "name": "esm-apps",
+              "available": "yes",
+              "entitled": "no",
+              "status": "n/a"
+            },
+            {
+              "name": "esm-infra",
+              "available": "yes",
+              "entitled": "no",
+              "status": "n/a"
+            }
+          ]
+        }
+      },
+      "payload": {
+        "attached": false,
+        "services": []
+      }
+    },
+    "collection_failure": {
+      "description": "`pro` is absent (not an Ubuntu host, or ubuntu-advantage-tools not installed) and there is no status cache on disk either - or the calls failed. The whole key is null and the server leaves the stored columns untouched.",
+      "raw": {
+        "pro_api": null,
+        "status_json": null
+      },
+      "payload": null
+    }
+  }
+}

--- a/tests/test_agent_signals.py
+++ b/tests/test_agent_signals.py
@@ -1,8 +1,9 @@
-"""Tests for setup_signals() and the OS-aware file-handles dispatch.
+"""Tests for setup_signals() and the OS-aware collector dispatch.
 
 SIGHUP must be guarded so the agent imports and runs on Windows. The
 _collect_file_handles dispatch (D2 + D10) emits Linux file-nr keys on Linux
-and the Windows handle-count key on Windows - never both."""
+and the Windows handle-count key on Windows - never both. The Ubuntu Pro
+block rides the same Linux-only branch."""
 
 import signal as real_signal
 import sys
@@ -95,3 +96,46 @@ def test_collect_file_handles_windows_emits_handle_count_only():
     assert data["handle_count"] == 12345
     assert "file_handles_used" not in data
     assert "file_handles_limit" not in data
+
+
+# --- Ubuntu Pro dispatch (server #746) ---
+
+
+def _run_collect_metrics(windows, reading):
+    """Run _collect_metrics with every other collector stubbed out."""
+    agent = _bare_agent()
+    agent.config = {}
+    agent.permissions = MagicMock()
+    agent.permissions.get_all.return_value = {}
+    data = {}
+    with patch("fivenines_agent.agent.is_windows", return_value=windows), \
+         patch("fivenines_agent.agent.load_average", return_value=[0.0, 0.0, 0.0]), \
+         patch("fivenines_agent.agent.handle_count", return_value=1), \
+         patch("fivenines_agent.agent.file_handles_used", return_value=1), \
+         patch("fivenines_agent.agent.file_handles_limit", return_value=2), \
+         patch("fivenines_agent.agent.collect_metrics"), \
+         patch("fivenines_agent.agent.mqtt_metrics", return_value=None), \
+         patch("fivenines_agent.agent.ubuntu_pro_status", return_value=reading):
+        agent._collect_metrics(data)
+    return data
+
+
+def test_ubuntu_pro_is_collected_unconditionally_on_linux():
+    """No config key, no capability gate, no version gate: an empty config must
+    still produce the block, or the feature is silently off fleet-wide."""
+    reading = {"attached": True, "services": ["esm-infra"]}
+    assert _run_collect_metrics(windows=False, reading=reading)["ubuntu_pro"] == reading
+
+
+def test_ubuntu_pro_collection_failure_travels_as_null():
+    """null is the documented "could not determine" the server PRESERVES on. It
+    must reach the payload rather than being swallowed, so a host that stops
+    being readable is distinguishable from one that was never checked."""
+    data = _run_collect_metrics(windows=False, reading=None)
+    assert "ubuntu_pro" in data
+    assert data["ubuntu_pro"] is None
+
+
+def test_ubuntu_pro_is_absent_on_windows():
+    """`pro` is an Ubuntu tool; a Windows agent must not carry the key at all."""
+    assert "ubuntu_pro" not in _run_collect_metrics(windows=True, reading=None)

--- a/tests/test_ubuntu_pro.py
+++ b/tests/test_ubuntu_pro.py
@@ -1,0 +1,426 @@
+"""Tests for the Ubuntu Pro attachment collector (agent #125 / server #746).
+
+Only the two boundaries are mocked: the `pro` subprocess and the on-disk status
+cache. Everything between them is the real parse -> payload pipeline. The
+cross-repo round-trip lives in test_ubuntu_pro_contract.py.
+
+The single rule most of these cases are really testing: an ambiguous outcome is
+``None``, never ``{"attached": False}`` and never a short service list.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from fivenines_agent import ubuntu_pro
+from fivenines_agent.ubuntu_pro import ubuntu_pro_status
+
+IS_ATTACHED = ubuntu_pro._IS_ATTACHED_ENDPOINT
+ENABLED_SERVICES = ubuntu_pro._ENABLED_SERVICES_ENDPOINT
+
+
+def _envelope(attributes, result="success", type_="IsAttached"):
+    return {
+        "_schema_version": "v1",
+        "data": {
+            "attributes": attributes,
+            "meta": {"environment_vars": []},
+            "type": type_,
+        },
+        "errors": [],
+        "result": result,
+        "version": "35.1",
+        "warnings": [],
+    }
+
+
+def _attached(value=True):
+    return _envelope(
+        {
+            "contract_remaining_days": 360,
+            "contract_status": "active",
+            "is_attached": value,
+            "is_attached_and_contract_valid": value,
+        }
+    )
+
+
+def _services(names):
+    entries = [
+        {"name": name, "variant_enabled": False, "variant_name": None} for name in names
+    ]
+    return _envelope({"enabled_services": entries}, type_="EnabledServices")
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch, tmp_path):
+    """Empty the module cache and point the status file somewhere absent.
+
+    Both matter: the cache is module-level state that would otherwise leak a
+    reading into the next test, and an unpatched path would make results depend
+    on whether the machine running the suite is itself an attached Ubuntu box.
+    """
+    monkeypatch.setattr(ubuntu_pro, "_cache", ubuntu_pro.TTLCache())
+    monkeypatch.setattr(
+        ubuntu_pro, "_STATUS_CACHE_FILE", str(tmp_path / "no-such-status.json")
+    )
+
+
+@pytest.fixture
+def pro(monkeypatch):
+    """Install a fake `pro` CLI. Returns a callable arming the next run.
+
+    *responses* maps an endpoint to what `pro api <endpoint>` prints: a dict is
+    JSON-encoded, a string is served verbatim, a tuple is (returncode, stdout).
+    An endpoint absent from the map fails the test rather than answering, since
+    several cases turn on the collector NOT making a call. The arming call
+    returns the list every invocation is recorded in.
+    """
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: "/usr/bin/pro")
+
+    def install(responses=None, raises=None):
+        responses = responses or {}
+        calls = []
+
+        def fake_run(cmd, *_args, **_kwargs):
+            calls.append(cmd)
+            if raises is not None:
+                raise raises
+            assert cmd[:2] == ["/usr/bin/pro", "api"]
+            endpoint = cmd[2]
+            assert endpoint in responses, f"unexpected `pro api {endpoint}` call"
+            response = responses[endpoint]
+            if isinstance(response, tuple):
+                returncode, stdout = response
+            else:
+                returncode, stdout = 0, response
+            if isinstance(stdout, (dict, list)):
+                stdout = json.dumps(stdout)
+            return subprocess.CompletedProcess(cmd, returncode, stdout, "")
+
+        monkeypatch.setattr(ubuntu_pro.subprocess, "run", fake_run)
+        return calls
+
+    return install
+
+
+@pytest.fixture
+def status_cache(monkeypatch, tmp_path):
+    """Write a status cache file and make it the only available source."""
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: None)
+
+    def install(content):
+        path = tmp_path / "status.json"
+        path.write_text(content if isinstance(content, str) else json.dumps(content))
+        monkeypatch.setattr(ubuntu_pro, "_STATUS_CACHE_FILE", str(path))
+
+    return install
+
+
+# --- the `pro api` path ----------------------------------------------------
+
+
+def test_attached_reports_its_enabled_services(pro):
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _services(["esm-apps", "esm-infra"]),
+        }
+    )
+    assert ubuntu_pro_status() == {
+        "attached": True,
+        "services": ["esm-apps", "esm-infra"],
+    }
+
+
+def test_detached_answers_without_a_second_spawn(pro):
+    """The enabled_services endpoint short-circuits on the same check, so
+    skipping the spawn is equivalent -- and it keeps every non-Pro Ubuntu host
+    in the fleet at one subprocess per cache window."""
+    calls = pro({IS_ATTACHED: _attached(False)})
+    assert ubuntu_pro_status() == {"attached": False, "services": []}
+    assert len(calls) == 1
+
+
+def test_attached_with_everything_disabled_is_an_empty_list(pro):
+    pro({IS_ATTACHED: _attached(), ENABLED_SERVICES: _services([])})
+    assert ubuntu_pro_status() == {"attached": True, "services": []}
+
+
+def test_unreadable_service_list_is_null_not_an_empty_one(pro):
+    """THE load-bearing case. `{"attached": true, "services": []}` is a real
+    state, so sending it for a list we could not read would tell the server we
+    checked and found no open pocket -- silently keeping a Pro customer's
+    installable fixes filed as unfixable, with nothing saying why."""
+    pro({IS_ATTACHED: _attached(), ENABLED_SERVICES: (1, "")})
+    assert ubuntu_pro_status() is None
+
+
+def test_legacy_plain_string_service_entries_are_accepted(pro):
+    """Older clients emitted the names directly rather than objects."""
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _envelope({"enabled_services": ["esm-infra", "usg"]}),
+        }
+    )
+    assert ubuntu_pro_status() == {"attached": True, "services": ["esm-infra", "usg"]}
+
+
+def test_service_names_are_lowercased_deduped_and_sorted(pro):
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _envelope(
+                {"enabled_services": [" ESM-Infra ", "esm-infra", "esm-apps", "  "]}
+            ),
+        }
+    )
+    assert ubuntu_pro_status() == {
+        "attached": True,
+        "services": ["esm-apps", "esm-infra"],
+    }
+
+
+def test_overlong_service_name_is_truncated_not_dropped(pro):
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _envelope({"enabled_services": ["x" * 200]}),
+        }
+    )
+    assert ubuntu_pro_status() == {
+        "attached": True,
+        "services": ["x" * ubuntu_pro._MAX_SERVICE_CHARS],
+    }
+
+
+def test_absurd_service_count_is_capped(pro):
+    names = [f"svc-{i:03d}" for i in range(50)]
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _envelope({"enabled_services": names}),
+        }
+    )
+    result = ubuntu_pro_status()
+    assert result is not None
+    assert result["services"] == sorted(names)[: ubuntu_pro._MAX_SERVICES]
+
+
+@pytest.mark.parametrize(
+    "entries",
+    ["esm-infra", [42], [None], [{"variant_enabled": False}]],
+    ids=["not-a-list", "int-entry", "null-entry", "object-without-name"],
+)
+def test_unparseable_service_entry_fails_the_whole_list(pro, entries):
+    """A silently short list is a wrong answer the server cannot detect: it
+    reads as "that pocket is closed"."""
+    pro(
+        {
+            IS_ATTACHED: _attached(),
+            ENABLED_SERVICES: _envelope({"enabled_services": entries}),
+        }
+    )
+    assert ubuntu_pro_status() is None
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [{}, {"is_attached": "true"}, {"is_attached": 1}, {"is_attached": None}],
+    ids=["absent", "truthy-string", "int", "null"],
+)
+def test_non_boolean_attachment_is_null(pro, attributes):
+    """A truthy string must never read as attached, and "could not tell" must
+    never read as detached."""
+    pro({IS_ATTACHED: _envelope(attributes)})
+    assert ubuntu_pro_status() is None
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        (1, ""),
+        "not json",
+        "[]",
+        {"result": "failure", "data": {}, "errors": [{"code": "boom"}]},
+        {"result": "success", "data": []},
+        {"result": "success", "data": {"attributes": "nope"}},
+    ],
+    ids=[
+        "non-zero-exit",
+        "unparseable",
+        "not-an-object",
+        "result-failure",
+        "data-not-an-object",
+        "attributes-not-an-object",
+    ],
+)
+def test_broken_envelope_is_null(pro, response):
+    pro({IS_ATTACHED: response})
+    assert ubuntu_pro_status() is None
+
+
+def test_envelope_without_a_result_field_is_still_read(pro):
+    """`result` defaults to "success" client-side and no released envelope
+    omits it, but a future shape that dropped a redundant field must not blank
+    the reading."""
+    envelope = _attached()
+    del envelope["result"]
+    pro({IS_ATTACHED: envelope, ENABLED_SERVICES: _services(["esm-infra"])})
+    assert ubuntu_pro_status() == {"attached": True, "services": ["esm-infra"]}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("no such file"), subprocess.TimeoutExpired("pro", 10)],
+    ids=["spawn-error", "timeout"],
+)
+def test_subprocess_failure_is_null(pro, error):
+    pro(raises=error)
+    assert ubuntu_pro_status() is None
+
+
+def test_missing_pro_binary_is_null(monkeypatch):
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: None)
+    assert ubuntu_pro_status() is None
+
+
+# --- the status-cache fallback ---------------------------------------------
+
+
+def test_status_cache_answers_when_pro_api_is_unavailable(status_cache):
+    status_cache(
+        {
+            "attached": True,
+            "services": [
+                {"name": "esm-infra", "status": "enabled"},
+                {"name": "esm-apps", "status": "enabled"},
+                {"name": "usg", "status": "disabled"},
+                {"name": "fips", "status": "n/a"},
+                {"name": "livepatch", "status": "warning"},
+            ],
+        }
+    )
+    assert ubuntu_pro_status() == {
+        "attached": True,
+        "services": ["esm-apps", "esm-infra"],
+    }
+
+
+def test_status_cache_detached(status_cache):
+    status_cache(
+        {"attached": False, "services": [{"name": "esm-infra", "status": "n/a"}]}
+    )
+    assert ubuntu_pro_status() == {"attached": False, "services": []}
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not json",
+        "[]",
+        {"services": []},
+        {"attached": "yes", "services": []},
+        {"attached": True, "services": "esm-infra"},
+        {"attached": True, "services": ["esm-infra"]},
+        {"attached": True, "services": [{"status": "enabled"}]},
+    ],
+    ids=[
+        "unparseable",
+        "not-an-object",
+        "attached-absent",
+        "attached-not-a-boolean",
+        "services-not-a-list",
+        "service-entry-not-an-object",
+        "enabled-entry-without-a-name",
+    ],
+)
+def test_broken_status_cache_is_null(status_cache, content):
+    status_cache(content)
+    assert ubuntu_pro_status() is None
+
+
+def test_pro_api_wins_over_a_contradicting_status_cache(pro, monkeypatch, tmp_path):
+    """The cache is a fallback, not a cross-check: a live `pro api` answer is
+    always the fresher one."""
+    path = tmp_path / "status.json"
+    path.write_text(json.dumps({"attached": False, "services": []}))
+    monkeypatch.setattr(ubuntu_pro, "_STATUS_CACHE_FILE", str(path))
+    pro({IS_ATTACHED: _attached(), ENABLED_SERVICES: _services(["esm-infra"])})
+    assert ubuntu_pro_status() == {"attached": True, "services": ["esm-infra"]}
+
+
+def test_a_timed_out_pro_falls_back_to_the_status_cache(pro, monkeypatch, tmp_path):
+    """A stale reading of a value that changes once in a machine's lifetime
+    beats a null that teaches the server nothing."""
+    path = tmp_path / "status.json"
+    path.write_text(
+        json.dumps(
+            {"attached": True, "services": [{"name": "esm-infra", "status": "enabled"}]}
+        )
+    )
+    monkeypatch.setattr(ubuntu_pro, "_STATUS_CACHE_FILE", str(path))
+    pro(raises=subprocess.TimeoutExpired("pro", 10))
+    assert ubuntu_pro_status() == {"attached": True, "services": ["esm-infra"]}
+
+
+def _record_levels(monkeypatch):
+    levels = []
+    monkeypatch.setattr(
+        ubuntu_pro, "log", lambda message, level="info": levels.append(level)
+    )
+    return levels
+
+
+def test_installed_pro_that_cannot_answer_logs_an_error(pro, monkeypatch):
+    """A non-Ubuntu host reporting null is routine and stays at debug level; a
+    host that HAS `pro` and still cannot be read is an anomaly worth surfacing
+    in the collector telemetry."""
+    levels = _record_levels(monkeypatch)
+    pro({IS_ATTACHED: (1, "")})
+    assert ubuntu_pro_status() is None
+    assert "error" in levels
+
+
+def test_absent_pro_does_not_log_an_error(monkeypatch):
+    levels = _record_levels(monkeypatch)
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: None)
+    assert ubuntu_pro_status() is None
+    assert "error" not in levels
+
+
+# --- caching ---------------------------------------------------------------
+
+
+def test_reading_is_cached_across_ticks(pro):
+    calls = pro({IS_ATTACHED: _attached(False)})
+    for _ in range(10):
+        assert ubuntu_pro_status() == {"attached": False, "services": []}
+    assert len(calls) == 1
+
+
+def test_failures_are_cached_too(pro):
+    """A `pro` that hangs for the whole timeout must not be re-spawned on the
+    next tick 15 seconds later."""
+    calls = pro(raises=subprocess.TimeoutExpired("pro", 10))
+    assert ubuntu_pro_status() is None
+    assert ubuntu_pro_status() is None
+    assert len(calls) == 1
+
+
+def test_a_re_attached_host_is_picked_up_once_the_window_closes(pro):
+    pro({IS_ATTACHED: _attached(False)})
+    assert ubuntu_pro_status() == {"attached": False, "services": []}
+
+    # Age the stored entry past the TTL rather than moving the clock: the cache
+    # reads time.monotonic() from its own module, and patching that globally
+    # would reach well beyond this collector.
+    entries = ubuntu_pro._cache._entries
+    stored_at, value, ttl = entries[ubuntu_pro._CACHE_KEY]
+    entries[ubuntu_pro._CACHE_KEY] = (stored_at - ubuntu_pro._CACHE_TTL - 1, value, ttl)
+
+    calls = pro({IS_ATTACHED: _attached(), ENABLED_SERVICES: _services(["esm-infra"])})
+    assert ubuntu_pro_status() == {"attached": True, "services": ["esm-infra"]}
+    assert len(calls) == 2

--- a/tests/test_ubuntu_pro_contract.py
+++ b/tests/test_ubuntu_pro_contract.py
@@ -1,0 +1,152 @@
+"""Cross-repo Ubuntu Pro contract round-trip (server #746 / agent #125).
+
+SHARED FIXTURE: fixtures/ubuntu_pro_contract_payload.json, byte-identical with
+the server's spec/fixtures/ubuntu_pro_contract_payload.json. Authored
+server-first as the specification; the agent repo is the source of truth from
+here on and the two copies change only in lockstep.
+
+Asserted on both sides:
+- here: each scenario's `raw` is fed back through the real collector with ONLY
+  the subprocess / status-file boundary mocked, and must produce
+  scenario["payload"] -- from EITHER collection source;
+- fivenines-server: spec/requests/api_collect_ubuntu_pro_spec.rb posts the same
+  scenario["payload"] under data["ubuntu_pro"] through /collect and asserts the
+  resulting hosts.ubuntu_pro_* columns.
+"""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from fivenines_agent import ubuntu_pro
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "ubuntu_pro_contract_payload.json"
+)
+
+SCENARIOS = [
+    "attached_full",
+    "attached_fips_only",
+    "attached_no_services",
+    "detached",
+    "collection_failure",
+]
+
+
+def _load_fixture():
+    with open(_FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch, tmp_path):
+    """Module-level cache emptied, status file pointed somewhere absent."""
+    monkeypatch.setattr(ubuntu_pro, "_cache", ubuntu_pro.TTLCache())
+    monkeypatch.setattr(
+        ubuntu_pro, "_STATUS_CACHE_FILE", str(tmp_path / "no-such-status.json")
+    )
+
+
+def _run_via_pro_api(scenario, monkeypatch):
+    """Feed raw["pro_api"] back through the `pro api` path.
+
+    The status cache stays absent (the autouse fixture), so a payload produced
+    here provably came from the CLI. An endpoint missing from the map is a hard
+    failure rather than a null: the detached scenario omits enabled_services on
+    purpose, and the collector must not reach for it.
+    """
+    responses = scenario["raw"]["pro_api"]
+    if responses is None:
+        monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: None)
+        return ubuntu_pro.ubuntu_pro_status()
+
+    def fake_run(cmd, *_args, **_kwargs):
+        assert cmd[:2] == ["/usr/bin/pro", "api"]
+        endpoint = cmd[2]
+        assert endpoint in responses, f"unexpected `pro api {endpoint}` call"
+        return subprocess.CompletedProcess(cmd, 0, json.dumps(responses[endpoint]), "")
+
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: "/usr/bin/pro")
+    monkeypatch.setattr(ubuntu_pro.subprocess, "run", fake_run)
+    return ubuntu_pro.ubuntu_pro_status()
+
+
+def _run_via_status_cache(scenario, monkeypatch, tmp_path):
+    """Feed raw["status_json"] back through the fallback path, with `pro` off
+    PATH so the CLI cannot contribute."""
+    monkeypatch.setattr(ubuntu_pro.shutil, "which", lambda _: None)
+    content = scenario["raw"]["status_json"]
+    if content is None:
+        return ubuntu_pro.ubuntu_pro_status()
+
+    path = tmp_path / "status.json"
+    path.write_text(json.dumps(content))
+    monkeypatch.setattr(ubuntu_pro, "_STATUS_CACHE_FILE", str(path))
+    return ubuntu_pro.ubuntu_pro_status()
+
+
+@pytest.mark.parametrize("name", SCENARIOS)
+@pytest.mark.parametrize("source", ["pro_api", "status_json"])
+def test_contract_fixture_round_trip(name, source, monkeypatch, tmp_path):
+    """Both sources must produce the identical payload. The fallback exists for
+    hosts the CLI path cannot answer, so it is not allowed to be a lossier
+    reading of the same machine."""
+    scenario = _load_fixture()["scenarios"][name]
+    if source == "pro_api":
+        produced = _run_via_pro_api(scenario, monkeypatch)
+    else:
+        produced = _run_via_status_cache(scenario, monkeypatch, tmp_path)
+    assert produced == scenario["payload"]
+
+
+def test_fixture_agent_min_version():
+    # Frozen literal, never the live pyproject version: the fixture documents
+    # the agent that FIRST ships the collector, and later releases must not
+    # drag it forward.
+    assert _load_fixture()["agent_min_version"] == "1.16.1"
+
+
+def test_fixture_covers_every_scenario():
+    assert sorted(_load_fixture()["scenarios"]) == sorted(SCENARIOS)
+
+
+def test_fixture_payload_shape_matches_the_field_contract():
+    """Only `attached` and `services` travel, `attached` is a real boolean, and
+    every service name is a lowercase non-empty string. The server refuses
+    anything else and preserves rather than guessing."""
+    documented = set(_load_fixture()["field_contract"])
+    assert documented == {"ubuntu_pro", "ubuntu_pro.attached", "ubuntu_pro.services"}
+
+    for scenario in _load_fixture()["scenarios"].values():
+        payload = scenario["payload"]
+        if payload is None:
+            continue
+        assert set(payload) == {"attached", "services"}
+        assert isinstance(payload["attached"], bool)
+        assert all(
+            isinstance(s, str) and s and s == s.strip().lower()
+            for s in payload["services"]
+        )
+        assert payload["services"] == sorted(set(payload["services"]))
+
+
+def test_fixture_pins_the_never_fabricate_shape():
+    """`{"attached": true, "services": []}` has to be a real scenario, because
+    it is exactly what an unread service list would look like. The collector
+    reports null for that case (test_ubuntu_pro.py); the contract needs the
+    genuine article on record so the two are never conflated."""
+    scenarios = _load_fixture()["scenarios"]
+    assert scenarios["attached_no_services"]["payload"] == {
+        "attached": True,
+        "services": [],
+    }
+    assert scenarios["collection_failure"]["payload"] is None
+
+
+def test_fixture_detached_scenario_omits_the_services_endpoint():
+    """Pins the one-call fast path in the contract itself: a detached machine
+    must be answerable from the attachment call alone."""
+    pro_api = _load_fixture()["scenarios"]["detached"]["raw"]["pro_api"]
+    assert set(pro_api) == {ubuntu_pro._IS_ATTACHED_ENDPOINT}


### PR DESCRIPTION
Closes #125. Server companion for [fivenines_server#746](https://github.com/Five-Nines-io/fivenines_server/issues/746), **which is already merged** -- the server half is inert until an agent starts sending this key, so deploy order is free.

## Why

The OSV scanner files a CVE whose only patch lives in an `Ubuntu:Pro:*` ecosystem under "fixable only with a subscription" rather than in the work queue. That is exact for an **unattached** host and merely pessimistic for an **attached** one, which can `apt install` the ESM fix today. The server cannot tell the two apart on its own.

**Attachment alone is not enough**, and that is the load-bearing part: a machine can be attached with every service disabled (`pro disable esm-infra` is one command), and each Pro OSV ecosystem maps to the archive pocket one specific *service* opens -- `esm-infra` does not unlock a FIPS-only fix. So the service list travels, not just the boolean.

## What it does

Reads `pro api u.pro.status.is_attached.v1` + `u.pro.status.enabled_services.v1`, falling back to `/var/lib/ubuntu-advantage/status.json` for clients too old to implement those endpoints or a `pro` off the agent's PATH.

```json
{"attached": true,  "services": ["esm-apps", "esm-infra"]}
{"attached": false, "services": []}
null
```

- **No extra privilege.** A non-root read falls back to the world-readable machine token, so the systemd unit is unchanged.
- **Cached 900s, failures included**, so a wedged `pro` is never re-spawned on the next tick. The value changes about once in a machine's lifetime.
- **A detached host costs ONE subprocess, not two.** The `enabled_services` endpoint short-circuits on the same `is_attached` check, so skipping the second spawn is equivalent rather than an approximation -- that is every non-Pro Ubuntu host in the fleet.

Wiring is deliberately **outside the COLLECTORS registry**: collection is unconditional (no config key, no capability gate, no version gate), so it sits in `_collect_metrics` next to `load_average`, inside the Linux-only branch.

## Honesty rules, in order of how much they matter

1. **Never `{"attached": false}` on a failure.** Missing / timed-out / errored `pro`, non-Ubuntu host, or a non-boolean `is_attached` all report `null`, and the server preserves its stored columns. A hiccup is not evidence a machine detached; treating it as one bounces that host's ESM findings between the two buckets on every miss, each flip a findings rewrite and a rescan.
2. **Both halves or nothing.** If attachment reads but the *service list* does not, the whole key is `null`. `{"attached": true, "services": []}` is a real state ("attached, everything disabled"), so fabricating it for an unread list fails in the quiet direction -- a Pro customer's installable fixes stay filed as unfixable forever with nothing saying why. Same rule one level down: a single unreadable entry fails the whole list rather than shipping a short one.
3. **No allowlist.** Names travel verbatim (lowercased, deduped, sorted); the server ignores tokens it does not recognise, which keeps a service Canonical adds later from needing an agent release.

## Verified, not assumed

The envelope shape, the alphabetical sort of `enabled_services`, and "network access required: no" were checked against the ubuntu-pro-client source. Both the current `{"name": ...}` entry shape and the older plain-string one are accepted. Both collection paths were also smoke-tested end-to-end through a real subprocess (including stderr chatter, which -- unlike the WireGuard rule -- must **not** fail the read).

## Tests

65 new, **100% coverage** on the new module, full suite green (2204 passed). The contract round-trip runs every scenario **twice, once per collection source**, so the fallback cannot be a lossier reading of the same machine.

## Follow-up for the server (tracked as the top P1 in TODOS.md)

The fixture was authored server-first and its own description asks for a byte-for-byte copy from the agent PR. Two values diverge from that draft:

- `agent_min_version` 1.15.1 (marked PROVISIONAL there) -> `1.16.1`
- `attached_full.services` `["esm-infra","esm-apps"]` -> `["esm-apps","esm-infra"]` -- `enabled_services.v1` returns `sorted(..., key=lambda x: x.name)`, so the draft's order is not one a real host can emit

That second one also needs the five hard-coded `%w[esm-infra esm-apps]` assertions in `api_collect_ubuntu_pro_spec.rb` flipped -- they are literals, not fixture-derived, so copying the file alone will not do it. **Nothing is broken until then**: the server reads only `scenarios.*.payload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)